### PR TITLE
Refactor so Prover has a pointer to the transition system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,14 @@ script:
   - ./scripts/travis-setup-osx-python.sh || true
   - sudo python3 -m pip install Cython==0.29.21 --install-option="--no-cython-compile"
   - sudo python3 -m pip install pytest
-  - ./travis-scripts/setup-msat.sh --auto-yes
+  # TEMP disable mathsat because website is down
+  # - ./travis-scripts/setup-msat.sh --auto-yes
   - ./contrib/setup-bison.sh
   - ./contrib/setup-flex.sh
   - ./contrib/setup-btor2tools.sh
   - ./travis-scripts/download-cvc4.sh
-  - ./contrib/setup-smt-switch.sh --with-msat --cvc4-home=./deps/CVC4 --python
+  # - ./contrib/setup-smt-switch.sh --with-msat --cvc4-home=./deps/CVC4 --python
+  - ./contrib/setup-smt-switch.sh --cvc4-home=./deps/CVC4 --python
   - sudo python3 -m pip install -e ./deps/smt-switch/build/python
   - ./configure.sh --with-msat --python --debug
   - cd build && make -j2 && make test && cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,8 @@ script:
   # - ./contrib/setup-smt-switch.sh --with-msat --cvc4-home=./deps/CVC4 --python
   - ./contrib/setup-smt-switch.sh --cvc4-home=./deps/CVC4 --python
   - sudo python3 -m pip install -e ./deps/smt-switch/build/python
-  - ./configure.sh --with-msat --python --debug
+  # - ./configure.sh --with-msat --python --debug
+  - ./configure.sh --python --debug
   - cd build && make -j2 && make test && cd ../
   - sudo python3 -m pip install -e ./build/python
   - pytest ./tests

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -55,7 +55,7 @@ void Bmc::initialize()
   // the solver or it could just be polluted with redundant assertions in the
   // future we can use solver_->reset_assertions(), but it is not currently
   // supported in boolector
-  solver_->assert_formula(unroller_.at_time(ts_.init(), 0));
+  solver_->assert_formula(unroller_.at_time(ts_->init(), 0));
 }
 
 ProverResult Bmc::check_until(int k)
@@ -77,7 +77,7 @@ bool Bmc::step(int i)
 
   bool res = true;
   if (i > 0) {
-    solver_->assert_formula(unroller_.at_time(ts_.trans(), i - 1));
+    solver_->assert_formula(unroller_.at_time(ts_->trans(), i - 1));
   }
 
   solver_->push();

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -71,11 +71,11 @@ bool BmcSimplePath::cover_step(int i)
 
   solver_->push();
   solver_->assert_formula(init0_);
-  Term not_init = solver_->make_term(PrimOp::Not, ts_.init());
+  Term not_init = solver_->make_term(PrimOp::Not, ts_->init());
   for (int j = 1; j <= i; ++j) {
     solver_->assert_formula(unroller_.at_time(not_init, j));
   }
-  if (ts_.statevars().size() && check_simple_path_lazy(i)) {
+  if (ts_->statevars().size() && check_simple_path_lazy(i)) {
     return true;
   }
   solver_->pop();

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -35,29 +35,25 @@ using namespace std;
 namespace pono {
 
 IC3IA::IC3IA(Property & p, SolverEnum se)
-  : super(p, se), abs_ts_(ts_.solver()),
-    ia_(ts_, abs_ts_, unroller_)
+    : super(p, se), abs_ts_(ts_->solver()), ia_(*ts_, abs_ts_, unroller_)
 {
   initialize();
 }
 
 IC3IA::IC3IA(Property & p, const SmtSolver & slv)
-  : super(p, slv), abs_ts_(ts_.solver()),
-    ia_(ts_, abs_ts_, unroller_)
+    : super(p, slv), abs_ts_(ts_->solver()), ia_(*ts_, abs_ts_, unroller_)
 {
   initialize();
 }
 
 IC3IA::IC3IA(const PonoOptions & opt, Property & p, const SolverEnum se)
-  : super(opt, p, se), abs_ts_(ts_.solver()),
-    ia_(ts_, abs_ts_, unroller_)
+    : super(opt, p, se), abs_ts_(ts_->solver()), ia_(*ts_, abs_ts_, unroller_)
 {
   initialize();
 }
 
 IC3IA::IC3IA(const PonoOptions & opt, Property & p, const SmtSolver & slv)
-    : super(opt, p, slv), abs_ts_(ts_.solver()),
-      ia_(ts_, abs_ts_, unroller_)
+    : super(opt, p, slv), abs_ts_(ts_->solver()), ia_(*ts_, abs_ts_, unroller_)
 {
   initialize();
 }
@@ -83,7 +79,7 @@ void IC3IA::initialize()
   assert(!to_solver_);
   initialize_interpolator();
 
-  interp_ts_ = RelationalTransitionSystem(ts_, *to_interpolator_);
+  interp_ts_ = RelationalTransitionSystem(*ts_, *to_interpolator_);
   interp_unroller_ = make_unique<Unroller>(interp_ts_, interpolator_);
 }
 
@@ -224,7 +220,7 @@ void IC3IA::set_labels()
 
     // add all the predicates from init and property
     UnorderedTermSet preds;
-    get_predicates(solver_, ts_.init(), preds, false);
+    get_predicates(solver_, ts_->init(), preds, false);
     get_predicates(solver_, bad_, preds, false);
     for (auto p : preds) {
       add_predicate(p);
@@ -271,19 +267,19 @@ ProverResult IC3IA::refine(ProofGoal pg)
   while (tmp.next) {
     tmp = *(tmp.next);
     cex.push_back(tmp.conj.term_);
-    assert(ts_.only_curr(tmp.conj.term_));
+    assert(ts_->only_curr(tmp.conj.term_));
   }
   assert(cex.size() > 1);
 
   // use interpolator to get predicates
   // remember -- need to transfer between solvers
   assert(interpolator_);
-  Term t = make_and({ ts_.init(), cex[0] });
+  Term t = make_and({ ts_->init(), cex[0] });
   Term A =
       interp_unroller_->at_time(to_interpolator_->transfer_term(t, BOOL), 0);
 
   TermVec B;
-  Term interp_trans = to_interpolator_->transfer_term(ts_.trans(), BOOL);
+  Term interp_trans = to_interpolator_->transfer_term(ts_->trans(), BOOL);
   B.reserve(cex.size() - 1);
   // add to B in reverse order so we can pop_back later
   for (int i = cex.size() - 1; i >= 0; --i) {
@@ -331,7 +327,7 @@ ProverResult IC3IA::refine(ProofGoal pg)
   } else {
     UnorderedTermSet preds;
     for (auto I : interpolants) {
-      assert(ts_.only_curr(I));
+      assert(ts_->only_curr(I));
       get_predicates(solver_, I, preds);
     }
 

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -83,11 +83,11 @@ void InterpolantMC::initialize()
   // B)
   UnorderedTermMap & cache = to_solver_.get_cache();
   Term tmp1;
-  for (auto s : ts_.statevars()) {
+  for (auto s : ts_->statevars()) {
     tmp1 = unroller_.at_time(s, 1);
     cache[to_interpolator_.transfer_term(tmp1)] = tmp1;
   }
-  for (auto i : ts_.inputvars()) {
+  for (auto i : ts_->inputvars()) {
     tmp1 = unroller_.at_time(i, 1);
     cache[to_interpolator_.transfer_term(tmp1)] = tmp1;
   }
@@ -95,8 +95,8 @@ void InterpolantMC::initialize()
   // need to copy over UF as well
   UnorderedTermSet free_symbols;
   get_free_symbols(bad_, free_symbols);
-  get_free_symbols(ts_.init(), free_symbols);
-  get_free_symbols(ts_.trans(), free_symbols);
+  get_free_symbols(ts_->init(), free_symbols);
+  get_free_symbols(ts_->trans(), free_symbols);
   for (auto s : free_symbols) {
     if (s->get_sort()->get_sort_kind() == FUNCTION) {
       cache[to_interpolator_.transfer_term(s)] = s;
@@ -104,8 +104,8 @@ void InterpolantMC::initialize()
   }
 
   concrete_cex_ = false;
-  init0_ = unroller_.at_time(ts_.init(), 0);
-  transA_ = unroller_.at_time(ts_.trans(), 0);
+  init0_ = unroller_.at_time(ts_->init(), 0);
+  transA_ = unroller_.at_time(ts_->trans(), 0);
   transB_ = solver_->make_term(true);
   bad_disjuncts_ = solver_->make_term(false);
 }
@@ -205,7 +205,8 @@ bool InterpolantMC::step(int i)
   // transB can't have any symbols from time 0 in it
   assert(i > 0);
   // extend the unrolling
-  transB_ = solver_->make_term(And, transB_, unroller_.at_time(ts_.trans(), i));
+  transB_ =
+      solver_->make_term(And, transB_, unroller_.at_time(ts_->trans(), i));
   ++reached_k_;
 
   return false;

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -58,7 +58,7 @@ void KInduction::initialize()
   // the solver or it could just be polluted with redundant assertions in the
   // future we can use solver_->reset_assertions(), but it is not currently
   // supported in boolector
-  init0_ = unroller_.at_time(ts_.init(), 0);
+  init0_ = unroller_.at_time(ts_->init(), 0);
   false_ = solver_->make_term(false);
   simple_path_ = solver_->make_term(true);
 }
@@ -95,7 +95,7 @@ bool KInduction::base_step(int i)
   }
   solver_->pop();
 
-  solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
+  solver_->assert_formula(unroller_.at_time(ts_->trans(), i));
   solver_->assert_formula(unroller_.at_time(property_.prop(), i));
 
   return true;
@@ -111,7 +111,7 @@ bool KInduction::inductive_step(int i)
   solver_->assert_formula(simple_path_);
   solver_->assert_formula(unroller_.at_time(bad_, i + 1));
 
-  if (ts_.statevars().size() && check_simple_path_lazy(i + 1)) {
+  if (ts_->statevars().size() && check_simple_path_lazy(i + 1)) {
     return true;
   }
 
@@ -124,10 +124,10 @@ bool KInduction::inductive_step(int i)
 
 Term KInduction::simple_path_constraint(int i, int j)
 {
-  assert(ts_.statevars().size());
+  assert(ts_->statevars().size());
 
   Term disj = false_;
-  for (auto v : ts_.statevars()) {
+  for (auto v : ts_->statevars()) {
     Term vi = unroller_.at_time(v, i);
     Term vj = unroller_.at_time(v, j);
     Term eq = solver_->make_term(PrimOp::Equal, vi, vj);

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -175,7 +175,7 @@ class ModelBasedIC3 : public Prover
    */
   bool intersects(const smt::Term & A, const smt::Term & B);
   /** Check if the term intersects with the initial states
-   *  syntactic sugar for intersects(ts_.init(), t);
+   *  syntactic sugar for intersects(ts_->init(), t);
    *  @param t the term to check
    *  @return true iff t intersects with the initial states
    */

--- a/engines/msat_ic3ia.cpp
+++ b/engines/msat_ic3ia.cpp
@@ -45,7 +45,7 @@ MsatIC3IA::MsatIC3IA(const PonoOptions & opt, Property & p, const SmtSolver & so
 
 ProverResult MsatIC3IA::prove()
 {
-  if (ts_.solver()->get_solver_enum() != MSAT) {
+  if (ts_->solver()->get_solver_enum() != MSAT) {
     throw PonoException("MsatIC3IA only supports mathsat solver.");
   }
 
@@ -60,31 +60,31 @@ ProverResult MsatIC3IA::prove()
 
   // give mapping between symbols
   UnorderedTermMap & ts_solver_cache = to_ts_solver.get_cache();
-  for (auto v : ts_.statevars()) {
+  for (auto v : ts_->statevars()) {
     ts_solver_cache[to_msat_solver.transfer_term(v)] = v;
-    ts_solver_cache[to_msat_solver.transfer_term(ts_.next(v))] = ts_.next(v);
+    ts_solver_cache[to_msat_solver.transfer_term(ts_->next(v))] = ts_->next(v);
   }
-  for (auto v : ts_.inputvars()) {
+  for (auto v : ts_->inputvars()) {
     ts_solver_cache[to_msat_solver.transfer_term(v)] = v;
   }
 
   // get mathsat terms for transition system
   msat_term msat_init =
-      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_.init()))
+      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_->init()))
           ->get_msat_term();
   msat_term msat_trans =
-      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_.trans()))
+      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_->trans()))
           ->get_msat_term();
   msat_term msat_prop = static_pointer_cast<MsatTerm>(
                             to_msat_solver.transfer_term(property_.prop()))
                             ->get_msat_term();
   unordered_map<msat_term, msat_term> msat_statevars;
-  for (auto sv : ts_.statevars()) {
+  for (auto sv : ts_->statevars()) {
     msat_statevars[static_pointer_cast<MsatTerm>(
                        to_msat_solver.transfer_term(sv))
                        ->get_msat_term()] =
         static_pointer_cast<MsatTerm>(
-            to_msat_solver.transfer_term(ts_.next(sv)))
+            to_msat_solver.transfer_term(ts_->next(sv)))
             ->get_msat_term();
   }
   // initialize the transition system
@@ -156,14 +156,14 @@ bool MsatIC3IA::compute_witness(msat_env env,
 
   // set up a BMC query
   // with state variables constrained at each step
-  solver_->assert_formula(unroller_.at_time(ts_.init(), 0));
+  solver_->assert_formula(unroller_.at_time(ts_->init(), 0));
   // assert that bad_ is not null
   // i.e. this prover was correctly initialized
   assert(bad_);
   solver_->assert_formula(unroller_.at_time(bad_, ic3ia_wit.size() - 1));
   for (size_t i = 0; i < ic3ia_wit.size(); ++i) {
     if (i + 1 < ic3ia_wit.size()) {
-      solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
+      solver_->assert_formula(unroller_.at_time(ts_->trans(), i));
     }
 
     for (auto msat_eq : ic3ia_wit[i]) {

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -40,9 +40,9 @@ Prover::Prover(Property & p, const smt::SmtSolver & s)
     : solver_(s),
       to_prover_solver_(s),
       property_(p, to_prover_solver_),
-      ts_(property_.transition_system()),
+      ts_(&property_.transition_system()),
       orig_ts_(p.transition_system()),
-      unroller_(ts_, solver_)
+      unroller_(*ts_, solver_)
 {
 }
 
@@ -53,15 +53,13 @@ Prover::Prover(const PonoOptions & opt, Property & p, smt::SolverEnum se)
   solver_->set_opt("produce-models", "true");
 }
 
-Prover::Prover(const PonoOptions & opt,
-               Property & p,
-               const smt::SmtSolver & s)
+Prover::Prover(const PonoOptions & opt, Property & p, const smt::SmtSolver & s)
     : solver_(s),
       to_prover_solver_(solver_),
       property_(p, to_prover_solver_),
-      ts_(property_.transition_system()),
+      ts_(&property_.transition_system()),
       orig_ts_(p.transition_system()),
-      unroller_(ts_, solver_),
+      unroller_(*ts_, solver_),
       options_(opt)
 {
 }
@@ -72,12 +70,12 @@ void Prover::initialize()
 {
   reached_k_ = -1;
   bad_ = solver_->make_term(smt::PrimOp::Not, property_.prop());
-  assert(ts_.only_curr(bad_));
+  assert(ts_->only_curr(bad_));
   if (options_.static_coi_) {
     /* Compute the set of state/input variables related to the
        bad-state property. Based on that information, rebuild the
        transition relation of the transition system. */
-    ConeOfInfluence coi(ts_, { bad_ }, {}, options_.verbosity_);
+    ConeOfInfluence coi(*ts_, { bad_ }, {}, options_.verbosity_);
   }
 }
 
@@ -217,19 +215,19 @@ bool Prover::compute_witness()
     witness_.push_back(UnorderedTermMap());
     UnorderedTermMap & map = witness_.back();
 
-    for (auto v : ts_.statevars()) {
+    for (auto v : ts_->statevars()) {
       Term vi = unroller_.at_time(v, i);
       Term r = solver_->get_value(vi);
       map[v] = r;
     }
 
-    for (auto v : ts_.inputvars()) {
+    for (auto v : ts_->inputvars()) {
       Term vi = unroller_.at_time(v, i);
       Term r = solver_->get_value(vi);
       map[v] = r;
     }
 
-    for (auto elem : ts_.named_terms()) {
+    for (auto elem : ts_->named_terms()) {
       Term ti = unroller_.at_time(elem.second, i);
       map[elem.second] = solver_->get_value(ti);
     }

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -79,8 +79,17 @@ class Prover
   smt::SmtSolver solver_;
   smt::TermTranslator to_prover_solver_;
   Property property_;
-  TransitionSystem &
-      ts_;  ///< convenient reference to transition system in property
+  TransitionSystem *
+      ts_;  ///< pointer to main transition system
+            ///< by default this is the one in property_
+            ///< however, this can change depending on the engine
+            ///< for example, a CEGAR technique will usually
+            ///< set the main ts_ to be the abstraction, and
+            ///< and keep a reference to the concrete transition system
+            ///< Additionally, the pointed-to transition system is NOT
+            ///< guaranteed to be fully initialized in the constructor
+            ///< of the engine
+            ///< this is because abstraction might not happen until later
   TransitionSystem &
       orig_ts_;  ///< reference to original TS before copied to new solver
 


### PR DESCRIPTION
Changes the base Prover class so that it keeps a pointer instead of a reference to the transition system. This is so that engines are free to change what the transition system points to. For example, in a CEGAR technique that utilizes some code from a concrete algorithm (e.g. an IC3 implementation that uses an abstract domain), it's most convenient to have the main `ts_` object be the abstraction, because that's what the algorithm operates on. However, abstraction is not available when the prover class is being constructed.


Note: might be worth considering whether notions of abstraction and refinement should be baked into `Prover` and is just a `no-op` by default. It's possible this would be a better `is-a` relationship with class inheritance. Right now it's a bit funny that some algorithms are CEGAR loops but are derived from a class that doesn't know anything about abstraction or refinement.