### PR TITLE
Use priority queue to manage proof goals

### DIFF
--- a/core/functional_unroller.h
+++ b/core/functional_unroller.h
@@ -59,7 +59,7 @@ class FunctionalUnroller : public Unroller
    *  @param k the time to unroll the term at
    *  @return the unrolled term
    */
-  smt::Term at_time(const smt::Term & t, unsigned int k);
+  smt::Term at_time(const smt::Term & t, unsigned int k) override;
 
   /** Provides extra constraints for a functional unrolling
    *  with intermittent fresh symbols

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -658,16 +658,6 @@ void IC3Base::assert_trans_label() const
   solver_->assert_formula(trans_label_);
 }
 
-bool IC3Base::has_proof_goals() const { return !proof_goals_.empty(); }
-
-ProofGoal * IC3Base::get_next_proof_goal()
-{
-  assert(has_proof_goals());
-  ProofGoal * pg = proof_goals_.top();
-  proof_goals_.pop();
-  return pg;
-}
-
 void IC3Base::add_proof_goal(const IC3Formula & c, size_t i, ProofGoal * n)
 {
   // IC3Formula aligned with frame so proof goal should be negated

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -78,23 +78,18 @@ static bool term_includes(const TermVec & a, const TermVec & b)
   return !(hash_b.size());
 }
 
-/** Syntactic subsumption check: ? a subsumes b ?
+/** Syntactic subsumption check for clauses: ? a subsumes b ?
  *  @param IC3Formula a
  *  @param IC3Formula b
  *  returns true iff 'a subsumes b'
  */
 static bool subsumes(const IC3Formula &a, const IC3Formula &b)
 {
+  assert(a.disjunction);
   assert(a.disjunction == b.disjunction);
   const TermVec &ac = a.children;
   const TermVec &bc = b.children;
-  if (a.disjunction) {
-    return (ac.size() <= bc.size() &&
-            std::includes(bc.begin(), bc.end(), ac.begin(), ac.end()));
-  } else {
-    return (ac.size() >= bc.size() &&
-            std::includes(ac.begin(), ac.end(), bc.begin(), bc.end()));
-  }
+  return term_includes(bc, ac);
 }
 
 /** IC3Base */

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -122,7 +122,7 @@ void IC3Base::initialize()
 
   frames_.clear();
   frame_labels_.clear();
-  // proof_goals_.clear();
+  proof_goals_.clear();
   // first frame is always the initial states
   push_frame();
   // can't use constrain_frame for initial states because not guaranteed to be

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -122,7 +122,7 @@ void IC3Base::initialize()
 
   frames_.clear();
   frame_labels_.clear();
-  proof_goals_.clear();
+  // proof_goals_.clear();
   // first frame is always the initial states
   push_frame();
   // can't use constrain_frame for initial states because not guaranteed to be

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -440,6 +440,8 @@ bool IC3Base::block_all()
     // new proof goal will be added
     if (block(pg)) {
       // if successfully blocked, then remove that proof goal
+      // expecting the top proof goal to still be pg
+      assert(pg == get_top_proof_goal());
       remove_top_proof_goal();
     } else if (!pg->idx) {
       // if a proof goal cannot be blocked at zero

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -426,18 +426,22 @@ bool IC3Base::block_all()
       reset_solver();
     }
 
-    ProofGoal * pg = get_next_proof_goal();
+    ProofGoal * pg = get_top_proof_goal();
     if (is_blocked(pg)) {
       logger.log(3,
                  "Skipping already blocked proof goal <{}, {}>",
                  pg->target.term->to_string(),
                  pg->idx);
+      remove_top_proof_goal();
       continue;
     };
 
     // block can fail, which just means a
     // new proof goal will be added
-    if (!block(pg) && !pg->idx) {
+    if (block(pg)) {
+      // if successfully blocked, then remove that proof goal
+      remove_top_proof_goal();
+    } else if (!pg->idx) {
       // if a proof goal cannot be blocked at zero
       // then there's a counterexample
       cex_pg_ = pg;

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -410,7 +410,7 @@ bool IC3Base::block_all()
       reset_solver();
     }
 
-    ProofGoal * pg = get_top_proof_goal();
+    const ProofGoal * pg = get_top_proof_goal();
     if (is_blocked(pg)) {
       logger.log(3,
                  "Skipping already blocked proof goal <{}, {}>",
@@ -441,7 +441,7 @@ bool IC3Base::block_all()
   return true;
 }
 
-bool IC3Base::block(ProofGoal * pg)
+bool IC3Base::block(const ProofGoal * pg)
 {
   const IC3Formula & c = pg->target;
   size_t i = pg->idx;
@@ -498,7 +498,7 @@ bool IC3Base::block(ProofGoal * pg)
   }
 }
 
-bool IC3Base::is_blocked(ProofGoal * pg)
+bool IC3Base::is_blocked(const ProofGoal * pg)
 {
   // syntactic check
   for (size_t i = pg->idx; i < frames_.size(); ++i) {
@@ -651,7 +651,9 @@ void IC3Base::assert_trans_label() const
   solver_->assert_formula(trans_label_);
 }
 
-void IC3Base::add_proof_goal(const IC3Formula & c, size_t i, ProofGoal * n)
+void IC3Base::add_proof_goal(const IC3Formula & c,
+                             size_t i,
+                             const ProofGoal * n)
 {
   // IC3Formula aligned with frame so proof goal should be negated
   // e.g. for bit-level IC3, IC3Formula is a Clause and the proof

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -107,19 +107,6 @@ struct ProofGoal
   ProofGoal(IC3Formula u, size_t i, ProofGoal * n) : target(u), idx(i), next(n)
   {
   }
-
-  ProofGoal(const ProofGoal & other)
-      : target(other.target), idx(other.idx), next(other.next)
-  {
-  }
-
-  ProofGoal operator=(ProofGoal other)
-  {
-    std::swap(target, other.target);
-    std::swap(idx, other.idx);
-    std::swap(next, other.next);
-    return *this;
-  }
 };
 
 /**

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -461,19 +461,24 @@ class IC3Base : public Prover
    */
   inline bool has_proof_goals() const { return !proof_goals_.empty(); }
 
-  /** Gets a new proof goal (and removes it from proof_goals_)
+  /** Gets a new proof goal
    *  @requires has_proof_goals()
    *  @return a proof goal with the lowest available frame number
+   *          i.e. from the top of the priority queue
    *  @alters proof_goals_
    *  @ensures returned proof goal is from lowest frame in proof goals
    */
-  inline ProofGoal * get_next_proof_goal()
+  inline ProofGoal * get_top_proof_goal()
   {
     assert(has_proof_goals());
     ProofGoal * pg = proof_goals_.top();
-    proof_goals_.pop();
     return pg;
   }
+
+  /** Removes the proof goal at the top of the priority queue
+   *  Proof goals should be removed once they are blocked
+   */
+  inline void remove_top_proof_goal() { proof_goals_.pop(); }
 
   /** Create and add a proof goal for cube c for frame i
    *  @param c the cube of the proof goal

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -128,6 +128,9 @@ struct ProofGoal
  */
 struct ProofGoalOrder
 {
+  // comparison for priority queue
+  // since priority queue returns largest element, we swap the arguments
+  // -- we want the lowest index to be processed first
   bool operator()(const ProofGoal * a, const ProofGoal * b) const
   {
     return b->idx < a->idx;
@@ -154,8 +157,6 @@ class ProofGoalQueue
     }
   }
 
-  // TODO: make sure code is consistent with pointers -- hacked in this priority
-  // queue and changed from shared_ptr to raw pointer
   void push_new(const IC3Formula & c, unsigned int t, ProofGoal * n = NULL)
   {
     ProofGoal * pg = new ProofGoal(c, t, n);

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -53,6 +53,7 @@
 **/
 #pragma once
 
+#include <algorithm>
 #include <queue>
 
 #include "engines/prover.h"
@@ -119,8 +120,6 @@ struct ProofGoal
     std::swap(next, other.next);
     return *this;
   }
-
-  bool operator<(const ProofGoal & other) const { return idx < other.idx; }
 };
 
 /**
@@ -131,30 +130,37 @@ struct ProofGoalOrder
 {
   bool operator()(const ProofGoal * a, const ProofGoal * b) const
   {
-    std::cout << "doing comparison" << std::endl;
-    throw std::exception();
-    return (*b) < (*a);
+    return b->idx < a->idx;
   }
 };
 
 /**
- * Priority queue of proof obligations
+ * Priority queue of proof obligations borrowed from open-source ic3ia
+ * implementation
  */
-class ProofQueue
+class ProofGoalQueue
 {
  public:
-  ~ProofQueue()
+  ~ProofGoalQueue() { clear(); }
+
+  void clear()
   {
     for (auto p : store_) {
       delete p;
     }
+    store_.clear();
+    while (!queue_.empty()) {
+      queue_.pop();
+    }
   }
 
+  // TODO: make sure code is consistent with pointers -- hacked in this priority
+  // queue and changed from shared_ptr to raw pointer
   void push_new(const IC3Formula & c, unsigned int t, ProofGoal * n = NULL)
   {
-    ProofGoal * po = new ProofGoal(c, t, n);
-    push(po);
-    store_.push_back(po);
+    ProofGoal * pg = new ProofGoal(c, t, n);
+    push(pg);
+    store_.insert(pg);
   }
 
   void push(ProofGoal * p) {
@@ -171,7 +177,10 @@ class ProofQueue
                               std::vector<ProofGoal *>,
                               ProofGoalOrder> Queue;
   Queue queue_;
-  std::vector<ProofGoal *> store_;
+  // TODO fix this
+  // used to be a vector but using a set because might add the same pointer
+  // twice need to use push instead of push_new in the right places
+  std::unordered_set<ProofGoal *> store_;
 };
 
 class IC3Base : public Prover
@@ -216,7 +225,7 @@ class IC3Base : public Prover
   std::vector<std::vector<IC3Formula>> frames_;
 
   ///< priority queue of outstanding proof goals
-  ProofQueue proof_goals_;
+  ProofGoalQueue proof_goals_;
 
   // labels for activating assertions
   smt::Term init_label_;       ///< label to activate init

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -130,7 +130,7 @@ struct ProofGoalOrder
 {
   bool operator()(const ProofGoal * a, const ProofGoal * b) const
   {
-    return a->idx < b->idx;
+    return b->idx < a->idx;
   }
 };
 

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -53,7 +53,6 @@
 **/
 #pragma once
 
-#include <algorithm>
 #include <queue>
 
 #include "engines/prover.h"
@@ -120,6 +119,8 @@ struct ProofGoal
     std::swap(next, other.next);
     return *this;
   }
+
+  bool operator<(const ProofGoal & other) const { return idx < other.idx; }
 };
 
 /**
@@ -130,37 +131,30 @@ struct ProofGoalOrder
 {
   bool operator()(const ProofGoal * a, const ProofGoal * b) const
   {
-    return b->idx < a->idx;
+    std::cout << "doing comparison" << std::endl;
+    throw std::exception();
+    return (*b) < (*a);
   }
 };
 
 /**
- * Priority queue of proof obligations borrowed from open-source ic3ia
- * implementation
+ * Priority queue of proof obligations
  */
-class ProofGoalQueue
+class ProofQueue
 {
  public:
-  ~ProofGoalQueue() { clear(); }
-
-  void clear()
+  ~ProofQueue()
   {
     for (auto p : store_) {
       delete p;
     }
-    store_.clear();
-    while (!queue_.empty()) {
-      queue_.pop();
-    }
   }
 
-  // TODO: make sure code is consistent with pointers -- hacked in this priority
-  // queue and changed from shared_ptr to raw pointer
   void push_new(const IC3Formula & c, unsigned int t, ProofGoal * n = NULL)
   {
-    ProofGoal * pg = new ProofGoal(c, t, n);
-    push(pg);
-    store_.insert(pg);
+    ProofGoal * po = new ProofGoal(c, t, n);
+    push(po);
+    store_.push_back(po);
   }
 
   void push(ProofGoal * p) { queue_.push(p); }
@@ -173,10 +167,7 @@ class ProofGoalQueue
       priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
           Queue;
   Queue queue_;
-  // TODO fix this
-  // used to be a vector but using a set because might add the same pointer
-  // twice need to use push instead of push_new in the right places
-  std::unordered_set<ProofGoal *> store_;
+  std::vector<ProofGoal *> store_;
 };
 
 class IC3Base : public Prover
@@ -221,7 +212,7 @@ class IC3Base : public Prover
   std::vector<std::vector<IC3Formula>> frames_;
 
   ///< priority queue of outstanding proof goals
-  ProofGoalQueue proof_goals_;
+  ProofQueue proof_goals_;
 
   // labels for activating assertions
   smt::Term init_label_;       ///< label to activate init

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -160,7 +160,7 @@ class ProofGoalQueue
   {
     ProofGoal * pg = new ProofGoal(c, t, n);
     push(pg);
-    store_.push_back(pg);
+    store_.insert(pg);
   }
 
   void push(ProofGoal * p) { queue_.push(p); }
@@ -173,7 +173,10 @@ class ProofGoalQueue
       priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
           Queue;
   Queue queue_;
-  std::vector<ProofGoal *> store_;
+  // TODO fix this
+  // used to be a vector but using a set because might add the same pointer
+  // twice need to use push instead of push_new in the right places
+  std::unordered_set<ProofGoal *> store_;
 };
 
 class IC3Base : public Prover

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -163,19 +163,15 @@ class ProofGoalQueue
     store_.insert(pg);
   }
 
-  void push(ProofGoal * p) {
-    std::cout << "ic3ia: before ProofQueue push" << std::endl;
-    queue_.push(p);
-    std::cout << "ic3ia: after ProofQueue push" << std::endl;
-  }
+  void push(ProofGoal * p) { queue_.push(p); }
   ProofGoal * top() { return queue_.top(); }
   void pop() { queue_.pop(); }
   bool empty() const { return queue_.empty(); }
 
  private:
-  typedef std::priority_queue<ProofGoal *,
-                              std::vector<ProofGoal *>,
-                              ProofGoalOrder> Queue;
+  typedef std::
+      priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
+          Queue;
   Queue queue_;
   // TODO fix this
   // used to be a vector but using a set because might add the same pointer

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -161,7 +161,7 @@ class ProofGoalQueue
   {
     ProofGoal * pg = new ProofGoal(c, t, n);
     push(pg);
-    store_.insert(pg);
+    store_.push_back(pg);
   }
 
   void push(ProofGoal * p) { queue_.push(p); }
@@ -174,10 +174,7 @@ class ProofGoalQueue
       priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
           Queue;
   Queue queue_;
-  // TODO fix this
-  // used to be a vector but using a set because might add the same pointer
-  // twice need to use push instead of push_new in the right places
-  std::unordered_set<ProofGoal *> store_;
+  std::vector<ProofGoal *> store_;
 };
 
 class IC3Base : public Prover

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -459,7 +459,7 @@ class IC3Base : public Prover
   /** Check if there are more proof goals
    *  @return true iff there are more proof goals
    */
-  bool has_proof_goals() const;
+  inline bool has_proof_goals() const { return !proof_goals_.empty(); }
 
   /** Gets a new proof goal (and removes it from proof_goals_)
    *  @requires has_proof_goals()
@@ -467,7 +467,13 @@ class IC3Base : public Prover
    *  @alters proof_goals_
    *  @ensures returned proof goal is from lowest frame in proof goals
    */
-  ProofGoal * get_next_proof_goal();
+  inline ProofGoal * get_next_proof_goal()
+  {
+    assert(has_proof_goals());
+    ProofGoal * pg = proof_goals_.top();
+    proof_goals_.pop();
+    return pg;
+  }
 
   /** Create and add a proof goal for cube c for frame i
    *  @param c the cube of the proof goal

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -157,15 +157,19 @@ class ProofQueue
     store_.push_back(po);
   }
 
-  void push(ProofGoal * p) { queue_.push(p); }
+  void push(ProofGoal * p) {
+    std::cout << "ic3ia: before ProofQueue push" << std::endl;
+    queue_.push(p);
+    std::cout << "ic3ia: after ProofQueue push" << std::endl;
+  }
   ProofGoal * top() { return queue_.top(); }
   void pop() { queue_.pop(); }
   bool empty() const { return queue_.empty(); }
 
  private:
-  typedef std::
-      priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
-          Queue;
+  typedef std::priority_queue<ProofGoal *,
+                              std::vector<ProofGoal *>,
+                              ProofGoalOrder> Queue;
   Queue queue_;
   std::vector<ProofGoal *> store_;
 };

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -130,7 +130,7 @@ struct ProofGoalOrder
 {
   bool operator()(const ProofGoal * a, const ProofGoal * b) const
   {
-    return b->idx < a->idx;
+    return a->idx < b->idx;
   }
 };
 

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -99,9 +99,10 @@ struct ProofGoal
   // based on open-source ic3ia ProofObligation
   IC3Formula target;
   size_t idx;
-  ProofGoal * next;
+  const ProofGoal * next;
 
-  ProofGoal(IC3Formula u, size_t i, ProofGoal * n) : target(u), idx(i), next(n)
+  ProofGoal(IC3Formula u, size_t i, const ProofGoal * n)
+      : target(u), idx(i), next(n)
   {
   }
 };
@@ -141,7 +142,9 @@ class ProofGoalQueue
     }
   }
 
-  void push_new(const IC3Formula & c, unsigned int t, ProofGoal * n = NULL)
+  void push_new(const IC3Formula & c,
+                unsigned int t,
+                const ProofGoal * n = NULL)
   {
     ProofGoal * pg = new ProofGoal(c, t, n);
     push(pg);
@@ -197,11 +200,11 @@ class IC3Base : public Prover
   bool failed_to_reset_solver_;  ///< some solvers don't support reset
                                  ///< assertions. Stop trying for those solvers.
 
-  ProofGoal * cex_pg_;  ///< if a proof goal is traced back to init
-                        ///< this gets set to the first proof goal
-                        ///< in the trace
-                        ///< otherwise starts null, can check that
-                        ///< cex_pg_.target.term is a nullptr
+  const ProofGoal * cex_pg_;  ///< if a proof goal is traced back to init
+                              ///< this gets set to the first proof goal
+                              ///< in the trace
+                              ///< otherwise starts null, can check that
+                              ///< cex_pg_.target.term is a nullptr
 
   ///< the frames data structure.
   ///< a vector of the given Unit template
@@ -404,13 +407,13 @@ class IC3Base : public Prover
    *  @return true iff the proof goal was blocked,
    *          otherwise a new proof goal was added to the proof goals
    */
-  bool block(ProofGoal * pg);
+  bool block(const ProofGoal * pg);
 
   /** Check if the given proof goal is already blocked
    *  @param pg the proof goal
    *  @return true iff the proof goal is already blocked
    */
-  bool is_blocked(ProofGoal * pg);
+  bool is_blocked(const ProofGoal * pg);
 
   /** Try propagating all clauses from frame index i to the next frame.
    *  @param i the frame index to propagate
@@ -483,7 +486,7 @@ class IC3Base : public Prover
    *  @param n pointer to the proof goal that led to this one -- null for bad
    *  (i.e. end of trace)
    */
-  void add_proof_goal(const IC3Formula & c, size_t i, ProofGoal * n);
+  void add_proof_goal(const IC3Formula & c, size_t i, const ProofGoal * n);
 
   /** Check if there are common assignments
    *  between A and B

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -101,9 +101,6 @@ struct ProofGoal
   size_t idx;
   ProofGoal * next;
 
-  // null constructor
-  ProofGoal() : idx(0), next(nullptr) {}
-
   ProofGoal(IC3Formula u, size_t i, ProofGoal * n) : target(u), idx(i), next(n)
   {
   }
@@ -177,6 +174,8 @@ class IC3Base : public Prover
   IC3Base(Property & p, const smt::SmtSolver & s,
           PonoOptions opt = PonoOptions());
 
+  virtual ~IC3Base();
+
   void initialize() override;
 
   ProverResult check_until(int k) override;
@@ -198,6 +197,12 @@ class IC3Base : public Prover
   bool failed_to_reset_solver_;  ///< some solvers don't support reset
                                  ///< assertions. Stop trying for those solvers.
 
+  ProofGoal * cex_pg_;  ///< if a proof goal is traced back to init
+                        ///< this gets set to the first proof goal
+                        ///< in the trace
+                        ///< otherwise starts null, can check that
+                        ///< cex_pg_.target.term is a nullptr
+
   ///< the frames data structure.
   ///< a vector of the given Unit template
   ///< which changes depending on the implementation
@@ -211,12 +216,6 @@ class IC3Base : public Prover
   smt::Term trans_label_;      ///< label to activate trans
   smt::TermVec frame_labels_;  ///< labels to activate frames
   smt::UnorderedTermMap labels_;  //< labels for unsat cores
-
-  ProofGoal * cex_pg_;  ///< if a proof goal is traced back to init
-                        ///< this gets set to the first proof goal
-                        ///< in the trace
-                        ///< otherwise starts null, can check that
-                        ///< cex_pg_.target.term is a nullptr
 
   // useful terms
   smt::Term solver_true_;

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -203,7 +203,7 @@ RefineResult IC3IA::refine()
   // recover the counterexample trace
   assert(check_intersects_initial(cex_pg_->target.term));
   TermVec cex({ cex_pg_->target.term });
-  ProofGoal * tmp = cex_pg_;
+  const ProofGoal * tmp = cex_pg_;
   while (tmp->next) {
     tmp = tmp->next;
     cex.push_back(tmp->target.term);

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -366,8 +366,7 @@ RefineResult IC3IA::refine()
   // clear the current proof goals
   // the transitions represented by those backwards reachable traces
   // may not be precise wrt the new predicates
-  // proof_goals_.clear();
-  proof_goals_ = ProofQueue();
+  proof_goals_.clear();
 
   // able to refine the system to rule out this abstract counterexample
   return RefineResult::REFINE_SUCCESS;

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -366,7 +366,8 @@ RefineResult IC3IA::refine()
   // clear the current proof goals
   // the transitions represented by those backwards reachable traces
   // may not be precise wrt the new predicates
-  proof_goals_.clear();
+  // proof_goals_.clear();
+  proof_goals_ = ProofQueue();
 
   // able to refine the system to rule out this abstract counterexample
   return RefineResult::REFINE_SUCCESS;


### PR DESCRIPTION
Use a priority queue for managing proof goals -- which will always return a proof goal at the lowest frame available. This PR also fixes an issue where proof goals were popped too early. Instead, they should only be removed from the queue when it has been blocked.