### PR TITLE
Add optional profiling via gperftools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if (WITH_MSAT)
 endif()
 
 if (WITH_PROFILING)
+  find_library(GOOGLE_PERF profiler REQUIRED)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_PROFILING")
 endif()
 
@@ -205,8 +206,8 @@ if (LIBRT)
   target_link_libraries(pono-lib PUBLIC ${LIBRT})
 endif()
 
-if (WITH_PROFILING)
-  target_link_libraries(pono-lib PUBLIC profiler)
+if (GOOGLE_PERF)
+  target_link_libraries(pono-lib PUBLIC ${GOOGLE_PERF})
 endif()
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,10 @@ if (LIBRT)
   target_link_libraries(pono-lib PUBLIC ${LIBRT})
 endif()
 
+if (WITH_PROFILING)
+  target_link_libraries(pono-lib PUBLIC profiler)
+endif()
+
 enable_testing()
 # Add tests subdirectory
 # The CMakeLists.txt file there sets up googletest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ if (WITH_MSAT)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_MSAT")
 endif()
 
+if (WITH_PROFILING)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITH_PROFILING")
+endif()
+
 include_directories("${PROJECT_SOURCE_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}/utils")
 include_directories("${PROJECT_SOURCE_DIR}/core")

--- a/LICENSE
+++ b/LICENSE
@@ -43,3 +43,7 @@ file.
 The 'contrib/optionparser-1.7' directory contains third-party
 software. The copyright and licensing information is in the
 'contrib/optionparser-1.7/src/optionparser.h' file.
+
+Pono optionally links against the third-party gperftools library, which comes
+under a BSD 3-clause license. The copyright and licensing information
+can be found here: https://github.com/gperftools/gperftools/blob/master/COPYING

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
 
 ## Setup
 
+TODO: ADD NOTES/REFERENCE ON PROFILING
+
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with boolector
 * [optional] to build with MathSAT (required for interpolant-based model checking) you need to obtain the libraries yourself
   * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
 
 ## Setup
 
-TODO: ADD NOTES/REFERENCE ON PROFILING
-TODO: on ubuntu, e.g., need 'sudo apt-get install google-perftools libgoogle-perftools-dev'
-TODO:   e.g. finally run  "google-pprof --text <pono-executable> <profile-data-file>"
-
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with boolector
 * [optional] to build with MathSAT (required for interpolant-based model checking) you need to obtain the libraries yourself
   * note that MathSAT is under a custom non-BSD compliant license and you must assume all responsibility for meeting the conditions
@@ -19,6 +15,30 @@ TODO:   e.g. finally run  "google-pprof --text <pono-executable> <profile-data-f
 * Run `./configure.sh`.
 * Run `cd build`.
 * Run `make`.
+
+
+### Profiling
+
+We link against the [gperftools library](https://github.com/gperftools/gperftools)
+to generate profiling data. To enable profiling, run `./configure.sh`
+with flag `--with-profiling` and recompile Pono by running `make` in
+the `build` directory. This assumes that you have installed the
+gperftools library before, e.g., on Ubuntu, run `sudo apt-get install
+google-perftools libgoogle-perftools-dev`.
+
+To profile, run `./pono --profiling-log=<log-file> ...` where
+`<log-file>` is the path to a file where profiling data is
+written. After normal or abnormal (e.g. via sending a signal)
+termination of Pono, the collected profile data can be analyzed by
+running, e.g., `google-pprof --text ./pono <log-file>` to produce a
+textual profile. See `man google-pprof` for further options.
+
+In general, see
+[https://github.com/gperftools/gperftools/tree/master/docs](https://github.com/gperftools/gperftools/tree/master/docs)
+for further information about gperftools.
+
+gperftools is licensed under a BSD 3-clause license, see
+[https://github.com/gperftools/gperftools/blob/master/COPYING](https://github.com/gperftools/gperftools/blob/master/COPYING).
 
 ## Existing code
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
 ## Setup
 
 TODO: ADD NOTES/REFERENCE ON PROFILING
+TODO:   e.g. finally run  "google-pprof --text <pono-executable> <profile-data-file>"
 
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with boolector
 * [optional] to build with MathSAT (required for interpolant-based model checking) you need to obtain the libraries yourself

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ generation of [CoSA](https://github.com/cristian-mattarei/CoSA) and thus was ori
 ## Setup
 
 TODO: ADD NOTES/REFERENCE ON PROFILING
+TODO: on ubuntu, e.g., need 'sudo apt-get install google-perftools libgoogle-perftools-dev'
 TODO:   e.g. finally run  "google-pprof --text <pono-executable> <profile-data-file>"
 
 * Run `./contrib/setup-smt-switch.sh` -- it will build smt-switch with boolector

--- a/configure.sh
+++ b/configure.sh
@@ -21,6 +21,7 @@ Configures the CMAKE build environment.
 --py2                   use python2 interpreter (default: python3)
 --static-lib            build a static library (default: shared)
 --static                build a static executable (default: dynamic); implies --static-lib
+--with-profiling        build with gperftools for profiling (default: off)
 EOF
   exit 0
 }
@@ -40,6 +41,7 @@ python=default
 py2=default
 lib_type=SHARED
 static_exec=NO
+with_profiling=default
 
 buildtype=Release
 
@@ -86,6 +88,7 @@ do
             static_exec=YES;
             lib_type=STATIC;
             ;;
+        --with-profiling) with_profiling=ON;;
         *) die "unexpected argument: $1";;
     esac
     shift
@@ -107,6 +110,9 @@ cmake_opts="-DCMAKE_BUILD_TYPE=$buildtype -DPONO_LIB_TYPE=${lib_type} -DPONO_STA
 
 [ $py2 != default ] \
     && cmake_opts="$cmake_opts -DUSE_PYTHON2=ON"
+
+[ $with_profiling != default ] \
+    && cmake_opts="$cmake_opts -DWITH_PROFILING=$with_profiling"
 
 root_dir=$(pwd)
 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -49,7 +49,8 @@ enum optionIndex
   NO_IC3_INDGEN,
   IC3_GEN_MAX_ITER,
   IC3_INDGEN_MODE,
-  IC3_FUNCTIONAL_PREIMAGE
+  IC3_FUNCTIONAL_PREIMAGE,
+  PROFILING_LOG_FILENAME
 };
 
 struct Arg : public option::Arg
@@ -225,6 +226,13 @@ const option::Descriptor usage[] = {
     "ic3-functional-preimage",
     Arg::None,
     "  --ic3-functional-preimage \tUse functional preimage in ic3." },
+  { PROFILING_LOG_FILENAME,
+    0,
+    "",
+    "profiling-log",
+    Arg::NonEmpty,
+    "  --profiling-log \tName of logfile for profiling output"
+    "(requires build with linked profiling library 'gperftools')." },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -233,7 +241,8 @@ const option::Descriptor usage[] = {
 namespace pono {
 
 const std::string PonoOptions::default_smt_solver_ = "btor";
-
+const std::string PonoOptions::default_profiling_log_filename_ = "";
+  
 Engine PonoOptions::to_engine(std::string s)
 {
   if (str2engine.find(s) != str2engine.end()) {
@@ -327,6 +336,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
                 "--ic3-indgen-mode value must be between 0 and 2.");
           break;
         case IC3_FUNCTIONAL_PREIMAGE: ic3_functional_preimage_ = true; break;
+        case PROFILING_LOG_FILENAME: profiling_log_filename_ = opt.arg; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -336,7 +336,14 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
                 "--ic3-indgen-mode value must be between 0 and 2.");
           break;
         case IC3_FUNCTIONAL_PREIMAGE: ic3_functional_preimage_ = true; break;
-        case PROFILING_LOG_FILENAME: profiling_log_filename_ = opt.arg; break;
+        case PROFILING_LOG_FILENAME:
+#ifndef WITH_PROFILING
+          throw PonoException("Profiling requires linking to gperftools library. "\
+                              "Please reconfigure Pono with './configure --with-profiling'.");
+#else
+          profiling_log_filename_ = opt.arg;
+#endif
+          break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -232,7 +232,7 @@ const option::Descriptor usage[] = {
     "profiling-log",
     Arg::NonEmpty,
     "  --profiling-log \tName of logfile for profiling output"
-    "(requires build with linked profiling library 'gperftools')." },
+    " (requires build with linked profiling library 'gperftools')." },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -242,7 +242,7 @@ namespace pono {
 
 const std::string PonoOptions::default_smt_solver_ = "btor";
 const std::string PonoOptions::default_profiling_log_filename_ = "";
-  
+
 Engine PonoOptions::to_engine(std::string s)
 {
   if (str2engine.find(s) != str2engine.end()) {
@@ -338,8 +338,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
         case IC3_FUNCTIONAL_PREIMAGE: ic3_functional_preimage_ = true; break;
         case PROFILING_LOG_FILENAME:
 #ifndef WITH_PROFILING
-          throw PonoException("Profiling requires linking to gperftools library. "\
-                              "Please reconfigure Pono with './configure --with-profiling'.");
+          throw PonoException(
+              "Profiling requires linking to gperftools library. "
+              "Please reconfigure Pono with './configure --with-profiling'.");
 #else
           profiling_log_filename_ = opt.arg;
 #endif

--- a/options/options.h
+++ b/options/options.h
@@ -102,7 +102,7 @@ class PonoOptions
   bool ceg_prophecy_arrays_;
   bool cegp_axiom_red_;  ///< reduce axioms with an unsat core in ceg prophecy
   std::string profiling_log_filename_;
-    
+
  private:
   // Default options
   static const Engine default_engine_ = BMC;

--- a/options/options.h
+++ b/options/options.h
@@ -65,7 +65,8 @@ class PonoOptions
         ic3_indgen_mode_(default_ic3_indgen_mode_),
         ic3_functional_preimage_(default_ic3_functional_preimage_),
         ceg_prophecy_arrays_(default_ceg_prophecy_arrays_),
-        cegp_axiom_red_(default_cegp_axiom_red_)
+        cegp_axiom_red_(default_cegp_axiom_red_),
+        profiling_log_filename_(default_profiling_log_filename_)
   {
   }
 
@@ -100,7 +101,8 @@ class PonoOptions
   // ceg-prophecy-arrays options
   bool ceg_prophecy_arrays_;
   bool cegp_axiom_red_;  ///< reduce axioms with an unsat core in ceg prophecy
-
+  std::string profiling_log_filename_;
+    
  private:
   // Default options
   static const Engine default_engine_ = BMC;
@@ -120,6 +122,7 @@ class PonoOptions
   static const unsigned int default_ic3_indgen_mode_ = 0;
   static const bool default_ic3_functional_preimage_ = false;
   static const bool default_cegp_axiom_red_ = true;
+  static const std::string default_profiling_log_filename_;
 };
 
 }  // namespace pono

--- a/pono.cpp
+++ b/pono.cpp
@@ -14,9 +14,9 @@
 **
 **/
 
+#include <csignal>
 #include <iostream>
 #include "assert.h"
-#include <csignal>
 
 #ifdef WITH_PROFILING
 #include <gperftools/profiler.h>
@@ -107,30 +107,31 @@ ProverResult check_prop(PonoOptions pono_options,
   return r;
 }
 
-//Note: signal handlers are registered only when profiling is enabled.
-void
-profiling_sig_handler (int sig)
+// Note: signal handlers are registered only when profiling is enabled.
+void profiling_sig_handler(int sig)
 {
   std::string signame;
   switch (sig) {
     case SIGINT: signame = "SIGINT"; break;
     case SIGTERM: signame = "SIGTERM"; break;
     case SIGALRM: signame = "SIGALRM"; break;
-    default: throw PonoException("Caught unexpected signal"\
-                                 "in profiling signal handler.");
+    default:
+      throw PonoException(
+          "Caught unexpected signal"
+          "in profiling signal handler.");
   }
-  logger.log (0, "\n Signal {} received\n", signame);
+  logger.log(0, "\n Signal {} received\n", signame);
 #ifdef WITH_PROFILING
   ProfilerFlush();
   ProfilerStop();
 #endif
   // Switch back to default handling for signal 'sig' and raise it.
-  signal (sig, SIG_DFL);
-  raise (sig);
+  signal(sig, SIG_DFL);
+  raise(sig);
 }
 
 int main(int argc, char ** argv)
-{  
+{
   PonoOptions pono_options;
   ProverResult res = pono_options.parse_and_set_options(argc, argv);
   if (res == ERROR) return res;
@@ -147,15 +148,16 @@ int main(int argc, char ** argv)
   // program.  This is necessary to gracefully stop profiling when,
   // e.g., an external time limit is enforced to stop the program.
   if (!pono_options.profiling_log_filename_.empty()) {
-    signal (SIGINT, profiling_sig_handler);
-    signal (SIGTERM, profiling_sig_handler);
-    signal (SIGALRM, profiling_sig_handler);
+    signal(SIGINT, profiling_sig_handler);
+    signal(SIGTERM, profiling_sig_handler);
+    signal(SIGALRM, profiling_sig_handler);
 #ifdef WITH_PROFILING
-    logger.log(0, "Profiling log filename: {}", pono_options.profiling_log_filename_);
+    logger.log(
+        0, "Profiling log filename: {}", pono_options.profiling_log_filename_);
     ProfilerStart(pono_options.profiling_log_filename_.c_str());
 #endif
   }
-  
+
   try {
     SmtSolver s;
     SmtSolver second_solver;
@@ -353,6 +355,6 @@ int main(int argc, char ** argv)
     ProfilerStop();
 #endif
   }
-  
+
   return res;
 }


### PR DESCRIPTION
This PR adds optional CPU profiling via linking against the `gperftools` library:

[https://github.com/gperftools/gperftools](https://github.com/gperftools/gperftools)

The README file of Pono comes with usage and installation information.

For this PR, a limited form of signal handling was added. In order to correctly finalize the generation of profile data, it is necessary to catch e.g. SIGINT or SIGTERM when Pono is interrupted by an external time out or when the user manually aborts Pono.