### PR TITLE
Interpolant return result

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -47,8 +47,7 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    # TEMP pull from branch until merged
-    git clone -b interpolant-return-val https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
     ./contrib/setup-btor.sh
 

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -47,7 +47,8 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    # TEMP pull from branch until merged
+    git clone -b interpolant-return-val https://github.com/makaimann/smt-switch
     cd smt-switch
     ./contrib/setup-btor.sh
 

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -114,10 +114,12 @@ bool InterpolantMC::step(int i)
   while (got_interpolant) {
     Term int_R = to_interpolator_.transfer_term(R);
     Term int_Ri;
-    got_interpolant = interpolator_->get_interpolant(
+    Result r = interpolator_->get_interpolant(
         interpolator_->make_term(And, int_R, int_transA),
         interpolator_->make_term(And, int_transB, int_bad),
         int_Ri);
+
+    got_interpolant = r.is_unsat();
 
     if (got_interpolant) {
       Ri = to_solver_.transfer_term(int_Ri);
@@ -148,6 +150,11 @@ bool InterpolantMC::step(int i)
         throw PonoException("Internal error: Expecting satisfiable result");
       }
       return false;
+    }
+    else if (r.is_unknown())
+    {
+      // TODO: figure out if makes sense to increase bound and try again
+      throw PonoException("Interpolant generation failed.");
     }
   }
 


### PR DESCRIPTION
This PR would keep Pono up to date with smt-switch following the merging of this PR: https://github.com/makaimann/smt-switch/pull/88

Instead of returning a boolean for success when generating an interpolant, and throwing an exception on interpolant failure, it now uses a Result:

* UNSAT: `I` should be populated with an interpolant
* SAT: query was sat so there is no interpolant
* UNKNOWN: interpolant failure

This should not be merged until after the smt-switch PR is merged, and the `setup-smt-switch.sh` script should be updated to pull from master (instead of from the smt-switch PR) before being merged.