### PR TITLE
Keep track of constraints added to trans through add_constraints, add_invar, and constrain_inputs

### DIFF
--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -65,9 +65,11 @@ void TransitionSystem::add_invar(const Term & constraint)
   if (only_curr(constraint)) {
     init_ = solver_->make_term(And, init_, constraint);
     trans_ = solver_->make_term(And, trans_, constraint);
+    Term next_constraint = solver_->substitute(constraint, next_map_);
     // add the next-state version
-    trans_ = solver_->make_term(
-        And, trans_, solver_->substitute(constraint, next_map_));
+    trans_ = solver_->make_term(And, trans_, next_constraint);
+    constraints_.push_back(constraint);
+    constraints_.push_back(next_constraint);
   } else {
     throw PonoException("Invariants should be over current states only.");
   }
@@ -77,6 +79,7 @@ void TransitionSystem::constrain_inputs(const Term & constraint)
 {
   if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
+    constraints_.push_back(constraint);
   } else {
     throw PonoException("Cannot have next-states in an input constraint.");
   }
@@ -88,10 +91,13 @@ void TransitionSystem::add_constraint(const Term & constraint)
     init_ = solver_->make_term(And, init_, constraint);
     trans_ = solver_->make_term(And, trans_, constraint);
     // add over next states
-    trans_ = solver_->make_term(
-        And, trans_, solver_->substitute(constraint, next_map_));
+    Term next_constraint = solver_->substitute(constraint, next_map_);
+    trans_ = solver_->make_term(And, trans_, next_constraint);
+    constraints_.push_back(constraint);
+    constraints_.push_back(next_constraint);
   } else if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
+    constraints_.push_back(constraint);
   } else {
     throw PonoException("Constraint cannot have next states");
   }

--- a/core/ts.h
+++ b/core/ts.h
@@ -157,6 +157,12 @@ class TransitionSystem
     return named_terms_;
   };
 
+  /** @return the constraints of the system
+   *  Note: these do not include next-state variable updates or initial state
+   * constraints
+   */
+  const smt::TermVec & constraints() const { return constraints_; };
+
   /** Whether the transition system is functional
    *  NOTE: This does *not* actually analyze the transition relation
    *  it only returns true if it's a FunctionalTransitionSystem object
@@ -200,6 +206,9 @@ class TransitionSystem
   smt::UnorderedTermSet next_states_;
   // maps next back to curr
   smt::UnorderedTermMap curr_map_;
+
+  smt::TermVec constraints_;  ///< constraints added via
+                              ///< add_invar/constrain_inputs/add_constraint
 
   typedef std::vector<const smt::UnorderedTermSet *> UnorderedTermSetPtrVec;
 

--- a/core/ts.h
+++ b/core/ts.h
@@ -207,6 +207,11 @@ class TransitionSystem
   // maps next back to curr
   smt::UnorderedTermMap curr_map_;
 
+  // extra vector of terms to TransitionSystems that records constraints
+  // added to the transition relation
+  // For a functional system, you could now rebuild trans by AND-ing
+  // together all the equalities from state_updates_
+  // and these constraints
   smt::TermVec constraints_;  ///< constraints added via
                               ///< add_invar/constrain_inputs/add_constraint
 


### PR DESCRIPTION
This PR would add an extra vector of terms to `TransitionSystems` that records constraints added to the transition relation. Currently, those constraints are just added directly to the `trans` formula. However, any future passes (such as COI or fault injection) that modify the transition relation and rebuild it might want to rebuild the transition relation. For a functional system, you could now rebuild `trans` by AND-ing together all the equalities from `state_updates_` and the constraints in `constraints_`. 