### PR TITLE
add option to suppress witness printing

### DIFF
--- a/options/defaults.h
+++ b/options/defaults.h
@@ -51,6 +51,7 @@ static const Engine default_engine = BMC;
 static const unsigned int default_prop_idx = 0;
 static const unsigned int default_bound = 10;
 static const unsigned int default_verbosity = 0;
+static const bool default_no_witness = false;
 /********************************* End Default Values
  * ********************************/
 }  // namespace pono


### PR DESCRIPTION
Adding a new command line option `--no-witness` which disables witness printing. This feature is useful e.g., for debugging with instances that produce a large witness output. The previous default behavior (i.e., witnesses are printed) does not change.