### PR TITLE
Change implicit abstraction class

### DIFF
--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -317,22 +317,6 @@ RefineResult IC3IA::refine()
   return RefineResult::REFINE_SUCCESS;
 }
 
-void IC3IA::reset_solver()
-{
-  super::reset_solver();
-
-  if (failed_to_reset_solver_){
-    return;
-  }
-
-  // copy of added predicates
-  UnorderedTermSet preds = predset_;
-  predset_.clear();
-  for (const auto & p : preds) {
-    add_predicate(p);
-  }
-}
-
 bool IC3IA::add_predicate(const Term & pred)
 {
   if (predset_.find(pred) != predset_.end()) {
@@ -345,6 +329,7 @@ bool IC3IA::add_predicate(const Term & pred)
   predset_.insert(pred);
   // add predicate to abstraction and get the new constraint
   Term predabs_rel = ia_.add_predicate(pred);
+  static_cast<RelationalTransitionSystem&>(ts_).constrain_trans(predabs_rel);
   // refine the transition relation incrementally
   // by adding a new constraint
   assert(!solver_context_);  // should be at context 0

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -61,7 +61,7 @@ IC3IA::IC3IA(const Property & p,
 
 IC3Formula IC3IA::get_model_ic3formula() const
 {
-  const TermVec & preds = ia_.predicates();
+  const UnorderedTermSet & preds = ia_.predicates();
   TermVec conjuncts;
   conjuncts.reserve(preds.size());
   for (const auto &p : preds) {
@@ -317,6 +317,22 @@ RefineResult IC3IA::refine()
   return RefineResult::REFINE_SUCCESS;
 }
 
+void IC3IA::reset_solver()
+{
+  super::reset_solver();
+
+  if (failed_to_reset_solver_){
+    return;
+  }
+
+  // copy of added predicates
+  UnorderedTermSet preds = predset_;
+  predset_.clear();
+  for (const auto & p : preds) {
+    add_predicate(p);
+  }
+}
+
 bool IC3IA::add_predicate(const Term & pred)
 {
   if (predset_.find(pred) != predset_.end()) {
@@ -335,7 +351,7 @@ bool IC3IA::add_predicate(const Term & pred)
   solver_->assert_formula(
       solver_->make_term(Implies, trans_label_, predabs_rel));
 
-  assert(predset_.size() == ia_.predicates().size());
+  //assert(predset_.size() == ia_.predicates().size());
 
   return true;
 }

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -180,13 +180,11 @@ void IC3IA::initialize()
 
 void IC3IA::abstract()
 {
-  UnorderedTermSet bool_symbols = ia_.do_abstraction();
+  const UnorderedTermSet &bool_symbols = ia_.do_abstraction();
   // add predicates automatically added by ia_
   // to our predset_
   // needed to prevent adding duplicate predicates later
-  for (const auto & b : bool_symbols) {
-    predset_.insert(b);
-  }
+  predset_.insert(bool_symbols.begin(), bool_symbols.end());
 
   assert(ts_.init());  // should be non-null
   assert(ts_.trans());

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -61,10 +61,9 @@ IC3IA::IC3IA(const Property & p,
 
 IC3Formula IC3IA::get_model_ic3formula() const
 {
-  const UnorderedTermSet & preds = ia_.predicates();
   TermVec conjuncts;
-  conjuncts.reserve(preds.size());
-  for (const auto &p : preds) {
+  conjuncts.reserve(predset_.size());
+  for (const auto &p : predset_) {
     if (solver_->get_value(p) == solver_true_) {
       conjuncts.push_back(p);
     } else {
@@ -120,16 +119,6 @@ void IC3IA::initialize()
   }
 
   super::initialize();
-
-  Sort boolsort = solver_->make_sort(BOOL);
-  // add predicates automatically added by ia_
-  // to our predset_
-  // needed to prevent adding duplicate predicates later
-  for (const auto & p : ia_.predicates()) {
-    // ia_ automatically includes all boolean variables
-    assert(p->is_symbolic_const() && p->get_sort() == boolsort);
-    predset_.insert(p);
-  }
 
   // add all the predicates from init and property to the abstraction
   // NOTE: abstract is called automatically in IC3Base initialize
@@ -191,7 +180,13 @@ void IC3IA::initialize()
 
 void IC3IA::abstract()
 {
-  ia_.do_abstraction();
+  UnorderedTermSet bool_symbols = ia_.do_abstraction();
+  // add predicates automatically added by ia_
+  // to our predset_
+  // needed to prevent adding duplicate predicates later
+  for (const auto & b : bool_symbols) {
+    predset_.insert(b);
+  }
 
   assert(ts_.init());  // should be non-null
   assert(ts_.trans());
@@ -328,15 +323,13 @@ bool IC3IA::add_predicate(const Term & pred)
   logger.log(2, "adding predicate {}", pred);
   predset_.insert(pred);
   // add predicate to abstraction and get the new constraint
-  Term predabs_rel = ia_.add_predicate(pred);
+  Term predabs_rel = ia_.predicate_refinement(pred);
   static_cast<RelationalTransitionSystem&>(ts_).constrain_trans(predabs_rel);
   // refine the transition relation incrementally
   // by adding a new constraint
   assert(!solver_context_);  // should be at context 0
   solver_->assert_formula(
       solver_->make_term(Implies, trans_label_, predabs_rel));
-
-  //assert(predset_.size() == ia_.predicates().size());
 
   return true;
 }

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -91,6 +91,8 @@ class IC3IA : public IC3
 
   RefineResult refine() override;
 
+  void reset_solver() override;
+
   // specific to IC3IA
 
   /** Adds predicate to abstraction

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -91,13 +91,10 @@ class IC3IA : public IC3
 
   RefineResult refine() override;
 
-  void reset_solver() override;
-
   // specific to IC3IA
 
   /** Adds predicate to abstraction
    *  (calls ia_.add_predicate)
-   *  and also incrementally updates the local transition relation
    *  and declares a new predicate state var (in pred_statevars_)
    *  @param pred the predicate over current state variables
    *  @return true iff the predicate was new (not seen before)

--- a/modifiers/abstractor.h
+++ b/modifiers/abstractor.h
@@ -67,12 +67,6 @@ class Abstractor
    */
   TransitionSystem & abs_ts() const { return abs_ts_; };
 
-  /** Perform the abstraction
-   *  This should populate the abstraction and concretization caches
-   *  This is a NOP implementation. Derived classes will implement this.
-   */
-  virtual void do_abstraction(){};
-
  protected:
   /** Populates term caches
    *  @param conc_term the concrete term

--- a/modifiers/array_abstractor.h
+++ b/modifiers/array_abstractor.h
@@ -96,7 +96,7 @@ class ArrayAbstractor : public Abstractor
   // if true, then array equality is abstracted with a UF
   bool abstract_array_equality() const { return abstract_array_equality_; };
 
-  void do_abstraction() override;
+  void do_abstraction();
 
  protected:
   /** Populates abs_walker_'s cache and sort maps (abstract_sorts_,

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -68,10 +68,12 @@ Term ImplicitPredicateAbstractor::add_predicate(const Term & pred)
   assert(abstracted_);
   assert(abs_ts_.only_curr(pred));
 
-  predicates_.push_back(pred);
-
   Term rel = predicate_refinement(pred);
-  abs_rts_.constrain_trans(rel);
+  if (predicates_.find(pred) == predicates_.end()) {
+    predicates_.insert(pred);
+    abs_rts_.constrain_trans(rel);
+  }
+
   return rel;
 }
 
@@ -156,7 +158,7 @@ void ImplicitPredicateAbstractor::do_abstraction()
       // so there doesn't need to be a relation added, e.g.
       // P(X') <-> P(X^) is not needed for boolean variables
       assert(abs_ts_.is_curr_var(sv));
-      predicates_.push_back(sv);
+      predicates_.insert(sv);
       continue;
     }
     Term nv = conc_ts_.next(sv);

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -53,6 +53,7 @@ ImplicitPredicateAbstractor::ImplicitPredicateAbstractor(
 
 Term ImplicitPredicateAbstractor::abstract(Term & t)
 {
+  assert(abstracted_);
   return solver_->substitute(t, abstraction_cache_);
 }
 
@@ -64,6 +65,7 @@ Term ImplicitPredicateAbstractor::concrete(Term & t)
 
 Term ImplicitPredicateAbstractor::predicate_refinement(const Term & pred)
 {
+  assert(abstracted_);
   Term next_pred = abs_ts_.next(pred);
   // constrain next state vars and abstract vars to agree on this predicate
   return solver_->make_term(Equal, next_pred, abstract(next_pred));

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -71,7 +71,6 @@ Term ImplicitPredicateAbstractor::add_predicate(const Term & pred)
   Term rel = predicate_refinement(pred);
   if (predicates_.find(pred) == predicates_.end()) {
     predicates_.insert(pred);
-    abs_rts_.constrain_trans(rel);
   }
 
   return rel;

--- a/modifiers/implicit_predicate_abstractor.h
+++ b/modifiers/implicit_predicate_abstractor.h
@@ -35,31 +35,27 @@ class ImplicitPredicateAbstractor : public Abstractor
 
   smt::Term concrete(smt::Term & t) override;
 
-  /** Add a predicate to the abstraction
-   *  @param pred the predicate to add (over concrete current state variables)
+  /** Returns the predicate refinement of the given predicate
+   *  @param pred the predicate to refine
+   *  (over concrete current state variables)
    *  @return the condition: pred(X') <-> pred(X^)
-   *          that was added to the abstract transition relation
    *          this is for use in a procedure that wants to incrementally add
    *          predicates instead of re-adding the whole updated transition
    * relation
    */
-  smt::Term add_predicate(const smt::Term & pred);
-
-  /** Returns reference to vector of all current predicates over
-   *  current state variables
-   *  @return vector of predicates
-   */
-  const smt::UnorderedTermSet & predicates() const { return predicates_; };
+  smt::Term predicate_refinement(const smt::Term & pred);
 
   bool reduce_predicates(const smt::TermVec & cex,
                          const smt::TermVec & new_preds,
                          smt::TermVec & out);
 
-  void do_abstraction() override;
+  /** Does the abstraction and returns a set of concrete boolean symbols
+   *  abstraction
+   *  @return set of concrete boolean symbols
+   */
+  smt::UnorderedTermSet do_abstraction();
 
  protected:
-  smt::Term predicate_refinement(const smt::Term & pred);
-
   const smt::SmtSolver & solver_;
 
   Unroller & unroller_;
@@ -69,9 +65,6 @@ class ImplicitPredicateAbstractor : public Abstractor
   RelationalTransitionSystem & abs_rts_;
   ///< relational version of abs_ts_
   ///< this abstraction requires a relational system
-
-  smt::UnorderedTermSet predicates_;  ///< set of predicates in abstraction
-                                      ///over current state vars
 
   bool abstracted_; ///< true iff do_abstraction has been called
 };

--- a/modifiers/implicit_predicate_abstractor.h
+++ b/modifiers/implicit_predicate_abstractor.h
@@ -49,7 +49,7 @@ class ImplicitPredicateAbstractor : public Abstractor
    *  current state variables
    *  @return vector of predicates
    */
-  const smt::TermVec & predicates() const { return predicates_; };
+  const smt::UnorderedTermSet & predicates() const { return predicates_; };
 
   bool reduce_predicates(const smt::TermVec & cex,
                          const smt::TermVec & new_preds,
@@ -70,8 +70,8 @@ class ImplicitPredicateAbstractor : public Abstractor
   ///< relational version of abs_ts_
   ///< this abstraction requires a relational system
 
-  smt::TermVec predicates_;  ///< list of predicates in abstraction over current
-                             ///< state vars
+  smt::UnorderedTermSet predicates_;  ///< set of predicates in abstraction
+                                      ///over current state vars
 
   bool abstracted_; ///< true iff do_abstraction has been called
 };

--- a/tests/test_modifiers.cpp
+++ b/tests/test_modifiers.cpp
@@ -125,7 +125,7 @@ TEST_P(ModifierUnitTests, ImplicitPredicateAbstractor)
   EXPECT_TRUE(r.is_sat());  // expecting check to fail
 
   // add it as a predicate
-  Term ref = ia.add_predicate(x_le_10);
+  Term ref = ia.predicate_refinement(x_le_10);
   abs_rts.constrain_trans(ref);
 
   // check if c <= 10 is inductive on the refined abstract system

--- a/tests/test_modifiers.cpp
+++ b/tests/test_modifiers.cpp
@@ -125,7 +125,8 @@ TEST_P(ModifierUnitTests, ImplicitPredicateAbstractor)
   EXPECT_TRUE(r.is_sat());  // expecting check to fail
 
   // add it as a predicate
-  ia.add_predicate(x_le_10);
+  Term ref = ia.add_predicate(x_le_10);
+  abs_rts.constrain_trans(ref);
 
   // check if c <= 10 is inductive on the refined abstract system
   s->push();


### PR DESCRIPTION
This PR removes the local copy of predicate maintained by implicit-abstractor. It also modifies the interface of the abstractor. 
