### PR TITLE
VCD Printer Update

### DIFF
--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -159,10 +159,15 @@ VCDWitnessPrinter::VCDWitnessPrinter(
       states_(ts.statevars()),
       named_terms_(ts.named_terms()),
       cex_(cex),
-      hash_id_cnt_(0)
+      hash_id_cnt_(0),
+      property_id_cnt_(0)
 {
   // figure out the variables and their scopes
   for (auto && name_term_pair : named_terms_) {
+    // It seems that next_var now will also go into named_terms
+    if (ts.is_next_var(name_term_pair.second))
+      continue;
+
     bool is_reg = 
       std::find(states_.begin(), states_.end(), name_term_pair.second)
       != states_.end();
@@ -228,11 +233,53 @@ std::string VCDWitnessPrinter::new_hash_id() {
   return "v" + std::to_string(hash_id_cnt_++);
 }
 
+std::string VCDWitnessPrinter::new_property_id() {
+  return "assert(property" + std::to_string(property_id_cnt_++)+")";
+}
+
+bool static is_bad_state_pattern(const std::string & n) {
+  auto dot_pos = n.rfind(':');
+  for (auto pos = dot_pos + 1; pos < n.length(); ++pos) {
+    char ch = n.at(pos);
+    if (isdigit(ch) || ch == '.' || ch == '-')
+      continue;
+    return false;
+  }
+  return true;
+}
+
 void VCDWitnessPrinter::check_insert_scope(std::string full_name,
                                            bool is_reg,
                                            const smt::Term & ast)
 {
-  // vcd doesn't like colons in name
+  // yosys could use $... for internal unnamed nodes,
+  // which maybe we don't want at all
+
+  if (full_name.front() == '$')
+    return;
+  if (is_bad_state_pattern(full_name))
+    full_name = new_property_id();
+
+  // yosys use " ; " as the separator for comment
+  // HZ: I'm actually surprised that text after ' ; '
+  // is not parsed by Btor2 frontend
+  // so the check is mostly unuseful.
+  // But it does not hurt to have it.
+  // There is just one exception, that is the
+  // name after bad state: 
+  // Yosys will output something like this:
+  //
+  //   155 bad 154 ./ridecore-src-buggy/topsim.v:101.13-112.8|./ridecore-src-buggy/pipeline.v:2005.11-2006.28
+  // 
+  // and the symbols and dots will overwhelm the later code that
+  // tries to sort out the hierarchy of the signal.
+  // Actually this is not signal name at all.
+  // That's why I use `new_property_id` above to replace it
+
+  auto pos = full_name.find(" ; ");
+  if(pos != full_name.npos)
+    full_name = full_name.substr(0,pos);
+  // gtkwave doesn't like colons in name
   std::replace(full_name.begin(), full_name.end(), ':', '_');
   auto scopes = split(full_name, ".");
   VCDScope * root = & root_scope_;
@@ -242,7 +289,7 @@ void VCDWitnessPrinter::check_insert_scope(std::string full_name,
     if (pos != root->subscopes.end()) { // we find it
       root = & (pos->second);
     } else { // we need to insert this scope
-      root->subscopes.insert(std::make_pair(next_scope, VCDScope()));
+      root->subscopes.emplace(next_scope, VCDScope());
       root = &( root->subscopes.at(next_scope) );
     }
   } // at the end of this loop, we are at the scope to insert our variable
@@ -252,14 +299,16 @@ void VCDWitnessPrinter::check_insert_scope(std::string full_name,
   std::map<std::string, VCDSignal> & signal_set = is_reg ? root->regs : root->wires;
 
   if (signal_set.find(short_name) != signal_set.end()) {
-    logger.log(1, full_name + " has been registered already");
+    // this can happen if the term is registered both under
+    // named_terms_ and statevars/inputvars
+    // we can ignore this issue.
     return;
   }
   auto hashid = new_hash_id();
-  signal_set.insert(std::make_pair(short_name,
+  signal_set.emplace(short_name,
     VCDSignal(
       short_name + width2range(width), 
-      full_name,  hashid , ast, width)));
+      full_name,  hashid , ast, width));
   allsig_bv_.push_back( &(signal_set.at(short_name)) );
 } // end of check_insert_scope
 
@@ -279,7 +328,7 @@ void VCDWitnessPrinter::check_insert_scope_array(
     if (pos != root->subscopes.end()) { // we find it
       root = & (pos->second);
     } else { // we need to insert this scope
-      root->subscopes.insert(std::make_pair(next_scope, VCDScope()));
+      root->subscopes.emplace(next_scope, VCDScope());
       root = &( root->subscopes.at(next_scope) );
     }
   } // at the end of this loop, we are at the scope to insert our variable
@@ -289,17 +338,18 @@ void VCDWitnessPrinter::check_insert_scope_array(
   std::map<std::string, VCDArray> & signal_set = root->arrays;
 
   if (signal_set.find(short_name) != signal_set.end()) {
-    // TODO: only check in Debug
+    // I actually maybe should use `assert(false)` here, because
+    // the code now should guarantee this will not happen
     throw PonoException(full_name + " has been registered already");
   }
 
-  signal_set.insert(std::make_pair(short_name,
-    VCDArray(short_name, full_name,  ast, data_width)));
+  signal_set.emplace(short_name,
+    VCDArray(short_name, full_name,  ast, data_width));
   auto & indices2hash = signal_set.at(short_name).indices2hash;
   for (const auto & index : indices)
-    indices2hash.insert(std::make_pair(index, new_hash_id()));
+    indices2hash.emplace(index, new_hash_id());
   if (has_default)
-    indices2hash.insert(std::make_pair("default", new_hash_id()));
+    indices2hash.emplace("default", new_hash_id());
   allsig_array_.push_back( &(signal_set.at(short_name)) );
   // to do: add indices and their hashes
 } // end of check_insert_scope_array
@@ -365,10 +415,10 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
       continue;
     }
     auto val = as_bits(pos->second->to_string());
-    valbuf.insert(std::make_pair(
+    valbuf.emplace(
       sig_bv_ptr->hash,
       val
-    ));
+    );
     fout << val << " " << sig_bv_ptr->hash << std::endl;
   } // for all bv signals
 
@@ -393,7 +443,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
       auto data = as_bits(store_children[2]->to_string());
       auto addr_pos = sig_array_ptr->indices2hash.find(addr);
       if (addr_pos != sig_array_ptr->indices2hash.end()) {
-        valbuf.insert(std::make_pair(addr_pos->second, data));
+        valbuf.emplace(addr_pos->second, data);
         fout << data << " " << addr_pos->second << std::endl;
       } else {
         logger.log(1, "missing addr index for array: {}: , addr : {}" ,
@@ -408,7 +458,7 @@ void VCDWitnessPrinter::dump_all(const smt::UnorderedTermMap & valmap,
       auto data_default = as_bits(const_val->to_string());
       auto addr_pos = sig_array_ptr->indices2hash.find("default");
       if (addr_pos != sig_array_ptr->indices2hash.end()) {
-        valbuf.insert(std::make_pair(addr_pos->second, data_default));
+        valbuf.emplace(addr_pos->second, data_default);
         fout << data_default << " " << addr_pos->second << std::endl;
       } else {
         logger.log(1, "missing addr index for array: {}: , addr : {}" ,
@@ -434,7 +484,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
     auto val = as_bits(pos->second->to_string());
     auto prev_pos = valprev.find(sig_bv_ptr->hash);
     if (prev_pos == valprev.end()) {
-      valprev.insert(std::make_pair(sig_bv_ptr->hash, val ));
+      valprev.emplace(sig_bv_ptr->hash, val );
       fout << val << " " << sig_bv_ptr->hash << std::endl;
       logger.log(1, "Bug, {} was not cached before time : {}.",
         sig_bv_ptr->full_name, std::to_string(t));
@@ -471,7 +521,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
       if (addr_pos != sig_array_ptr->indices2hash.end()) {
         auto prev_pos = valprev.find(addr_pos->second);
         if (prev_pos == valprev.end()) {
-          valprev.insert(std::make_pair(addr_pos->second, data ));
+          valprev.emplace(addr_pos->second, data );
           fout << data << " " << addr_pos->second << std::endl;
           logger.log(1, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"["+addr+"]", std::to_string(t));
@@ -495,7 +545,7 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
       if (addr_pos != sig_array_ptr->indices2hash.end()) {
         auto prev_pos = valprev.find(addr_pos->second);
         if (prev_pos == valprev.end()) {
-          valprev.insert(std::make_pair(addr_pos->second, data_default ));
+          valprev.emplace(addr_pos->second, data_default );
           fout << data_default << " " << addr_pos->second << std::endl;
           logger.log(1, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"[default]", std::to_string(t));

--- a/printers/vcd_witness_printer.cpp
+++ b/printers/vcd_witness_printer.cpp
@@ -523,7 +523,12 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.emplace(addr_pos->second, data );
           fout << data << " " << addr_pos->second << std::endl;
-          logger.log(1, "{} was not cached before time : {}.",
+          // this happens if some elements are not assigned by
+          // the solver in the beginning, I think this is also
+          // common and GtkWave is able to handle it (by having X, don't care)
+          // before it is first assigned
+          // so you can consider even remove the logger below
+          logger.log(3, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"["+addr+"]", std::to_string(t));
         } else {
           if (prev_pos->second != data) {
@@ -532,6 +537,9 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
           }
         } // exists in prev pos or not
       } else {
+        // we should have already recorded all the indices by
+        // going through all the frames earlier on
+        // so if the case happens, it should be a bug actually
         logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, addr);
       }
@@ -547,7 +555,12 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
         if (prev_pos == valprev.end()) {
           valprev.emplace(addr_pos->second, data_default );
           fout << data_default << " " << addr_pos->second << std::endl;
-          logger.log(1, "{} was not cached before time : {}.",
+          // this happens if some elements are not assigned by
+          // the solver in the beginning, I think this is also
+          // common and GtkWave is able to handle it (by having X, don't care)
+          // before it is first assigned
+          // so you can consider even remove the logger below
+          logger.log(3, "{} was not cached before time : {}.",
             sig_array_ptr->full_name+"[default]", std::to_string(t));
         } else {
           if (prev_pos->second != data_default) {
@@ -556,6 +569,9 @@ void VCDWitnessPrinter::dump_diff(const smt::UnorderedTermMap & valmap,
           }
         } // exists in prev pos or not
       } else {
+        // we should have already recorded all the indices by
+        // going through all the frames earlier on
+        // so if the case happens, it should be a bug actually
         logger.log(1, "missing addr index for array: {}: , addr : {}" ,
           sig_array_ptr->full_name, "-default-");
       }

--- a/printers/vcd_witness_printer.h
+++ b/printers/vcd_witness_printer.h
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <vector>
 #include <set>
+#include <functional>
 
 #include "gmpxx.h"
 #include "smt-switch/smt.h"
@@ -70,8 +71,8 @@ public:
   // types
   typedef std::map<std::string, std::vector<std::string>> per_mem_indices;
 protected:
- const smt::UnorderedTermSet inputs_;
- const smt::UnorderedTermSet states_;
+ const smt::UnorderedTermSet & inputs_;
+ const smt::UnorderedTermSet & states_;
  const std::unordered_map<std::string, smt::Term> & named_terms_;
  const std::vector<smt::UnorderedTermMap> & cex_;
 
@@ -93,6 +94,9 @@ protected:
 
  uint64_t hash_id_cnt_;
  std::string new_hash_id();
+
+ uint64_t property_id_cnt_;
+ std::string new_property_id();
 
  void dump_current_scope(std::ostream & fout, const VCDScope *) const;
 


### PR DESCRIPTION
I think what goes into the `named_terms_` might have changed and VCD printer was not catching up with that change.
This is to adapt it for that.

It also solves issues related to Yosys's generated signal name format in Btor2.

And I made some array related checks less verbose.