### PR TITLE
Always include a transition before intersecting with bad

### DIFF
--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -214,11 +214,11 @@ bool ModelBasedIC3::intersects_bad()
 {
   TermVec conjuncts;
   conjunctive_partition(bad_, conjuncts);
-  // include the last frame
-  // this is an optimization, it is not necessary for correctness
-  for (auto c : frames_.back()) {
-    conjuncts.push_back(c);
-  }
+  // // include the last frame
+  // // this is an optimization, it is not necessary for correctness
+  // for (auto c : frames_.back()) {
+  //   conjuncts.push_back(c);
+  // }
   Conjunction bad_at_last_frame(solver_, conjuncts);
   Conjunction pred;
   if (!get_predecessor(reached_k_ + 1, bad_at_last_frame, pred)) {

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -213,8 +213,7 @@ bool ModelBasedIC3::intersects_bad()
 
   // include the last frame
   // this is an optimization, it is not necessary for correctness
-  assert(frames_.size() == reached_k_ + 2);
-  for (auto c : frames_[reached_k_ + 1]) {
+  for (auto c : frames_.back()) {
     conjuncts.push_back(c);
   }
   Conjunction bad_at_last_frame(solver_, conjuncts);

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -207,67 +207,16 @@ ProverResult ModelBasedIC3::step_0()
 
 bool ModelBasedIC3::intersects_bad()
 {
-  solver_->push();
-
-  // assert the last frame (conjunction over clauses)
-  assert_frame(reached_k_ + 1);
-
-  // see if it intersects with bad
-  solver_->assert_formula(bad_);
-
-  Result r = solver_->check_sat();
-  if (r.is_sat()) {
-    // create a proof goal for the bad state
-    const UnorderedTermSet & statevars = ts_.statevars();
-    TermVec cube_vec;
-    cube_vec.reserve(statevars.size());
-    Term eq;
-    for (auto sv : statevars) {
-      eq = solver_->make_term(Equal, sv, solver_->get_value(sv));
-      cube_vec.push_back(eq);
-    }
-
-    // reduce the bad cube
-    solver_->pop();
-    solver_->push();
-
-    Term neg_assert =
-      solver_->make_term(Not, solver_->make_term(And, bad_,
-                                                 get_frame(reached_k_ + 1)));
-    solver_->assert_formula(neg_assert);
-
-    TermVec splits;
-    split_eq(solver_, cube_vec, splits);
-
-    Term b;
-    TermVec bool_assump;
-    for (auto a : splits) {
-      unsigned i = 0;
-      b = label(a);
-      bool_assump.push_back(b);
-      solver_->assert_formula(solver_->make_term(Implies, b, a));
-    }
-
-    Result rr = solver_->check_sat_assuming(bool_assump);
-    assert(rr.is_unsat());
-
-    TermVec red_lits;
-    UnorderedTermSet core_set;
-    solver_->get_unsat_core(core_set);
-    for (size_t j = 0; j < bool_assump.size(); ++j) {
-      if (core_set.find(bool_assump[j]) != core_set.end()) {
-        red_lits.push_back(splits[j]);
-      }
-    }
-
-    Conjunction c(solver_, red_lits);
-    add_proof_goal(c, reached_k_ + 1);
+  Conjunction bad(solver_, { bad_ });
+  Conjunction pred;
+  if (!get_predecessor(reached_k_ + 1, bad, pred)) {
+    Term gen_block_bad = inductive_generalization(reached_k_ + 1, pred);
+    frames_[reached_k_ + 1].push_back(gen_block_bad);
+    return false;
+  } else {
+    add_proof_goal(pred, reached_k_);
+    return true;
   }
-
-  solver_->pop();
-
-  assert(!r.is_unknown());
-  return r.is_sat();
 }
 
 bool ModelBasedIC3::get_predecessor(size_t i,

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -65,7 +65,8 @@ class ModelBasedIC3 : public Prover
    */
   ProverResult step_0();
 
-  /** Check if last frame intersects with bad
+  /** Check if a transition from the second to last frame can result in a bad
+   * state
    *  @return true iff the last frame intersects with bad
    *  post-condition: if true is returned, bad cube added to proof goals
    */


### PR DESCRIPTION
Instead of intersecting the last frame with bad, always use a transition from the second to last frame.

Initial results look good (posted below), but I haven't yet fully convinced myself this is correct.