### PR TITLE
Fix in IC3 relational preimage generalization

### DIFF
--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -163,13 +163,14 @@ void ModelBasedIC3::initialize()
 
   // set labels
   Sort boolsort = solver_->make_sort(BOOL);
+  // Note: we're using Iff instead of Implies for the labels so that if we want
+  // to negate the formula we can -- e.g. for generalization purposes
   init_label_ = solver_->make_symbol("__init_label", boolsort);
-  solver_->assert_formula(solver_->make_term(Implies, init_label_, ts_.init()));
+  solver_->assert_formula(solver_->make_term(Iff, init_label_, ts_.init()));
   // frame 0 label is identical to init label
   init_label_ = frame_labels_[0];
   trans_label_ = solver_->make_symbol("__trans_label", boolsort);
-  solver_->assert_formula(
-      solver_->make_term(Implies, trans_label_, ts_.trans()));
+  solver_->assert_formula(solver_->make_term(Iff, trans_label_, ts_.trans()));
 
   assert(!interpolator_);
   assert(solver_);
@@ -729,7 +730,7 @@ Conjunction ModelBasedIC3::generalize_predecessor(size_t i,
 
       // preimage formula
       Term pre_formula = get_frame(i - 1);
-      pre_formula = solver_->make_term(And, pre_formula, ts_.trans());
+      pre_formula = solver_->make_term(And, pre_formula, trans_label_);
       pre_formula = solver_->make_term(And, pre_formula,
                                        solver_->make_term(Not, c.term_));
       pre_formula = solver_->make_term(And, pre_formula, ts_.next(c.term_));

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -729,7 +729,7 @@ Conjunction ModelBasedIC3::generalize_predecessor(size_t i,
 
       // preimage formula
       Term pre_formula = get_frame(i - 1);
-      pre_formula = solver_->make_term(And, pre_formula, trans_label_);
+      pre_formula = solver_->make_term(And, pre_formula, ts_.trans());
       pre_formula = solver_->make_term(And, pre_formula,
                                        solver_->make_term(Not, c.term_));
       pre_formula = solver_->make_term(And, pre_formula, ts_.next(c.term_));

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -165,9 +165,13 @@ class ModelBasedIC3 : public Prover
    *  from Fi and all frames after it
    *  @param i the frame number
    */
-  void assert_frame(size_t i) const;
+  void assert_frame_labels(size_t i) const;
 
   smt::Term get_frame(size_t i) const;
+
+  void assert_trans_label() const;
+
+  virtual smt::Term get_trans() const;
 
   void fix_if_intersects_initial(smt::TermVec & to_keep,
                                  const smt::TermVec & rem);

--- a/tests/test_ic3.cpp
+++ b/tests/test_ic3.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include "core/fts.h"
+#include "core/rts.h"
 #include "engines/mbic3.h"
 #include "gtest/gtest.h"
 #include "smt/available_solvers.h"
@@ -32,20 +33,20 @@ class IC3UnitTests : public ::testing::Test,
 
 TEST_P(IC3UnitTests, SimpleSystemSafe)
 {
-  FunctionalTransitionSystem fts(s);
-  Term s1 = fts.make_statevar("s1", boolsort);
-  Term s2 = fts.make_statevar("s2", boolsort);
+  RelationalTransitionSystem rts(s);
+  Term s1 = rts.make_statevar("s1", boolsort);
+  Term s2 = rts.make_statevar("s2", boolsort);
 
   // INIT !s1 & !s2
-  fts.constrain_init(s->make_term(Not, s1));
-  fts.constrain_init(s->make_term(Not, s2));
+  rts.constrain_init(s->make_term(Not, s1));
+  rts.constrain_init(s->make_term(Not, s2));
 
   // TRANS next(s1) = (s1 | s2)
   // TRANS next(s2) = s2
-  fts.assign_next(s1, s->make_term(Or, s1, s2));
-  fts.assign_next(s2, s2);
+  rts.assign_next(s1, s->make_term(Or, s1, s2));
+  rts.assign_next(s2, s2);
 
-  Property p(fts, s->make_term(Not, s1));
+  Property p(rts, s->make_term(Not, s1));
 
   ModelBasedIC3 mbic3(p, s);
   ProverResult r = mbic3.prove();
@@ -53,7 +54,7 @@ TEST_P(IC3UnitTests, SimpleSystemSafe)
 
   // get the invariant
   Term invar = mbic3.invar();
-  ASSERT_TRUE(check_invar(fts, p.prop(), invar));
+  ASSERT_TRUE(check_invar(rts, p.prop(), invar));
 }
 
 TEST_P(IC3UnitTests, SimpleSystemUnsafe)


### PR DESCRIPTION
Looks like I introduced a bug in https://github.com/upscale-project/pono/pull/107. I didn't catch it until now because it only happens for relational systems. I ran it on hwmcc but I must have not rerun it after making more changes. This PR would fix the bug and modify a test so that this kind of issue is tested for in the future.

It seems that the issue is related to preimage generalization for relational systems where we take the whole formula and negate it. If we use the transition system label instead of the actual transition relation, it causes strange over-generalizations. I don't fully understand it, but I think it's because the label is too weak, we want to include the whole transition relation.