### PR TITLE
Fixes for msat-ic3ia after prover-update

### DIFF
--- a/engines/msat_ic3ia.cpp
+++ b/engines/msat_ic3ia.cpp
@@ -40,7 +40,7 @@ ProverResult MsatIC3IA::prove()
 {
   initialize();
 
-  if (ts_->solver()->get_solver_enum() != MSAT) {
+  if (ts_.solver()->get_solver_enum() != MSAT) {
     throw PonoException("MsatIC3IA only supports mathsat solver.");
   }
 
@@ -55,11 +55,11 @@ ProverResult MsatIC3IA::prove()
 
   // give mapping between symbols
   UnorderedTermMap & ts_solver_cache = to_ts_solver.get_cache();
-  for (const auto &v : ts_->statevars()) {
+  for (const auto & v : ts_.statevars()) {
     ts_solver_cache[to_msat_solver.transfer_term(v)] = v;
-    ts_solver_cache[to_msat_solver.transfer_term(ts_->next(v))] = ts_->next(v);
+    ts_solver_cache[to_msat_solver.transfer_term(ts_.next(v))] = ts_.next(v);
   }
-  for (const auto &v : ts_->inputvars()) {
+  for (const auto & v : ts_.inputvars()) {
     ts_solver_cache[to_msat_solver.transfer_term(v)] = v;
   }
 
@@ -68,8 +68,8 @@ ProverResult MsatIC3IA::prove()
   auto is_uf = [](const Term & term) {
     return term->get_sort()->get_sort_kind() == smt::FUNCTION;
   };
-  get_matching_terms(ts_->init(), ufs, is_uf);
-  get_matching_terms(ts_->trans(), ufs, is_uf);
+  get_matching_terms(ts_.init(), ufs, is_uf);
+  get_matching_terms(ts_.trans(), ufs, is_uf);
   get_matching_terms(bad_, ufs, is_uf);
 
   for (const auto &uf : ufs) {
@@ -79,21 +79,22 @@ ProverResult MsatIC3IA::prove()
 
   // get mathsat terms for transition system
   msat_term msat_init =
-      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_->init()))
+      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_.init()))
           ->get_msat_term();
   msat_term msat_trans =
-      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_->trans()))
+      static_pointer_cast<MsatTerm>(to_msat_solver.transfer_term(ts_.trans()))
           ->get_msat_term();
-  msat_term msat_prop = static_pointer_cast<MsatTerm>(
-                            to_msat_solver.transfer_term(property_.prop()))
-                            ->get_msat_term();
+  msat_term msat_prop =
+      static_pointer_cast<MsatTerm>(
+          to_msat_solver.transfer_term(solver_->make_term(Not, bad_)))
+          ->get_msat_term();
   unordered_map<msat_term, msat_term> msat_statevars;
-  for (const auto &sv : ts_->statevars()) {
+  for (const auto & sv : ts_.statevars()) {
     msat_statevars[static_pointer_cast<MsatTerm>(
                        to_msat_solver.transfer_term(sv))
                        ->get_msat_term()] =
         static_pointer_cast<MsatTerm>(
-            to_msat_solver.transfer_term(ts_->next(sv)))
+            to_msat_solver.transfer_term(ts_.next(sv)))
             ->get_msat_term();
   }
   // initialize the transition system
@@ -166,14 +167,14 @@ bool MsatIC3IA::compute_witness(msat_env env,
 
   // set up a BMC query
   // with state variables constrained at each step
-  solver_->assert_formula(unroller_.at_time(ts_->init(), 0));
+  solver_->assert_formula(unroller_.at_time(ts_.init(), 0));
   // assert that bad_ is not null
   // i.e. this prover was correctly initialized
   assert(bad_);
   solver_->assert_formula(unroller_.at_time(bad_, ic3ia_wit.size() - 1));
   for (size_t i = 0; i < ic3ia_wit.size(); ++i) {
     if (i + 1 < ic3ia_wit.size()) {
-      solver_->assert_formula(unroller_.at_time(ts_->trans(), i));
+      solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
     }
 
     for (const auto &msat_eq : ic3ia_wit[i]) {

--- a/tests/test_msat_ic3ia.cpp
+++ b/tests/test_msat_ic3ia.cpp
@@ -37,9 +37,9 @@ TEST_P(MsatIC3IAUnitTests, IntCounterSafe)
   rts.constrain_init(rts.make_term(Equal, c, rts.make_term(0, intsort)));
   rts.assign_next(c, rts.make_term(Plus, c, rts.make_term(1, intsort)));
 
-  Property p(rts, rts.make_term(Ge, c, rts.make_term(0, intsort)));
+  Property p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
 
-  MsatIC3IA msat_ic3ia(p, s);
+  MsatIC3IA msat_ic3ia(p, rts, s);
   ProverResult res = msat_ic3ia.prove();
   EXPECT_EQ(res, ProverResult::TRUE);
 
@@ -61,9 +61,9 @@ TEST_P(MsatIC3IAUnitTests, IntCounterUnsafe)
                     rts.next(c),
                     rts.make_term(Plus, c, rts.make_term(1, intsort)))));
 
-  Property p(rts, rts.make_term(Ge, c, rts.make_term(0, intsort)));
+  Property p(s, rts.make_term(Ge, c, rts.make_term(0, intsort)));
 
-  MsatIC3IA msat_ic3ia(p, s);
+  MsatIC3IA msat_ic3ia(p, rts, s);
   ProverResult res = msat_ic3ia.prove();
   EXPECT_EQ(res, ProverResult::FALSE);
 


### PR DESCRIPTION
This PR just has some basic fixes for the `msat-ic3ia` backend (after https://github.com/upscale-project/pono/pull/164), which is currently not tested on Travis.