### PR TITLE
Add a method for replacing terms in the transition relation

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=cea17f272712b93e7df96a8b194b2c21cd599b15
+# pulling a branch for now
+# SMT_SWITCH_VERSION=cea17f272712b93e7df96a8b194b2c21cd599b15
 
 usage () {
     cat <<EOF
@@ -59,9 +60,11 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    # TEMPORARILY pulling a branch
+    # TODO put this back
+    git clone -b substitution-walker https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
+    # git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,8 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-# pulling a branch for now
-# SMT_SWITCH_VERSION=cea17f272712b93e7df96a8b194b2c21cd599b15
+SMT_SWITCH_VERSION=492b7d499fa1a5b0de281bbbe6db60ead1a89358
 
 usage () {
     cat <<EOF
@@ -60,11 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    # TEMPORARILY pulling a branch
-    # TODO put this back
-    git clone -b substitution-walker https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    # git checkout -f $SMT_SWITCH_VERSION
+    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 
 #include "assert.h"
+#include "smt-switch/substitution_walker.h"
 #include "smt-switch/utils.h"
 
 using namespace smt;
@@ -595,6 +596,56 @@ bool TransitionSystem::only_curr(const Term & term) const
 bool TransitionSystem::no_next(const Term & term) const
 {
   return contains(term, UnorderedTermSetPtrVec{ &statevars_, &inputvars_ });
+}
+
+void TransitionSystem::replace_terms(const UnorderedTermMap & to_replace)
+{
+  // first check that all the replacements contain known symbols
+  for (auto elem : to_replace) {
+    if (!known_symbols(elem.first) || !known_symbols(elem.second)) {
+      throw PonoException("Got an unknown symbol in replace_terms map");
+    }
+  }
+
+  // use a substitution walker because
+  //   1. it keeps a persistent cache
+  //   2. it supports substituting arbitrary terms (e.g. not just mapping from
+  //   symbols)
+  SubstitutionWalker sw(solver_, to_replace);
+
+  // now rebuild terms in every data structure with replacements
+  init_ = sw.visit(init_);
+  if (!only_curr(init_)) {
+    throw PonoException(
+        "Replaced a state variable appearing in init with an input in "
+        "replace_terms");
+  }
+  trans_ = sw.visit(trans_);
+
+  unordered_map<string, Term> new_named_terms;
+  unordered_map<Term, string> new_term_to_name;
+  for (auto elem : named_terms_) {
+    new_named_terms[elem.first] = sw.visit(elem.second);
+    new_term_to_name[sw.visit(elem.second)] = term_to_name_.at(elem.second);
+  }
+  named_terms_ = new_named_terms;
+  term_to_name_ = new_term_to_name;
+
+  // NOTE: don't need to update vars, let COI reduction handle that
+  UnorderedTermMap new_state_updates;
+  Term sv;
+  for (auto elem : state_updates_) {
+    sv = elem.first;
+    new_state_updates[sw.visit(sv)] = sw.visit(elem.second);
+  }
+  state_updates_ = new_state_updates;
+
+  TermVec new_constraints;
+  new_constraints.reserve(constraints_.size());
+  for (auto c : constraints_) {
+    new_constraints.push_back(sw.visit(c));
+  }
+  constraints_ = new_constraints;
 }
 
 bool TransitionSystem::known_symbols(const Term & term) const

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -633,10 +633,17 @@ void TransitionSystem::replace_terms(const UnorderedTermMap & to_replace)
 
   // NOTE: don't need to update vars, let COI reduction handle that
   UnorderedTermMap new_state_updates;
-  Term sv;
+  Term sv, update;
   for (auto elem : state_updates_) {
     sv = elem.first;
-    new_state_updates[sw.visit(sv)] = sw.visit(elem.second);
+    sv = sw.visit(sv);
+    update = sw.visit(elem.second);
+    if (functional_ && !no_next(update)) {
+      throw PonoException(
+          "Got a next state variable in a state update for a functional "
+          "TransitionSystem in replace_terms");
+    }
+    new_state_updates[sv] = update;
   }
   state_updates_ = new_state_updates;
 

--- a/core/ts.h
+++ b/core/ts.h
@@ -280,6 +280,18 @@ class TransitionSystem
    * states */
   bool no_next(const smt::Term & term) const;
 
+  /** Replace terms in the transition system with other terms
+   *  Traverses all the data structures and updates them with
+   *  the replacements
+   *  Recommended usage is for experts only. Use this feature
+   *    to cut out parts of the design by replacing terms with
+   *    fresh inputs. Then cone of influence reduction can remove
+   *    the unconnected parts of the transition system
+   *  @param to_replace a mapping from terms in the transition
+   *         system to their replacement.
+   */
+  void replace_terms(const smt::UnorderedTermMap & to_replace);
+
   // term building functionality -- forwards to the underlying SmtSolver
   // assumes all Terms/Sorts belong to solver_
   // e.g. should only use it on terms created by this TransitionSystem

--- a/python/pono_imp.pxd
+++ b/python/pono_imp.pxd
@@ -37,6 +37,7 @@ cdef extern from "core/ts.h" namespace "pono":
         const c_TermVec & constraints() except +
         bint is_functional() except +
         bint is_deterministic() except +
+        void replace_terms(const c_UnorderedTermMap & to_replace) except +
         c_Sort make_sort(const string name, uint64_t arity) except +
         c_Sort make_sort(const c_SortKind sk) except +
         c_Sort make_sort(const c_SortKind sk, uint64_t size) except +

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -212,6 +212,24 @@ cdef class __AbstractTransitionSystem:
     def is_deterministic(self):
         return dref(self.cts).is_deterministic()
 
+    def replace_terms(self, dict to_replace):
+        '''
+        EXPERTS ONLY
+        Use the provided dictionary to substitute all the terms with the mapping in the transition system
+        Can be used to cut out pieces of the transition system that are unneeded. Note, there are no guarantees,
+        the user is responsible for maintaining any semantics of the system that they want.
+
+        Modifies the transition system in place.
+        '''
+
+        cdef Term term = Term(self)
+        cdef c_UnorderedTermMap utm
+
+        for k, v in to_replace.items():
+            utm[(<Term?> k).ct] = (<Term?> v).ct
+
+        dref(self.cts).replace_terms(utm)
+
     def make_sort(self, arg0, arg1=None, arg2=None, arg3=None):
         cdef Sort s = Sort(self)
         cdef c_SortKind sk

--- a/scripts/travis-mac-install.sh
+++ b/scripts/travis-mac-install.sh
@@ -3,7 +3,7 @@
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
     export PATH=/usr/local/bin:/usr/local/sbin:$PATH
-    brew install gnu-getopt gmp gettext
+    brew install gnu-getopt gettext
 else
     echo "NOT in OSX -- nothing to do"
 fi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,11 @@ target_link_libraries(test_coi gtest_main)
 target_link_libraries(test_coi pono-lib)
 add_test(NAME test_coi COMMAND test_coi)
 
+add_executable(test_ts_replace_terms "${PROJECT_SOURCE_DIR}/tests/test_ts_replace_terms.cpp")
+target_link_libraries(test_ts_replace_terms gtest_main)
+target_link_libraries(test_ts_replace_terms pono-lib)
+add_test(NAME test_ts_replace_terms COMMAND test_ts_replace_terms)
+
 add_executable(test_btor2_ts_copy_equal "${PROJECT_SOURCE_DIR}/tests/test_btor2_ts_copy_equal.cpp")
 target_link_libraries(test_btor2_ts_copy_equal gtest_main)
 target_link_libraries(test_btor2_ts_copy_equal pono-lib)

--- a/tests/test_ts_replace_terms.cpp
+++ b/tests/test_ts_replace_terms.cpp
@@ -1,0 +1,54 @@
+#include <utility>
+#include <vector>
+
+#include "core/fts.h"
+#include "gtest/gtest.h"
+#include "smt-switch/utils.h"
+#include "smt/available_solvers.h"
+#include "utils/exceptions.h"
+
+using namespace pono;
+using namespace smt;
+using namespace std;
+
+namespace pono_tests {
+
+class TSReplaceTests : public ::testing::Test,
+                       public ::testing::WithParamInterface<SolverEnum>
+{
+ protected:
+  void SetUp() override
+  {
+    s = create_solver(GetParam());
+    bvsort = s->make_sort(BV, 8);
+  }
+  SmtSolver s;
+  Sort bvsort;
+};
+
+TEST_P(TSReplaceTests, ReplaceTerms)
+{
+  FunctionalTransitionSystem fts(s);
+
+  Term x = fts.make_statevar("x", bvsort);
+  Term v = fts.make_statevar("v", bvsort);
+
+  Term mul = s->make_term(BVMul, v, x);
+  fts.assign_next(x, mul);
+
+  Term fresh = fts.make_statevar("fresh", bvsort);
+  fts.replace_terms({ { mul, fresh } });
+
+  EXPECT_EQ(fresh, fts.state_updates().at(x));
+
+  UnorderedTermSet free_syms;
+  get_free_symbolic_consts(fts.init(), free_syms);
+  get_free_symbolic_consts(fts.trans(), free_syms);
+
+  EXPECT_TRUE(free_syms.find(v) == free_syms.end());
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverTSReplaceTests,
+                         TSReplaceTests,
+                         testing::ValuesIn(available_solver_enums()));
+}  // namespace pono_tests


### PR DESCRIPTION
This can be used to prune out pieces of a transition system, e.g. by replacing terms with fresh input variables. This is an EXPERTS ONLY feature which makes no guarantee about the resulting system.

FYI @ntsis