### PR TITLE
Check that list of files is nonempty and fix assertion typo in Python coreir encoding test

### DIFF
--- a/tests/python/test_encoders.py
+++ b/tests/python/test_encoders.py
@@ -17,13 +17,16 @@ from pathlib import Path
 def test_coreir(create_solver):
     file_dir = Path(os.path.dirname(__file__))
     coreir_inputs_directory = file_dir / Path("../encoders/inputs/coreir")
-    for f in coreir_inputs_directory.glob("*.json"):
+    coreir_files = list(coreir_inputs_directory.glob("*.json"))
+    assert coreir_files
+    for f in coreir_files:
         print("Encoding:", f)
         context = coreir.Context()
+        context.load_library("commonlib")
         top_mod = context.load_from_file(str(f))
 
         solver = create_solver(False)
         rts = c.RelationalTransitionSystem(solver)
         ce = c.CoreIREncoder(top_mod, rts)
         t = solver.make_term(True)
-        assert ce.trans != t, "Expecting a non-empty transition relation"
+        assert rts.trans != t, "Expecting a non-empty transition relation"


### PR DESCRIPTION
Addresses https://github.com/upscale-project/pono/issues/98. The assertion should use `rts` not `ce`. This test was previously silently passing because the list of files was empty which was fixed by https://github.com/upscale-project/pono/pull/97. The coreir encoder was tested in C++, but passing a module encoded through `pycoreir` and passed to the Pono python bindings was only tested here.

I'll consider adding the `coreir` tests to Travis in another PR to help avoid problems like this in the future.