### PR TITLE
Build fixes for --with-msat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,7 +235,7 @@ endif()
 
 target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch.a")
 target_link_libraries(pono-lib PUBLIC "${PROJECT_SOURCE_DIR}/deps/btor2tools/build/lib/libbtor2parser.a")
-target_link_libraries(pono-lib PUBLIC "${GMP_LIBRARIES}")
+target_link_libraries(pono-lib PUBLIC "${GMP_LIBRARIES}" "${GMPXX_LIBRARIES}")
 target_link_libraries(pono-lib PUBLIC pthread)
 target_link_libraries(pono-lib PUBLIC y)
 

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=492b7d499fa1a5b0de281bbbe6db60ead1a89358
+SMT_SWITCH_VERSION=9d8b1ebe5a06c3f7a2f924efcdcaa978f503232a
 
 usage () {
     cat <<EOF


### PR DESCRIPTION
This PR pulls an updated version of smt-switch that repacks that static `libsmt-switch-msat.a` with a workaround to fix missing symbols and also links `gmpxx`.