### PR TITLE
Add support for compiling with external coreir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ add_library(pono-lib "${PONO_LIB_TYPE}"
 
 set_target_properties(pono-lib PROPERTIES OUTPUT_NAME pono)
 
-if (WITH_COREIR)
+if (WITH_COREIR OR WITH_COREIR_EXTERN)
   add_definitions(-DWITH_COREIR)
   target_sources(pono-lib PUBLIC "${PROJECT_SOURCE_DIR}/frontends/coreir_encoder.cpp")
 endif()
@@ -183,6 +183,21 @@ target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch
 
 if (WITH_MSAT)
   target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-msat.a")
+endif()
+
+if (WITH_COREIR_EXTERN)
+  # coreir installs into /usr/local
+  add_library(coreir SHARED IMPORTED)
+  set_target_properties(coreir PROPERTIES
+    IMPORTED_LOCATION "/usr/local/lib/libcoreir${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include"
+  )
+  add_library(verilogAST SHARED IMPORTED)
+  set_target_properties(verilogAST PROPERTIES
+    IMPORTED_LOCATION "/usr/local/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include"
+  )
+  target_link_libraries(pono-lib PUBLIC coreir verilogAST)
 endif()
 
 if (WITH_COREIR)

--- a/configure.sh
+++ b/configure.sh
@@ -16,6 +16,7 @@ Configures the CMAKE build environment.
 --with-msat             build with MathSAT which has a custom non-BSD compliant license.  (default : off)
                         Required for interpolant based model checking
 --with-coreir           build the CoreIR frontend (default: off)
+--with-coreir-extern    build the CoreIR frontend using an externally installed library (e.g. pycoreir) (default: off)
 --debug                 build debug with debug symbols (default: off)
 --python                compile with python bindings (default: off)
 --py2                   use python2 interpreter (default: python3)
@@ -35,6 +36,7 @@ install_prefix=default
 build_type=default
 with_msat=default
 with_coreir=default
+with_coreir_extern=default
 debug=default
 python=default
 py2=default
@@ -69,6 +71,7 @@ do
             ;;
         --with-msat) with_msat=ON;;
         --with-coreir) with_coreir=ON;;
+        --with-coreir-extern) with_coreir_extern=ON;;
         --debug)
             debug=yes;
             buildtype=Debug
@@ -101,6 +104,9 @@ cmake_opts="-DCMAKE_BUILD_TYPE=$buildtype -DPONO_LIB_TYPE=${lib_type} -DPONO_STA
 
 [ $with_coreir != default ] \
     && cmake_opts="$cmake_opts -DWITH_COREIR=$with_coreir"
+
+[ $with_coreir_extern != default ] \
+    && cmake_opts="$cmake_opts -DWITH_COREIR_EXTERN=$with_coreir_extern"
 
 [ $python != default ] \
     && cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"

--- a/configure.sh
+++ b/configure.sh
@@ -16,7 +16,7 @@ Configures the CMAKE build environment.
 --with-msat             build with MathSAT which has a custom non-BSD compliant license.  (default : off)
                         Required for interpolant based model checking
 --with-coreir           build the CoreIR frontend (default: off)
---with-coreir-extern    build the CoreIR frontend using a globally installed library (e.g. pycoreir) (default: off)
+--with-coreir-extern    build the CoreIR frontend using an installation of coreir in /usr/local/lib (default: off)
 --debug                 build debug with debug symbols (default: off)
 --python                compile with python bindings (default: off)
 --py2                   use python2 interpreter (default: python3)

--- a/configure.sh
+++ b/configure.sh
@@ -16,7 +16,7 @@ Configures the CMAKE build environment.
 --with-msat             build with MathSAT which has a custom non-BSD compliant license.  (default : off)
                         Required for interpolant based model checking
 --with-coreir           build the CoreIR frontend (default: off)
---with-coreir-extern    build the CoreIR frontend using an externally installed library (e.g. pycoreir) (default: off)
+--with-coreir-extern    build the CoreIR frontend using a globally installed library (e.g. pycoreir) (default: off)
 --debug                 build debug with debug symbols (default: off)
 --python                compile with python bindings (default: off)
 --py2                   use python2 interpreter (default: python3)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 
 # WITH_COREIR is a macro in the Cython files
 # Needs to be set either way
-if (WITH_COREIR)
+if (WITH_COREIR OR WITH_COREIR_EXTERN)
   set(CYTHON_FLAGS "--compile-time-env WITH_COREIR=ON ${CYTHON_FLAGS}"
       CACHE STRING "Extra flags to the cython compiler." FORCE)
 else()


### PR DESCRIPTION
This adds support for compiling with a standard coreir installation into
/usr/local.  In the future we may consider supporting more general
installation locations using CMake find_package style, but for now this
should cover the basic use case. (For example, we could try to find the
verison of CoreIR distributed with the pycoreir wheel, but the wheel
would need to be updated to include the header files, also the static
linking may be something we need to deal with.)