### PR TITLE
[coreir-extern] use /usr install prefix on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,16 +191,20 @@ if (WITH_MSAT)
 endif()
 
 if (WITH_COREIR_EXTERN)
-  # coreir installs into /usr/local
+  if(APPLE)
+    set(COREIR_EXTERN_PREFIX "/usr/local")
+  else()
+    set(COREIR_EXTERN_PREFIX "/usr")
+  endif()
   add_library(coreir SHARED IMPORTED)
   set_target_properties(coreir PROPERTIES
-    IMPORTED_LOCATION "/usr/local/lib/libcoreir${CMAKE_SHARED_LIBRARY_SUFFIX}"
-    INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include"
+    IMPORTED_LOCATION "${COREIR_EXTERN_PREFIX}/lib/libcoreir${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "${COREIR_EXTERN_PREFIX}/include"
   )
   add_library(verilogAST SHARED IMPORTED)
   set_target_properties(verilogAST PROPERTIES
-    IMPORTED_LOCATION "/usr/local/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}"
-    INTERFACE_INCLUDE_DIRECTORIES "/usr/local/include"
+    IMPORTED_LOCATION "${COREIR_EXTERN_PREFIX}/lib/libverilogAST${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "${COREIR_EXTERN_PREFIX}/include"
   )
   target_link_libraries(pono-lib PUBLIC coreir verilogAST)
 endif()


### PR DESCRIPTION
CoreIR uses /usr as the install prefix on linux, see
https://github.com/rdaly525/coreir/blob/master/release/Makefile#L2-L9