### PR TITLE
Move COI analysis to main

### DIFF
--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -192,12 +192,6 @@ void IC3IA::check_ts() const
   // no restrictions except that interpolants must be supported
   // instead of checking explicitly, just let the interpolator throw an
   // exception better than maintaining in two places
-
-  if (options_.static_coi_) {
-    throw PonoException(
-        "Abstraction-refinement procedure in IC3IA does not yet work with "
-        "static cone-of-influence");
-  }
 }
 
 void IC3IA::initialize()

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -79,12 +79,6 @@ void Prover::initialize()
   reached_k_ = -1;
   bad_ = solver_->make_term(smt::PrimOp::Not, property_.prop());
   assert(ts_->only_curr(bad_));
-  if (options_.static_coi_) {
-    /* Compute the set of state/input variables related to the
-       bad-state property. Based on that information, rebuild the
-       transition relation of the transition system. */
-    ConeOfInfluence coi(*ts_, { bad_ }, {}, options_.verbosity_);
-  }
 
   initialized_ = true;
 }

--- a/pono.cpp
+++ b/pono.cpp
@@ -31,6 +31,7 @@
 #include "engines/ceg_prophecy_arrays.h"
 #include "frontends/btor2_encoder.h"
 #include "frontends/smv_encoder.h"
+#include "modifiers/coi.h"
 #include "modifiers/control_signals.h"
 #include "options/options.h"
 #include "printers/btor2_witness_printer.h"
@@ -213,6 +214,14 @@ int main(int argc, char ** argv)
       s->set_opt("incremental", "true");
     }
 
+    if (pono_options.static_coi_ && !pono_options.no_witness_) {
+      logger.log(
+          0,
+          "Warning: disabling witness production. Temporary restriction -- "
+          "Cannot produce witness with option --static-coi");
+      pono_options.no_witness_ = true;
+    }
+
     // TODO: make this less ugly, just need to keep it in scope if using
     //       it would be better to have a generic encoder
     //       and also only create the transition system once
@@ -252,6 +261,13 @@ int main(int argc, char ** argv)
             add_reset_seq(fts, reset_symbol, pono_options.reset_bnd_);
         // guard the property with reset_done
         prop = fts.solver()->make_term(Implies, reset_done, prop);
+      }
+
+      if (pono_options.static_coi_) {
+        /* Compute the set of state/input variables related to the
+           bad-state property. Based on that information, rebuild the
+           transition relation of the transition system. */
+        ConeOfInfluence coi(fts, { prop }, {}, pono_options.verbosity_);
       }
 
       vector<UnorderedTermMap> cex;
@@ -304,6 +320,16 @@ int main(int argc, char ** argv)
             add_reset_seq(rts, reset_symbol, pono_options.reset_bnd_);
         // guard the property with reset_done
         prop = rts.solver()->make_term(Implies, reset_done, prop);
+      }
+
+      if (pono_options.static_coi_) {
+        // NOTE: currently only supports FunctionalTransitionSystem
+        // but let ConeOfInfluence throw the exception
+        // and this will change in the future
+        /* Compute the set of state/input variables related to the
+           bad-state property. Based on that information, rebuild the
+           transition relation of the transition system. */
+        ConeOfInfluence coi(rts, { prop }, {}, pono_options.verbosity_);
       }
 
       Property p(rts, prop);


### PR DESCRIPTION
This PR moves cone of influence analysis to the main method. This way, the reduction happens before the transition system is even passed to an engine. The primary motivation for this change is that the engine might change the transition system (e.g. through abstraction) before running. This caused issues with cone of influence analysis that happened in `initialize`. This change was the simplest way we thought of for supporting cone-of-influence with engines like `ic3ia`. Furthermore, it seems like a nice logical separation in that it occurs completely separately from the engine.