### PR TITLE
Various minor fixes

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -339,12 +339,28 @@ bool IC3Base::intersects_bad(IC3Formula & out)
   Result r = check_sat();
 
   if (r.is_sat()) {
-    const IC3Formula &c = get_model_ic3formula();
-    // reduce c
-    TermVec red_c;
-    reducer_.reduce_assump_unsatcore(smart_not(bad_), c.children, red_c);
+    out = get_model_ic3formula();
+    assert(out.term);
+    assert(out.children.size());
+    assert(ic3formula_check_valid(out));
 
-    out = ic3formula_conjunction(red_c);
+    // reduce
+    TermVec red_c;
+    // with abstraction can't guarantee this is unsat
+    if (reducer_.reduce_assump_unsatcore(
+            smart_not(bad_), out.children, red_c)) {
+      logger.log(1,
+                 "generalized bad cube to {}/{}",
+                 red_c.size(),
+                 out.children.size());
+      out = ic3formula_conjunction(red_c);
+
+      assert(out.term);
+      assert(out.children.size());
+      assert(ic3formula_check_valid(out));
+    } else {
+      logger.log(1, "generalizing bad failed");
+    }
   }
 
   pop_solver_context();

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -63,12 +63,14 @@ IC3Formula IC3IA::get_model_ic3formula() const
 {
   TermVec conjuncts;
   conjuncts.reserve(predset_.size());
+  Term val;
   for (const auto &p : predset_) {
-    if (solver_->get_value(p) == solver_true_) {
+    if ((val = solver_->get_value(p)) == solver_true_) {
       conjuncts.push_back(p);
     } else {
       conjuncts.push_back(solver_->make_term(Not, p));
     }
+    assert(val->is_value());
   }
 
   return ic3formula_conjunction(conjuncts);

--- a/engines/msat_ic3ia.cpp
+++ b/engines/msat_ic3ia.cpp
@@ -104,7 +104,9 @@ ProverResult MsatIC3IA::prove()
 
   // just using default options for now
   ic3ia::Options ic3ia_opts;
-  // the only option we pass through is verbosity
+  // the only options we pass through are
+  // verbosity and random seed
+  ic3ia_opts.seed = options_.random_seed_;
   ic3ia_opts.verbosity = options_.verbosity_;
   ic3ia::Logger & l = ic3ia::Logger::get();
   l.set_verbosity(ic3ia_opts.verbosity);


### PR DESCRIPTION
This PR fixes a few minor issues in the IC3 variants backends

* sets the random seed in msat-ic3ia
* adds a fallback in case the bad cube can't be generalized
* adds an assertion in the `ic3ia` `get_model_ic3formula` that the value is actually a value
  * this came up because one of the mathsat options caused it to not get values for certain formulae