### PR TITLE
Refactor proof queue

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -171,8 +171,8 @@ ProverResult IC3Base::check_until(int k)
   ProverResult res;
   RefineResult ref_res;
   int i = reached_k_ + 1;
-  assert(i >= 0);
-  while (i <= k) {
+  assert(reached_k_ + 1 >= 0);
+  for (size_t i = reached_k_ + 1; i <= k; ++i) {
     // reset cex_pg_ to null
     // there might be multiple abstract traces if there's a derived class
     // doing abstraction refinement
@@ -182,34 +182,8 @@ ProverResult IC3Base::check_until(int k)
     }
 
     res = step(i);
-    ref_res = REFINE_NONE;  // just a default value
-
-    if (res == ProverResult::TRUE) {
+    if (res != ProverResult::UNKNOWN) {
       return res;
-    } else if (res == ProverResult::FALSE) {
-      // expecting cex_pg_ to be non-null and point to the first proof goal in a
-      // trace
-      assert(cex_pg_->target.term);
-      ref_res = refine();
-      if (ref_res == RefineResult::REFINE_NONE) {
-        // found a concrete counterexample
-        return res;
-      } else if (ref_res == RefineResult::REFINE_FAIL) {
-        logger.log(1, "Failed in refinement.");
-        return ProverResult::UNKNOWN;
-      }
-    }
-
-    // two cases
-    // got unknown, so keep going
-    // got false, but was able to refine successfully
-    assert(res == ProverResult::UNKNOWN
-           || (res == ProverResult::FALSE
-               && ref_res == RefineResult::REFINE_SUCCESS));
-
-    // increment i, unless there was a refinement step just done
-    if (ref_res != RefineResult::REFINE_SUCCESS) {
-      i++;
     }
   }
 

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -28,6 +28,47 @@ using namespace std;
 
 namespace pono {
 
+/**
+ * Priority queue of proof obligations inspired by open-source ic3ia
+ * implementation
+ */
+class ProofGoalQueue
+{
+ public:
+  ~ProofGoalQueue() { clear(); }
+
+  void clear()
+  {
+    for (auto p : store_) {
+      delete p;
+    }
+    store_.clear();
+    while (!queue_.empty()) {
+      queue_.pop();
+    }
+  }
+
+  void new_proof_goal(const IC3Formula & c,
+                      unsigned int t,
+                      const ProofGoal * n = NULL)
+  {
+    ProofGoal * pg = new ProofGoal(c, t, n);
+    queue_.push(pg);
+    store_.push_back(pg);
+  }
+
+  ProofGoal * top() { return queue_.top(); }
+  void pop() { queue_.pop(); }
+  bool empty() const { return queue_.empty(); }
+
+ private:
+  typedef std::
+      priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
+          Queue;
+  Queue queue_;
+  std::vector<ProofGoal *> store_;
+};
+
 // helper functions
 
 /** Less than comparison of the hash of two terms
@@ -99,7 +140,6 @@ void IC3Base::initialize()
 
   frames_.clear();
   frame_labels_.clear();
-  proof_goals_.clear();
   // first frame is always the initial states
   push_frame();
   // can't use constrain_frame for initial states because not guaranteed to be
@@ -230,7 +270,7 @@ IC3Formula IC3Base::ic3formula_negate(const IC3Formula & u) const
   return IC3Formula(term, neg_children, !is_clause);
 }
 
-bool IC3Base::intersects_bad()
+bool IC3Base::intersects_bad(IC3Formula & out)
 {
   push_solver_context();
   // assert the last frame (conjunction over clauses)
@@ -245,7 +285,7 @@ bool IC3Base::intersects_bad()
     TermVec red_c;
     reducer_.reduce_assump_unsatcore(smart_not(bad_), c.children, red_c);
 
-    add_proof_goal(ic3formula_conjunction(red_c), reached_k_ + 1, NULL);
+    out = ic3formula_conjunction(red_c);
   }
 
   pop_solver_context();
@@ -269,13 +309,9 @@ ProverResult IC3Base::step(int i)
   // intersect bad, and reached_k_ + 2 frames overall
   assert(reached_k_ + 2 == frames_.size());
   logger.log(1, "Blocking phase at frame {}", i);
-  // blocking phase
-  while (intersects_bad()) {
-    assert(has_proof_goals());
-    if (!block_all()) {
-      // counter-example
-      return ProverResult::FALSE;
-    }
+  if (!block_all()) {
+    // counter-example
+    return ProverResult::FALSE;
   }
 
   logger.log(1, "Propagation phase at frame {}", i);
@@ -319,16 +355,13 @@ ProverResult IC3Base::step_0()
   return ProverResult::UNKNOWN;
 }
 
-bool IC3Base::rel_ind_check(size_t i,
-                            const IC3Formula & c,
-                            vector<IC3Formula> & out)
+bool IC3Base::rel_ind_check(size_t i, const IC3Formula & c, IC3Formula & out)
 {
   assert(i > 0);
   assert(i < frames_.size());
   // expecting to be the polarity for proof goals, not frames
   // e.g. a conjunction
   assert(!c.is_disjunction());
-  assert(!out.size());  // expecting to get an empty vector to populate
 
   assert(solver_context_ == 0);
   push_solver_context();
@@ -344,14 +377,12 @@ bool IC3Base::rel_ind_check(size_t i,
 
   Result r = check_sat();
   if (r.is_sat()) {
-    IC3Formula predecessor;
     if (options_.ic3_pregen_) {
-      predecessor = generalize_predecessor(i, c);
+      out = generalize_predecessor(i, c);
     } else {
-      predecessor = get_model_ic3formula();
+      out = get_model_ic3formula();
     }
-    assert(ic3formula_check_valid(predecessor));
-    out.push_back(predecessor);
+    assert(ic3formula_check_valid(out));
     pop_solver_context();
   } else {
     // TODO: consider automatically taking advantage
@@ -361,34 +392,20 @@ bool IC3Base::rel_ind_check(size_t i,
     //         or at least how to make a conjunctive partition
     //         or it's possible they all can function approximately the same
     //       would also have to move the pop_solver_context later
+    out = c;
     pop_solver_context();
-    if (options_.ic3_indgen_) {
-      assert(solver_context_ == 0); // important that there are no lingering assertions
-      out = inductive_generalization(i, c);
-    } else {
-      out.push_back(ic3formula_negate(c));
-    }
-    Term conj = solver_->make_term(true);
-    for (const auto &u : out) {
-      conj = solver_->make_term(And, conj, u.term);
-      assert(ic3formula_check_valid(u));
-      assert(ts_.only_curr(u.term));
-    }
-    assert(!check_intersects_initial(solver_->make_term(Not, conj)));
   }
-  assert(solver_context_ == 0);
+  assert(!solver_context_);
 
   if (r.is_sat()) {
-    // for now, assuming that there's only one predecessor produced
-    assert(out.size() == 1);
     // this check needs to be here after the solver context has been popped
     // if i == 1 and there's a predecessor, then it should be an initial state
-    assert(i != 1 || check_intersects_initial(out.at(0).term));
+    assert(i != 1 || check_intersects_initial(out.term));
 
     // should never intersect with a frame before F[i-1]
     // otherwise, this predecessor should have been found
     // in a previous step (before a new frame was pushed)
-    assert(i < 2 || !check_intersects(out.at(0).term, get_frame_term(i - 2)));
+    assert(i < 2 || !check_intersects(out.term, get_frame_term(i - 2)));
   }
 
   assert(!r.is_unknown());
@@ -399,98 +416,110 @@ bool IC3Base::rel_ind_check(size_t i,
 
 bool IC3Base::block_all()
 {
-  while (has_proof_goals()) {
-    if (options_.ic3_reset_interval_
-        && num_check_sat_since_reset_ >= options_.ic3_reset_interval_) {
-      reset_solver();
-    }
+  assert(!solver_context_);
+  ProofGoalQueue proof_goals;
+  IC3Formula bad_goal;
+  while (intersects_bad(bad_goal)) {
+    assert(bad_goal.term);  // expecting non-null
+    proof_goals.new_proof_goal(bad_goal, frontier_idx(), nullptr);
 
-    const ProofGoal * pg = get_top_proof_goal();
-    if (is_blocked(pg)) {
-      logger.log(3,
-                 "Skipping already blocked proof goal <{}, {}>",
-                 pg->target.term->to_string(),
-                 pg->idx);
-      remove_top_proof_goal();
-      continue;
-    };
+    while (!proof_goals.empty()) {
+      const ProofGoal * pg = proof_goals.top();
 
-    // block can fail, which just means a
-    // new proof goal will be added
-    if (block(pg)) {
-      // if successfully blocked, then remove that proof goal
-      // expecting the top proof goal to still be pg
-      assert(pg == get_top_proof_goal());
-      remove_top_proof_goal();
-    } else if (!pg->idx) {
-      // if a proof goal cannot be blocked at zero
-      // then there's a counterexample
-      // NOTE: creating a new allocation
-      //       because the pg memory is already managed
-      //       by proof_goals_
-      cex_pg_ = new ProofGoal(pg->target, pg->idx, pg->next);
-      return false;
-    }
-  }
-  assert(!has_proof_goals());
+      if (!pg->idx) {
+        // went all the way back to initial
+        // TODO refactor refinement to not use cex_pg_
+        // need to create a new proof goal that's not managed by the queue
+        cex_pg_ = new ProofGoal(pg->target, pg->idx, pg->next);
+        RefineResult s = refine();
+        if (s == REFINE_SUCCESS) {
+          // on successful refinement, clear the queue of proof goals
+          // which might not have been precise
+          // TODO might have to change this if there's an algorithm
+          // that refines but can keep proof goals around
+          proof_goals.clear();
+
+          // and reset cex_pg_
+          if (cex_pg_) {
+            delete cex_pg_;
+            cex_pg_ = nullptr;
+          }
+        } else if (s == REFINE_NONE) {
+          // this is a real counterexample
+          // TODO refactor this
+          assert(cex_pg_);
+          assert(cex_pg_->target.term == pg->target.term);
+          assert(cex_pg_->idx == pg->idx);
+          return false;
+        } else {
+          assert(s == REFINE_FAIL);
+          throw PonoException("Refinement failed");
+        }
+      }
+
+      if (is_blocked(pg)) {
+        logger.log(3,
+                   "Skipping already blocked proof goal <{}, {}>",
+                   pg->target.term,
+                   pg->idx);
+        // remove the proof goal since it has already been blocked
+        assert(pg == proof_goals.top());
+        proof_goals.pop();
+        continue;
+      }
+
+      IC3Formula collateral;  // populated by rel_ind_check
+      if (rel_ind_check(pg->idx, pg->target, collateral)) {
+        // this proof goal can be blocked
+        assert(!solver_context_);
+        assert(collateral.term);
+        logger.log(
+            3, "Blocking term at frame {}: {}", pg->idx, pg->target.term);
+
+        // remove the proof goal now that it has been blocked
+        assert(pg == proof_goals.top());
+        proof_goals.pop();
+
+        vector<IC3Formula> blocking_units;
+        if (options_.ic3_indgen_) {
+          assert(collateral.term);
+          blocking_units = inductive_generalization(pg->idx, collateral);
+        } else {
+          blocking_units.push_back(ic3formula_negate(pg->target));
+        }
+        assert(blocking_units.size());
+
+        // Most IC3 implementations will have only a single element in the
+        // vector e.g. a single clause. But this is not guaranteed for all for
+        // example, interpolant-based generalization for bit-vectors is not
+        // always a single clause
+        size_t min_idx = frames_.size();
+        for (const auto & bu : blocking_units) {
+          // try to push
+          size_t idx = find_highest_frame(pg->idx, bu);
+          constrain_frame(idx, bu);
+          if (idx < min_idx) {
+            min_idx = idx;
+          }
+        }
+
+        // we're limited by the minimum index that a conjunct could be pushed to
+        if (min_idx + 1 < frames_.size()) {
+          assert(!pg->target.disjunction);
+          proof_goals.new_proof_goal(pg->target, min_idx + 1, pg->next);
+        }
+      } else {
+        // could not block this proof goal
+        assert(collateral.term);
+        proof_goals.new_proof_goal(collateral, pg->idx - 1, pg);
+      }
+    }  // end while(!proof_goals.empty())
+
+    assert(!(bad_goal = IC3Formula()).term);  // in debug mode, reset it
+  }                                           // end while(intersects_bad())
+
+  assert(proof_goals.empty());
   return true;
-}
-
-bool IC3Base::block(const ProofGoal * pg)
-{
-  const IC3Formula & c = pg->target;
-  size_t i = pg->idx;
-
-  logger.log(
-      3, "Attempting to block proof goal <{}, {}>", c.term->to_string(), i);
-
-  assert(i < frames_.size());
-  assert(i >= 0);
-  // TODO: assert c -> frames_[i]
-
-  if (i == 0) {
-    // can't block anymore -- this is a counterexample
-    return false;
-  }
-
-  vector<IC3Formula> collateral;  // populated by rel_ind_check
-  if (rel_ind_check(i, c, collateral)) {
-    // collateral is a vector of blocking units
-    assert(collateral.size());
-    logger.log(3, "Blocking term at frame {}: {}", i, c.term->to_string());
-    if (options_.verbosity_ >= 3) {
-      for (const auto &u : collateral) {
-        logger.log(3, " with {}", u.term->to_string());
-      }
-    }
-
-    // Most IC3 implementations will have only a single element in the vector
-    // e.g. a single clause. But this is not guaranteed for all
-    // for example, interpolant-based generalization for bit-vectors is not
-    // always a single clause
-    size_t min_idx = frames_.size();
-    for (const auto &bu : collateral) {
-      // try to push
-      size_t idx = find_highest_frame(i, bu);
-      constrain_frame(idx, bu);
-      if (idx < min_idx) {
-        min_idx = idx;
-      }
-    }
-
-    // we're limited by the minimum index that a conjunct could be pushed to
-    if (min_idx + 1 < frames_.size()) {
-      add_proof_goal(c, min_idx + 1, pg->next);
-    }
-    return true;
-  } else {
-    // collateral is a vector of predecessors
-    // for now, assume there is only one
-    // TODO: extend this to support multiple predecessors
-    assert(collateral.size() == 1);
-    add_proof_goal(collateral.at(0), i - 1, pg);
-    return false;
-  }
 }
 
 bool IC3Base::is_blocked(const ProofGoal * pg)
@@ -644,18 +673,6 @@ void IC3Base::assert_trans_label() const
   // just because of how IC3 works
   assert(solver_context_ > 0);
   solver_->assert_formula(trans_label_);
-}
-
-void IC3Base::add_proof_goal(const IC3Formula & c,
-                             size_t i,
-                             const ProofGoal * n)
-{
-  // IC3Formula aligned with frame so proof goal should be negated
-  // e.g. for bit-level IC3, IC3Formula is a Clause and the proof
-  // goal should be a Cube
-  assert(!c.is_disjunction());
-  assert(ic3formula_check_valid(c));
-  proof_goals_.push_new(c, i, n);
 }
 
 bool IC3Base::check_intersects(const Term & A, const Term & B)

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -395,6 +395,7 @@ bool IC3Base::block_all()
   IC3Formula bad_goal;
   while (intersects_bad(bad_goal)) {
     assert(bad_goal.term);  // expecting non-null
+    assert(proof_goals.empty());  // bad should be the first goal each iteration
     proof_goals.new_proof_goal(bad_goal, frontier_idx(), nullptr);
 
     while (!proof_goals.empty()) {

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -418,6 +418,7 @@ bool IC3Base::block_all()
             delete cex_pg_;
             cex_pg_ = nullptr;
           }
+          continue;
         } else if (s == REFINE_NONE) {
           // this is a real counterexample
           // TODO refactor this

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -223,7 +223,9 @@ class IC3Base : public Prover
    *  @requires !rel_ind_check(i, c, _)
    *  @param i the frame number to generalize it against
    *  @param c the IC3Formula that should be blocked
-   *  @return a generalized IC3Formula
+   *  @return a vector of IC3Formulas interpreted as a conjunction of
+   * IC3Formulas. Standard IC3 implementations will have a size one vector (e.g.
+   * a single clause) Let the returned conjunction term be d
    *  @ensures d -> !c and F[i-1] /\ d /\ T /\ !d' is unsat
    *           e.g. it blocks c and is inductive relative to F[i-1]
    */

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -122,48 +122,6 @@ struct ProofGoalOrder
   }
 };
 
-/**
- * Priority queue of proof obligations borrowed from open-source ic3ia
- * implementation
- */
-class ProofGoalQueue
-{
- public:
-  ~ProofGoalQueue() { clear(); }
-
-  void clear()
-  {
-    for (auto p : store_) {
-      delete p;
-    }
-    store_.clear();
-    while (!queue_.empty()) {
-      queue_.pop();
-    }
-  }
-
-  void push_new(const IC3Formula & c,
-                unsigned int t,
-                const ProofGoal * n = NULL)
-  {
-    ProofGoal * pg = new ProofGoal(c, t, n);
-    push(pg);
-    store_.push_back(pg);
-  }
-
-  void push(ProofGoal * p) { queue_.push(p); }
-  ProofGoal * top() { return queue_.top(); }
-  void pop() { queue_.pop(); }
-  bool empty() const { return queue_.empty(); }
-
- private:
-  typedef std::
-      priority_queue<ProofGoal *, std::vector<ProofGoal *>, ProofGoalOrder>
-          Queue;
-  Queue queue_;
-  std::vector<ProofGoal *> store_;
-};
-
 class IC3Base : public Prover
 {
  public:
@@ -213,8 +171,6 @@ class IC3Base : public Prover
   std::vector<std::vector<IC3Formula>> frames_;
 
   ///< priority queue of outstanding proof goals
-  ProofGoalQueue proof_goals_;
-
   // labels for activating assertions
   smt::Term init_label_;       ///< label to activate init
   smt::Term trans_label_;      ///< label to activate trans
@@ -267,9 +223,7 @@ class IC3Base : public Prover
    *  @requires !rel_ind_check(i, c, _)
    *  @param i the frame number to generalize it against
    *  @param c the IC3Formula that should be blocked
-   *  @return a vector of IC3Formulas interpreted as a conjunction of
-   * IC3Formulas. Standard IC3 implementations will have a size one vector (e.g.
-   * a single clause) Let the returned conjunction term be d
+   *  @return a generalized IC3Formula
    *  @ensures d -> !c and F[i-1] /\ d /\ T /\ !d' is unsat
    *           e.g. it blocks c and is inductive relative to F[i-1]
    */
@@ -357,7 +311,7 @@ class IC3Base : public Prover
    * goals This method can be overriden if you want to add more than a single
    *  IC3Formula that intersects bad to the proof goals
    */
-  virtual bool intersects_bad();
+  virtual bool intersects_bad(IC3Formula & out);
 
   // ********************************** Common Methods
   // These methods are common to all flavors of IC3 currently implemented
@@ -387,9 +341,7 @@ class IC3Base : public Prover
    *  @ensures returns false  : out -> F[i-1] /\ \forall s in out . (s, c) \in
    * [T] returns true   : out unchanged, F[i-1] /\ T /\ c' is unsat
    */
-  bool rel_ind_check(size_t i,
-                     const IC3Formula & c,
-                     std::vector<IC3Formula> & out);
+  bool rel_ind_check(size_t i, const IC3Formula & c, IC3Formula & out);
 
   // Helper methods
 
@@ -402,13 +354,6 @@ class IC3Base : public Prover
    *  pg.next iteratively
    */
   bool block_all();
-
-  /** Attempt to block the given proof goal
-   *  @param pg the proof goal
-   *  @return true iff the proof goal was blocked,
-   *          otherwise a new proof goal was added to the proof goals
-   */
-  bool block(const ProofGoal * pg);
 
   /** Check if the given proof goal is already blocked
    *  @param pg the proof goal
@@ -456,38 +401,6 @@ class IC3Base : public Prover
   smt::Term get_frame_term(size_t i) const;
 
   void assert_trans_label() const;
-
-  /** Check if there are more proof goals
-   *  @return true iff there are more proof goals
-   */
-  inline bool has_proof_goals() const { return !proof_goals_.empty(); }
-
-  /** Gets a new proof goal
-   *  @requires has_proof_goals()
-   *  @return a proof goal with the lowest available frame number
-   *          i.e. from the top of the priority queue
-   *  @alters proof_goals_
-   *  @ensures returned proof goal is from lowest frame in proof goals
-   */
-  inline ProofGoal * get_top_proof_goal()
-  {
-    assert(has_proof_goals());
-    ProofGoal * pg = proof_goals_.top();
-    return pg;
-  }
-
-  /** Removes the proof goal at the top of the priority queue
-   *  Proof goals should be removed once they are blocked
-   */
-  inline void remove_top_proof_goal() { proof_goals_.pop(); }
-
-  /** Create and add a proof goal for cube c for frame i
-   *  @param c the cube of the proof goal
-   *  @param i the frame number for the proof goal
-   *  @param n pointer to the proof goal that led to this one -- null for bad
-   *  (i.e. end of trace)
-   */
-  void add_proof_goal(const IC3Formula & c, size_t i, const ProofGoal * n);
 
   /** Check if there are common assignments
    *  between A and B
@@ -560,6 +473,8 @@ class IC3Base : public Prover
    * exception is just caught and things continue on as normal
    */
   virtual void reset_solver();
+
+  inline size_t frontier_idx() const { return frames_.size() - 1; }
 
   /** Create a boolean label for a given term
    *  These are cached in labels_

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -205,12 +205,12 @@ RefineResult IC3IA::refine()
 {
   // recover the counterexample trace
   assert(check_intersects_initial(cex_pg_->target.term));
-  TermVec cex({ cex_pg_->target.term });
+  TermVec cex;
   const ProofGoal * tmp = cex_pg_;
-  while (tmp->next) {
-    tmp = tmp->next;
+  while (tmp) {
     cex.push_back(tmp->target.term);
     assert(ts_.only_curr(tmp->target.term));
+    tmp = tmp->next;
   }
 
   if (cex.size() == 1) {

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -298,11 +298,6 @@ RefineResult IC3IA::refine()
     add_predicate(p);
   }
 
-  // clear the current proof goals
-  // the transitions represented by those backwards reachable traces
-  // may not be precise wrt the new predicates
-  proof_goals_.clear();
-
   // able to refine the system to rule out this abstract counterexample
   return RefineResult::REFINE_SUCCESS;
 }

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -445,7 +445,7 @@ void ModelBasedIC3::check_ts() const
   }
 }
 
-bool ModelBasedIC3::intersects_bad()
+bool ModelBasedIC3::intersects_bad(IC3Formula & out)
 {
   push_solver_context();
   // assert the last frame (conjunction over clauses)
@@ -458,8 +458,7 @@ bool ModelBasedIC3::intersects_bad()
     // push bad as a proof goal
     TermVec conjuncts;
     conjunctive_partition(bad_, conjuncts, true);
-    const IC3Formula &bad_at_last_frame = ic3formula_conjunction(conjuncts);
-    add_proof_goal(bad_at_last_frame, reached_k_ + 1, NULL);
+    out = ic3formula_conjunction(conjuncts);
   }
 
   pop_solver_context();

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -52,7 +52,7 @@ class ModelBasedIC3 : public IC3Base
 
   void check_ts() const override;
 
-  bool intersects_bad() override;
+  bool intersects_bad(IC3Formula & out) override;
 
   void initialize() override;
 };


### PR DESCRIPTION
This PR refactors the `IC3Base` code such that the queue of proof goals is a local variable instead of a member variable. This makes it much clearer when goals are added and removed.

This addresses the assertion failure that @zhanghongce brought up.