### PR TITLE
Add reset solver feature to IC3Base

### DIFF
--- a/engines/ic3.cpp
+++ b/engines/ic3.cpp
@@ -151,7 +151,7 @@ std::vector<IC3Formula> IC3::inductive_generalization(size_t i,
           bool_assump.push_back(l);
         }
 
-        Result r = solver_->check_sat_assuming(bool_assump);
+        Result r = check_sat_assuming(bool_assump);
         assert(!r.is_unknown());
 
         if (r.is_sat()) {

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -716,18 +716,6 @@ void IC3Base::pop_solver_context()
   solver_context_--;
 }
 
-inline Result IC3Base::check_sat()
-{
-  num_check_sat_since_reset_++;
-  return solver_->check_sat();
-}
-
-inline Result IC3Base::check_sat_assuming(const smt::TermVec & assumps)
-{
-  num_check_sat_since_reset_++;
-  return solver_->check_sat_assuming(assumps);
-}
-
 void IC3Base::reset_solver()
 {
   assert(solver_context_ == 0);

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -722,7 +722,7 @@ inline Result IC3Base::check_sat()
   return solver_->check_sat();
 }
 
-Result IC3Base::check_sat_assuming(const smt::TermVec & assumps)
+inline Result IC3Base::check_sat_assuming(const smt::TermVec & assumps)
 {
   num_check_sat_since_reset_++;
   return solver_->check_sat_assuming(assumps);

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -716,7 +716,7 @@ void IC3Base::pop_solver_context()
   solver_context_--;
 }
 
-Result IC3Base::check_sat()
+inline Result IC3Base::check_sat()
 {
   num_check_sat_since_reset_++;
   return solver_->check_sat();

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -465,9 +465,17 @@ class IC3Base : public Prover
    */
   void pop_solver_context();
 
-  smt::Result check_sat();
+  inline smt::Result check_sat()
+  {
+    num_check_sat_since_reset_++;
+    return solver_->check_sat();
+  }
 
-  smt::Result check_sat_assuming(const smt::TermVec & assumps);
+  inline smt::Result check_sat_assuming(const smt::TermVec & assumps)
+  {
+    num_check_sat_since_reset_++;
+    return solver_->check_sat_assuming(assumps);
+  }
 
   /** Attempts to reset the solver and re-add constraints
    *  NOTE: not all solvers support reset_assertions, in which case the

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -43,6 +43,9 @@
 **           - be sure to use [push/pop]_solver_context instead of using
 **             the solver interface directly so that the assertions on
 **             the solver context (tracked externally) are correct
+**           - be sure to use the check_sat() and check_sat_assuming
+**             member methods -- they will keep track of the number of
+**             calls since a reset
 **
 **/
 #pragma once
@@ -137,6 +140,8 @@ class IC3Base : public Prover
   //       currently no way to check
   //       then solver_context_ is relative to the starting context
   size_t solver_context_;
+
+  size_t num_check_sat_since_reset_;
 
   ///< the frames data structure.
   ///< a vector of the given Unit template
@@ -445,6 +450,10 @@ class IC3Base : public Prover
    *  updates solver_context_
    */
   void pop_solver_context();
+
+  smt::Result check_sat();
+
+  smt::Result check_sat_assuming(const smt::TermVec & assumps);
 
   /** Create a boolean label for a given term
    *  These are cached in labels_

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -216,7 +216,7 @@ vector<IC3Formula> ModelBasedIC3::inductive_generalization(size_t i,
               bool_assump.push_back(l);
             }
 
-            Result r = solver_->check_sat_assuming(bool_assump);
+            Result r = check_sat_assuming(bool_assump);
             assert(!r.is_unknown());
 
             if (r.is_sat()) {
@@ -468,7 +468,7 @@ bool ModelBasedIC3::intersects_bad()
   assert_frame_labels(reached_k_ + 1);
   // see if it intersects with bad
   solver_->assert_formula(bad_);
-  Result r = solver_->check_sat();
+  Result r = check_sat();
 
   if (r.is_sat()) {
     // push bad as a proof goal

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -47,6 +47,7 @@ enum optionIndex
   SMT_SOLVER,
   NO_IC3_PREGEN,
   NO_IC3_INDGEN,
+  IC3_RESET_INTERVAL,
   IC3_GEN_MAX_ITER,
   IC3_FUNCTIONAL_PREIMAGE,
   MBIC3_INDGEN_MODE,
@@ -206,6 +207,17 @@ const option::Descriptor usage[] = {
     "ic3-no-indgen",
     Arg::None,
     "  --ic3-no-indgen \tDisable inductive generalization in ic3." },
+  { IC3_RESET_INTERVAL,
+    0,
+    "",
+    "ic3-reset-interval",
+    Arg::Numeric,
+    "  --ic3-reset-interval \tNumber of check-sat queries before "
+    "resetting the solver. "
+    "Setting it to 0 means an unbounded number of iterations."
+    "Note: some solvers don't support resetting assertions, in which "
+    "case it will just fail to reset and not try again. This will be "
+    "printed at verbosity 1." },
   { IC3_GEN_MAX_ITER,
     0,
     "",
@@ -332,6 +344,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
+        case IC3_RESET_INTERVAL: ic3_reset_interval_ = atoi(opt.arg); break;
         case IC3_GEN_MAX_ITER: ic3_gen_max_iter_ = atoi(opt.arg); break;
         case MBIC3_INDGEN_MODE:
           mbic3_indgen_mode = atoi(opt.arg);

--- a/options/options.h
+++ b/options/options.h
@@ -66,6 +66,7 @@ class PonoOptions
         ic3_pregen_(default_ic3_pregen_),
         ic3_indgen_(default_ic3_indgen_),
         ic3_gen_max_iter_(default_ic3_gen_max_iter_),
+        ic3_reset_interval_(default_ic3_reset_interval_),
         mbic3_indgen_mode(default_mbic3_indgen_mode),
         ic3_functional_preimage_(default_ic3_functional_preimage_),
         ceg_prophecy_arrays_(default_ceg_prophecy_arrays_),
@@ -98,6 +99,8 @@ class PonoOptions
   // ic3 options
   bool ic3_pregen_;  ///< generalize counterexamples in IC3
   bool ic3_indgen_;  ///< inductive generalization in IC3
+  unsigned int ic3_reset_interval_;  ///< number of check sat calls before
+                                     ///< resetting. 0 means unbounded
   unsigned int ic3_gen_max_iter_; ///< max iterations in ic3 generalization. 0
                                   ///means unbounded
   unsigned int mbic3_indgen_mode;  ///< inductive generalization mode [0,2]
@@ -122,6 +125,7 @@ class PonoOptions
   static const std::string default_smt_solver_;
   static const bool default_ic3_pregen_ = true;
   static const bool default_ic3_indgen_ = true;
+  static const unsigned int default_ic3_reset_interval_ = 5000;
   static const unsigned int default_ic3_gen_max_iter_ = 2;
   static const unsigned int default_mbic3_indgen_mode = 0;
   static const bool default_ic3_functional_preimage_ = false;


### PR DESCRIPTION
Adds option to reset solver after certain number of check sat calls (default is 5000).