### PR TITLE
Make KInduction destructor virtual because it's a parent class

### DIFF
--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -26,7 +26,7 @@ class KInduction : public Prover
   KInduction(Property & p, const smt::SmtSolver & solver,
              PonoOptions opt = PonoOptions());
 
-  ~KInduction();
+  virtual ~KInduction();
 
   typedef Prover super;
 


### PR DESCRIPTION
`BmcSimplePath` inherits from `KInduction`