### PR TITLE
Refactor inductive generalization

### DIFF
--- a/engines/ic3.cpp
+++ b/engines/ic3.cpp
@@ -93,10 +93,9 @@ bool IC3::ic3formula_check_valid(const IC3Formula & u) const
   return true;
 }
 
-std::vector<IC3Formula> IC3::inductive_generalization(size_t i,
-                                                      const IC3Formula & c)
+IC3Formula IC3::inductive_generalization(size_t i, const IC3Formula & c)
 {
-  assert(!c.is_disjunction());  // expecting a cube
+  assert(!c.disjunction);  // expecting a cube
 
   if (options_.mbic3_indgen_mode != 0) {
     throw PonoException("Boolean IC3 only supports indgen mode 0 but got "
@@ -189,8 +188,8 @@ std::vector<IC3Formula> IC3::inductive_generalization(size_t i,
   // TODO: would it be more intuitive to start with a clause
   //       and generalize the clause directly?
   const IC3Formula &blocking_clause = ic3formula_negate(ic3formula_conjunction(lits));
-  assert(blocking_clause.is_disjunction());  // expecting a clause
-  return { blocking_clause };
+  assert(blocking_clause.disjunction);  // expecting a clause
+  return blocking_clause;
 }
 
 IC3Formula IC3::generalize_predecessor(size_t i, const IC3Formula & c)
@@ -248,7 +247,7 @@ IC3Formula IC3::generalize_predecessor(size_t i, const IC3Formula & c)
 
   const IC3Formula & res = ic3formula_conjunction(red_cube_lits);
   // expecting a Cube here
-  assert(!res.is_disjunction());
+  assert(!res.disjunction);
 
   return res;
 }

--- a/engines/ic3.h
+++ b/engines/ic3.h
@@ -37,8 +37,7 @@ class IC3 : public IC3Base
 
   bool ic3formula_check_valid(const IC3Formula & u) const override;
 
-  std::vector<IC3Formula> inductive_generalization(
-      size_t i, const IC3Formula & c) override;
+  IC3Formula inductive_generalization(size_t i, const IC3Formula & c) override;
 
   IC3Formula generalize_predecessor(size_t i, const IC3Formula & c) override;
 

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -570,6 +570,7 @@ void IC3Base::constrain_frame(size_t i, const IC3Formula & constraint,
   assert(solver_context_ == 0);
   assert(i < frame_labels_.size());
   assert(constraint.disjunction);
+  assert(ts_.only_curr(constraint.term));
 
   if (new_constraint) {
     for (size_t j = 1; j <= i; ++j) {

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -83,8 +83,6 @@ struct IC3Formula
   /** Returns true iff this IC3Formula has not been initialized */
   bool is_null() const { return (term == nullptr); };
 
-  bool is_disjunction() const { return disjunction; };
-
   smt::Term term;  ///< term representation of this formula
   smt::TermVec
       children;  ///< flattened children of either a disjunction or conjunction
@@ -221,16 +219,17 @@ class IC3Base : public Prover
   /** Attempt to generalize before blocking in frame i
    *  The standard approach is inductive generalization
    *  @requires !rel_ind_check(i, c, _)
+   *  @requires c is a conjunction (e.g. !c.disjunction)
    *  @param i the frame number to generalize it against
    *  @param c the IC3Formula that should be blocked
-   *  @return a vector of IC3Formulas interpreted as a conjunction of
-   * IC3Formulas. Standard IC3 implementations will have a size one vector (e.g.
-   * a single clause) Let the returned conjunction term be d
+   *  @return a generalized IC3Formula
+   *
+   *  Let the returned formula be d
    *  @ensures d -> !c and F[i-1] /\ d /\ T /\ !d' is unsat
    *           e.g. it blocks c and is inductive relative to F[i-1]
    */
-  virtual std::vector<IC3Formula> inductive_generalization(
-      size_t i, const IC3Formula & c) = 0;
+  virtual IC3Formula inductive_generalization(size_t i,
+                                              const IC3Formula & c) = 0;
 
   /** Generalize a counterexample
    *  @requires rel_ind_check(i, c)

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -302,7 +302,8 @@ IC3Formula ModelBasedIC3::inductive_generalization(size_t i,
       Sort interp_boolsort = interpolator_->make_sort(BOOL);
       for (const auto & ii : interp_disjuncts) {
         assert(ii->get_sort() == interp_boolsort);
-        solver_interp_disjuncts.push_back(to_solver_->transfer_term(ii, BOOL));
+        solver_interp_disjuncts.push_back(
+            ts_.curr(to_solver_->transfer_term(ii, BOOL)));
       }
 
       assert(solver_interp_disjuncts.size() == interp_disjuncts.size());

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -143,14 +143,14 @@ bool ModelBasedIC3::ic3formula_check_valid(const IC3Formula & u) const
   return true;
 }
 
-vector<IC3Formula> ModelBasedIC3::inductive_generalization(size_t i,
-                                                           const IC3Formula & c)
+IC3Formula ModelBasedIC3::inductive_generalization(size_t i,
+                                                   const IC3Formula & c)
 {
   // only need interpolator if in mode 2
   assert(options_.mbic3_indgen_mode == 2 || interpolator_ == nullptr);
 
-  assert(!c.is_disjunction());
-  vector<IC3Formula> gen_res;
+  assert(!c.disjunction);
+  IC3Formula gen_res;
 
   if (options_.ic3_indgen_) {
     if (options_.mbic3_indgen_mode == 0) {
@@ -238,7 +238,7 @@ vector<IC3Formula> ModelBasedIC3::inductive_generalization(size_t i,
         progress = lits.size() < prev_size;
       }
 
-      gen_res.push_back(ic3formula_negate(ic3formula_conjunction(lits)));
+      gen_res = ic3formula_negate(ic3formula_conjunction(lits));
 
     } else if (options_.mbic3_indgen_mode == 1) {
       TermVec tmp, lits, red_lits;
@@ -260,7 +260,7 @@ vector<IC3Formula> ModelBasedIC3::inductive_generalization(size_t i,
       for (const auto &l : red_lits) {
         curr_lits.push_back(ts_.curr(l));
       }
-      gen_res.push_back(ic3formula_negate(ic3formula_conjunction(curr_lits)));
+      gen_res = ic3formula_negate(ic3formula_conjunction(curr_lits));
     } else if (options_.mbic3_indgen_mode == 2) {
       // TODO: consider creating a separate derived class for this mode
       interpolator_->reset_assertions();
@@ -283,26 +283,35 @@ vector<IC3Formula> ModelBasedIC3::inductive_generalization(size_t i,
       Term interp;
       Result r = interpolator_->get_interpolant(int_A, int_B, interp);
       assert(r.is_unsat());
+      logger.log(3, "Got interpolant: {}", interp);
 
-      Term solver_interp = to_solver_->transfer_term(interp);
-      logger.log(3, "Got interpolant: {}", solver_interp);
-      TermVec interp_conjuncts;
-      conjunctive_partition(solver_interp, interp_conjuncts, true);
+      // Note: structure of interpolant is not guaranteed to be a clause
+      //       but we'll at least try to split it up into disjuncts
+      // Note 2: using disjunctive_partition before translating back to
+      //         main solver because boolector removes ORs when putting into
+      //         AIG form
+      //         but since boolector doesn't support interpolation we know
+      //         the interpolator is not boolector
 
-      for (const auto &c : interp_conjuncts) {
-        // these will not necessarily be a disjunction actually, they'll just be
-        // a single formula, {c} from the conjunctive partition of the
-        // interpolant
-        // --> interpolant not guaranteed to be a clause
-        gen_res.push_back(ic3formula_disjunction({ ts_.curr(c) }));
+      TermVec interp_disjuncts;
+      disjunctive_partition(interp, interp_disjuncts);
+
+      TermVec solver_interp_disjuncts;
+      solver_interp_disjuncts.reserve(interp_disjuncts.size());
+
+      Sort interp_boolsort = interpolator_->make_sort(BOOL);
+      for (const auto & ii : interp_disjuncts) {
+        assert(ii->get_sort() == interp_boolsort);
+        solver_interp_disjuncts.push_back(to_solver_->transfer_term(ii, BOOL));
       }
 
+      assert(solver_interp_disjuncts.size() == interp_disjuncts.size());
+      gen_res = ic3formula_disjunction(solver_interp_disjuncts);
     } else {
       assert(false);
     }
   }
-
-  assert(gen_res.size());
+  assert(gen_res.term);
   return gen_res;
 }
 

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -45,8 +45,7 @@ class ModelBasedIC3 : public IC3Base
 
   bool ic3formula_check_valid(const IC3Formula & u) const override;
 
-  std::vector<IC3Formula> inductive_generalization(
-      size_t i, const IC3Formula & c) override;
+  IC3Formula inductive_generalization(size_t i, const IC3Formula & c) override;
 
   IC3Formula generalize_predecessor(size_t i, const IC3Formula & c) override;
 


### PR DESCRIPTION
Only return a single `IC3Formula` instead of a vector from `inductive_generalization`. It only used to return a `vector` before because of the interpolation mode for `ModelBasedIC3`. In that case, there was no guarantee that the interpolant was a single clause and could actually be a conjunction of formulae. However, that algorithm is not very good anyway and it complicated the rest of the code. In particular, there was an issue when trying to push the learned `IC3Formula` to higher frames. It should have been considering the whole vector at once, but instead it was checking each one individually. It's much simpler to just use a single `IC3Formula`. The `ModelBasedIC3` interpolation mode still works, it just might return an `IC3Formula` with only one child. I.e. the interpolant was a conjunction instead of a disjunction so it's just returned as a single formula.