### PR TITLE
Fixes for automatic PyPi release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,6 @@ target_include_directories(pono-lib PUBLIC ${INCLUDE_DIRS})
 # Should we build python bindings
 option (BUILD_PYTHON_BINDINGS
    "Build Python bindings")
-option (USE_PYTHON2
-   "Use Python2 for bindings")
 
 if (BUILD_PYTHON_BINDINGS)
   add_subdirectory(python)

--- a/configure.sh
+++ b/configure.sh
@@ -20,7 +20,6 @@ Configures the CMAKE build environment.
 --with-coreir-extern    build the CoreIR frontend using an installation of coreir in /usr/local/lib (default: off)
 --debug                 build debug with debug symbols (default: off)
 --python                compile with python bindings (default: off)
---py2                   use python2 interpreter (default: python3)
 --static-lib            build a static library (default: shared)
 --static                build a static executable (default: dynamic); implies --static-lib
 --with-profiling        build with gperftools for profiling (default: off)
@@ -42,7 +41,6 @@ with_coreir=default
 with_coreir_extern=default
 debug=default
 python=default
-py2=default
 lib_type=SHARED
 static_exec=NO
 with_profiling=default
@@ -84,9 +82,6 @@ do
         --python)
             python=yes
             ;;
-        --py2)
-            py2=yes
-            ;;
         --static-lib)
             lib_type=STATIC
             ;;
@@ -119,9 +114,6 @@ cmake_opts="-DCMAKE_BUILD_TYPE=$buildtype -DPONO_LIB_TYPE=${lib_type} -DPONO_STA
 
 [ $python != default ] \
     && cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"
-
-[ $py2 != default ] \
-    && cmake_opts="$cmake_opts -DUSE_PYTHON2=ON"
 
 [ $with_profiling != default ] \
     && cmake_opts="$cmake_opts -DWITH_PROFILING=$with_profiling"

--- a/contrib/setup-coreir.sh
+++ b/contrib/setup-coreir.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-COREIR_VERSION=f49da00d96e41a05ec32befc10e3115de4d71d4d
+COREIR_VERSION=9205bb90799b6dc97a1baea9e7b50c86858ee779
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=dacdfc90e4c00f06fa62fae4b38aabf7a4390c8a
+SMT_SWITCH_VERSION=829b1f29b2a1529e406918c3136bfde4137a7c83
 
 usage () {
     cat <<EOF

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -104,7 +104,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pono',
-    version='0.1.0',
+    version='draft0.1.0',
     author='Makai Mann',
     ext_modules=[CMakeExtension('pono')],
     cmdclass=dict(build_ext=CMakeBuild),

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -107,7 +107,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pono',
-    version='0.0.9',
+    version='0.1.0',
     author='Makai Mann',
     ext_modules=[CMakeExtension('pono')],
     cmdclass=dict(build_ext=CMakeBuild),

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -81,7 +81,7 @@ class CMakeBuild(build_ext):
         python_make_dir = os.path.join(build_dir, "python")
         if not os.path.isfile(os.path.join(python_make_dir, "Makefile")):
             configure_path = os.path.join(root_dir, "configure.sh")
-            configure_args = [configure_path, "--python"]
+            configure_args = [configure_path, "--python", '--static']
             subprocess.check_call(configure_args, cwd=root_dir)
 
         # build the main library

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -81,7 +81,7 @@ class CMakeBuild(build_ext):
         python_make_dir = os.path.join(build_dir, "python")
         if not os.path.isfile(os.path.join(python_make_dir, "Makefile")):
             configure_path = os.path.join(root_dir, "configure.sh")
-            configure_args = [configure_path, "--python", '--static']
+            configure_args = [configure_path, "--python"]
             subprocess.check_call(configure_args, cwd=root_dir)
 
         # build the main library
@@ -104,7 +104,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name='pono',
-    version='draft0.1.0',
+    version='0.0.9',
     author='Makai Mann',
     ext_modules=[CMakeExtension('pono')],
     cmdclass=dict(build_ext=CMakeBuild),

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -72,6 +72,9 @@ class CMakeBuild(build_ext):
         # build flex
         contrib_flex = os.path.join(contrib_path, "setup-flex.sh")
         subprocess.check_call(contrib_flex)
+        # build coreir
+        contrib_coreir = os.path.join(contrib_path, "setup-coreir.sh")
+        subprocess.check_call(contrib_coreir)
 
         # configure
         root_dir = os.path.dirname(contrib_path)
@@ -81,7 +84,7 @@ class CMakeBuild(build_ext):
         python_make_dir = os.path.join(build_dir, "python")
         if not os.path.isfile(os.path.join(python_make_dir, "Makefile")):
             configure_path = os.path.join(root_dir, "configure.sh")
-            configure_args = [configure_path, "--python"]
+            configure_args = [configure_path, "--python", "--with-coreir"]
             subprocess.check_call(configure_args, cwd=root_dir)
 
         # build the main library

--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -61,7 +61,7 @@ class CMakeBuild(build_ext):
         # contrib folder
         contrib_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
         # build smt-switch
-        contrib_smt_switch = os.path.join(contrib_path, "setup-smt-switch.sh")
+        contrib_smt_switch = [os.path.join(contrib_path, "setup-smt-switch.sh"), "--python"]
         subprocess.check_call(contrib_smt_switch)
         # build btor2
         contrib_btor2 = os.path.join(contrib_path, "setup-btor2tools.sh")

--- a/contrib/wheels/ci.sh
+++ b/contrib/wheels/ci.sh
@@ -3,7 +3,8 @@ set -e
 
 cd pono/
 mkdir -p build
-pip install Cython==0.29
+yum install -y gmp-static libedit-devel
+pip install toml setuptools pexpect Cython==0.29
 python contrib/wheels/build_wheel.py bdist_wheel
 auditwheel show dist/*
 auditwheel repair dist/*

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -43,6 +43,39 @@ else()
   set(PYTHON_VERSION_PATCH ${Python3_VERSION_PATCH})
 endif()
 
+# TODO: either get rid of python2 or actually support both
+if (Python3_Development_FOUND)
+  set(PYTHON_LIBRARY "${Python3_LIBRARIES}" CACHE STRING "Python libraries")
+  set(PYTHON_INCLUDE_DIR "${Python3_INCLUDE_DIRS}" CACHE STRING "Python include directories")
+else()
+  message(STATUS "Didn't find python library and include directory -- falling back")
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+    "from distutils import sysconfig as s;
+print(s.get_python_inc(plat_specific=True));
+print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
+"
+     RESULT_VARIABLE PY_SUCCESS
+     OUTPUT_VARIABLE PY_VALS
+     ERROR_VARIABLE  PY_ERR)
+
+  if (NOT PY_SUCCESS MATCHES 0)
+    message(FATAL "Cannot locate python library...")
+  endif()
+
+  # create a list
+  string(REGEX REPLACE ";" "\\\\;" PY_VALS ${PY_VALS})
+  string(REGEX REPLACE "\n" ";" PY_VALS ${PY_VALS})
+
+  list(GET PY_VALS 0 PY_INCLUDE_DIR)
+  list(GET PY_VALS 1 PY_LIB_SUFFIX)
+
+  set(PYTHON_INCLUDE_DIR "${PY_INCLUDE_DIR}" CACHE STRING "Python include directory")
+
+  # since cmake could not find the library, just set the name/version
+  # and let the linker figure it out
+  set(PYTHON_LIBRARY python${PY_LIB_SUFFIX} CACHE STRING "Python library")
+
+endif()
 
 # WITH_COREIR is a macro in the Cython files
 # Needs to be set either way

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -13,37 +13,21 @@ endif()
 
 # Need to make sure libraries match the interpreter
 # Our CMake files use the latest Python finding cmake modules (as of 2020)
-# https://cmake.org/cmake/help/v3.12/module/FindPython.html (specifically the versioned ones
-#  FindPython2 and FindPython3
-
-if (USE_PYTHON2)
-  message("-- We understand: it's hard to let go. We'll try to use Python2, but it's not really supported, so no promises.")
-  find_package (Python2 COMPONENTS Interpreter Development)
-else()
-  find_package (Python3 COMPONENTS Interpreter Development)
-endif()
+# https://cmake.org/cmake/help/v3.12/module/FindPython.html (specifically the versioned one
+#  FindPython3
+find_package (Python3 COMPONENTS Interpreter Development)
 
 
 # However, the Python Extensions from scikit-build still use an old version
 # We need to set variables so that FindPythonInterp is not run in FindPythonExtensions
 # below, but it looks in the right place for the PythonLibs
-if (USE_PYTHON2)
-  set(PYTHON_EXECUTABLE ${Python2_EXECUTABLE})
-  set(PYTHONINTERP_FOUND ${Python2_Interpreter_FOUND})
-  set(PYTHON_VERSION_STRING ${Python2_VERSION})
-  set(PYTHON_VERSION_MAJOR ${Python2_VERSION_MAJOR})
-  set(PYTHON_VERSION_MINOR ${Python2_VERSION_MINOR})
-  set(PYTHON_VERSION_PATCH ${Python2_VERSION_PATCH})
-else()
-  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-  set(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
-  set(PYTHON_VERSION_STRING ${Python3_VERSION})
-  set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
-  set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
-  set(PYTHON_VERSION_PATCH ${Python3_VERSION_PATCH})
-endif()
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+set(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
+set(PYTHON_VERSION_STRING ${Python3_VERSION})
+set(PYTHON_VERSION_MAJOR ${Python3_VERSION_MAJOR})
+set(PYTHON_VERSION_MINOR ${Python3_VERSION_MINOR})
+set(PYTHON_VERSION_PATCH ${Python3_VERSION_PATCH})
 
-# TODO: either get rid of python2 or actually support both
 if (Python3_Development_FOUND)
   set(PYTHON_LIBRARY "${Python3_LIBRARIES}" CACHE STRING "Python libraries")
   set(PYTHON_INCLUDE_DIR "${Python3_INCLUDE_DIRS}" CACHE STRING "Python include directories")

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(name='pono',
       long_description="Python bindings for the model checker Pono",
-      version='${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
+      version='draft${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
       url='https://github.com/upscale-project/pono',
       license='BSD',
       test_requires=['pytest'],

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(name='pono',
       long_description="Python bindings for the model checker Pono",
-      version='draft${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
+      version='${PONO_MAJOR}.${PONO_MINOR}.${PONO_RELEASE}',
       url='https://github.com/upscale-project/pono',
       license='BSD',
       test_requires=['pytest'],


### PR DESCRIPTION
Debugging the automatic PyPi release. Ready to release version 0.1.0 to PyPi with coreir (will allow `pip install pono`).