### PR TITLE
Improved IC3IA options

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,8 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-# TEMP pull branch
-# SMT_SWITCH_VERSION=92371eb947f2641c161adf70d3d9be5fc60b9e75
+SMT_SWITCH_VERSION=9230477a5b9cd287cf4a30ed53d20700f714f821
 
 usage () {
     cat <<EOF
@@ -60,10 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone -b reset-reducer https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    # temp pulling branch
-    # git checkout -f $SMT_SWITCH_VERSION
+    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,8 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-# TEMP pull branch
-# SMT_SWITCH_VERSION=9230477a5b9cd287cf4a30ed53d20700f714f821
+SMT_SWITCH_VERSION=0c0b12a11b9a0d68d6d724389393120172ed50f3
 
 usage () {
     cat <<EOF
@@ -60,10 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone -b update-assuming-interface https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    # TEMP pull branch
-    # git checkout -f $SMT_SWITCH_VERSION
+    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=9230477a5b9cd287cf4a30ed53d20700f714f821
+# TEMP pull branch
+# SMT_SWITCH_VERSION=9230477a5b9cd287cf4a30ed53d20700f714f821
 
 usage () {
     cat <<EOF
@@ -59,9 +60,10 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    git clone -b update-assuming-interface https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
+    # TEMP pull branch
+    # git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=92371eb947f2641c161adf70d3d9be5fc60b9e75
+# TEMP pull branch
+# SMT_SWITCH_VERSION=92371eb947f2641c161adf70d3d9be5fc60b9e75
 
 usage () {
     cat <<EOF
@@ -59,9 +60,10 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    git clone -b reset-reducer https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
+    # temp pulling branch
+    # git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -510,7 +510,7 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   // preds.insert(predset_.begin(), predset_.end());
   get_predicates(solver_, get_frame_term(1), preds, false, false, true);
   predset_.clear();
-  predvars_.clear();
+  predlbls_.clear();
 
   // reset init and trans -- done with calling ia_.do_abstraction
   predset_ = ia_.do_abstraction();

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -513,7 +513,10 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   predlbls_.clear();
 
   // reset init and trans -- done with calling ia_.do_abstraction
-  predset_ = ia_.do_abstraction();
+  // then add all boolean constants as (precise) predicates
+  for (const auto & p : ia_.do_abstraction()) {
+    preds.insert(p);
+  }
 
   // reset the solver
   reset_solver();

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -510,6 +510,7 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   // preds.insert(predset_.begin(), predset_.end());
   get_predicates(solver_, get_frame_term(1), preds, false, false, true);
   predset_.clear();
+  predvars_.clear();
 
   // reset init and trans -- done with calling ia_.do_abstraction
   predset_ = ia_.do_abstraction();

--- a/engines/ic3.cpp
+++ b/engines/ic3.cpp
@@ -57,11 +57,10 @@ IC3Formula IC3::get_model_ic3formula() const
 
 bool IC3::ic3formula_check_valid(const IC3Formula & u) const
 {
-  const Sort &boolsort = solver_->make_sort(BOOL);
   // check that children are literals
   Op op;
   for (const auto &c : u.children) {
-    if (!is_lit(c, boolsort)) {
+    if (!is_lit(c, boolsort_)) {
       return false;
     }
   }
@@ -136,16 +135,15 @@ void IC3::predecessor_generalization(size_t i,
 
 void IC3::check_ts() const
 {
-  const Sort &boolsort = solver_->make_sort(BOOL);
   for (const auto &sv : ts_.statevars()) {
-    if (sv->get_sort() != boolsort) {
+    if (sv->get_sort() != boolsort_) {
       throw PonoException("Got non-boolean state variable in bit-level IC3: "
                           + sv->to_string());
     }
   }
 
   for (const auto &iv : ts_.inputvars()) {
-    if (iv->get_sort() != boolsort) {
+    if (iv->get_sort() != boolsort_) {
       throw PonoException("Got non-boolean input variable in bit-level IC3: "
                           + iv->to_string());
     }

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -412,7 +412,7 @@ ProverResult IC3Base::step(int i)
       // save the invariant
       // which is the frame that just had all terms
       // from the previous frames propagated
-      set_invar(j + 1);
+      invar_ = get_frame_term(j + 1);
       return ProverResult::TRUE;
     }
   }

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -479,9 +479,10 @@ bool IC3Base::rel_ind_check(size_t i,
     for (const auto & cc : c.children) {
       ccnext = ts_.next(cc);
       lbl = label(ccnext);
-      if (lbl != ccnext) {
+      if (lbl != ccnext && !is_global_label(lbl)) {
         // only need to add assertion if the label is not the same as ccnext
         // could be the same if ccnext is already a literal
+        // and is not alreayd in a global assumption
         solver_->assert_formula(solver_->make_term(Implies, lbl, ccnext));
       }
       assumps_.push_back(lbl);
@@ -984,6 +985,12 @@ Term IC3Base::label(const Term & t)
 
   labels_[t] = l;
   return l;
+}
+
+bool IC3Base::is_global_label(const Term & l) const
+{
+  return (l == trans_label_ || l == bad_label_
+          || std::count(frame_labels_.begin(), frame_labels_.end(), l));
 }
 
 smt::Term IC3Base::smart_not(const Term & t) const

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -480,7 +480,7 @@ bool IC3Base::rel_ind_check(size_t i,
       if (lbl != ccnext && !is_global_label(lbl)) {
         // only need to add assertion if the label is not the same as ccnext
         // could be the same if ccnext is already a literal
-        // and is not alreayd in a global assumption
+        // and is not already in a global assumption
         solver_->assert_formula(solver_->make_term(Implies, lbl, ccnext));
       }
       assumps_.push_back(lbl);

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -824,6 +824,9 @@ bool IC3Base::check_intersects_initial(const Term & t)
 void IC3Base::fix_if_intersects_initial(TermVec & to_keep, const TermVec & rem)
 {
   assert(!solver_context_);
+  // TODO: there's a tricky issue here. The reducer doesn't have the label
+  // assumptions so we can't use init_label_ here. need to come up with a
+  // better interface. Should we add label assumptions to reducer?
   if (rem.size() != 0) {
     Term formula = solver_->make_term(And, ts_.init(), make_and(to_keep));
 
@@ -919,7 +922,6 @@ void IC3Base::reset_solver()
 
   try {
     solver_->reset_assertions();
-    reducer_.reset_assertions();
 
     // Now need to add back in constraints at context level 0
     logger.log(2, "IC3Base: Reset solver and now re-adding constraints.");

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -107,8 +107,6 @@ IC3Base::IC3Base(const Property & p,
                  const SmtSolver & s,
                  PonoOptions opt)
     : super(p, ts, s, opt),
-      // NOTE: this is a hack
-      // TODO fix this
       reducer_(create_reducer_for(
           s->get_solver_enum(), Engine::IC3IA_ENGINE, false)),
       solver_context_(0),

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -153,7 +153,6 @@ void IC3Base::initialize()
   // an IC3Formula it's handled specially
   solver_->assert_formula(
       solver_->make_term(Implies, frame_labels_.at(0), ts_.init()));
-  reducer_.assume_label(frame_labels_.at(0), ts_.init());
   push_frame();
 
   // set semantics of TS labels
@@ -166,11 +165,9 @@ void IC3Base::initialize()
   trans_label_ = solver_->make_symbol("__trans_label", boolsort_);
   solver_->assert_formula(
       solver_->make_term(Implies, trans_label_, ts_.trans()));
-  reducer_.assume_label(trans_label_, ts_.trans());
 
   bad_label_ = solver_->make_symbol("__bad_label", boolsort_);
   solver_->assert_formula(solver_->make_term(Implies, bad_label_, bad_));
-  reducer_.assume_label(bad_label_, bad_);
 }
 
 ProverResult IC3Base::check_until(int k)
@@ -760,7 +757,6 @@ void IC3Base::constrain_frame_label(size_t i, const IC3Formula & constraint)
 
   solver_->assert_formula(
       solver_->make_term(Implies, frame_labels_.at(i), constraint.term));
-  reducer_.assume_label(frame_labels_.at(i), constraint.term);
 }
 
 void IC3Base::assert_frame_labels(size_t i) const
@@ -829,7 +825,7 @@ void IC3Base::fix_if_intersects_initial(TermVec & to_keep, const TermVec & rem)
 {
   assert(!solver_context_);
   if (rem.size() != 0) {
-    Term formula = solver_->make_term(And, init_label_, make_and(to_keep));
+    Term formula = solver_->make_term(And, ts_.init(), make_and(to_keep));
 
     bool success = reducer_.reduce_assump_unsatcore(formula,
                                                     rem,
@@ -932,14 +928,11 @@ void IC3Base::reset_solver()
     assert(init_label_ == frame_labels_.at(0));
     solver_->assert_formula(
         solver_->make_term(Implies, init_label_, ts_.init()));
-    reducer_.assume_label(init_label_, ts_.init());
 
     solver_->assert_formula(
         solver_->make_term(Implies, trans_label_, ts_.trans()));
-    reducer_.assume_label(trans_label_, ts_.trans());
 
     solver_->assert_formula(solver_->make_term(Implies, bad_label_, bad_));
-    reducer_.assume_label(bad_label_, bad_);
 
     for (size_t i = 0; i < frames_.size(); ++i) {
       for (const auto & constraint : frames_.at(i)) {

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -109,8 +109,8 @@ IC3Base::IC3Base(const Property & p,
     : super(p, ts, s, opt),
       // NOTE: this is a hack
       // TODO fix this
-      reducer_(create_solver_for(
-          s->get_solver_enum(), Engine::IC3IA_ENGINE, false, NO_MODEL)),
+      reducer_(create_reducer_for(
+          s->get_solver_enum(), Engine::IC3IA_ENGINE, false)),
       solver_context_(0),
       num_check_sat_since_reset_(0),
       failed_to_reset_solver_(false),

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -101,10 +101,15 @@ static bool subsumes(const IC3Formula &a, const IC3Formula &b)
 
 /** IC3Base */
 
-IC3Base::IC3Base(const Property & p, const TransitionSystem & ts,
-                 const SmtSolver & s, PonoOptions opt)
+IC3Base::IC3Base(const Property & p,
+                 const TransitionSystem & ts,
+                 const SmtSolver & s,
+                 PonoOptions opt)
     : super(p, ts, s, opt),
-      reducer_(create_solver(s->get_solver_enum())),
+      // NOTE: this is a hack
+      // TODO fix this
+      reducer_(create_solver_for(
+          s->get_solver_enum(), Engine::IC3IA_ENGINE, false, NO_MODEL)),
       solver_context_(0),
       num_check_sat_since_reset_(0),
       failed_to_reset_solver_(false),

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -406,7 +406,7 @@ ProverResult IC3Base::step(int i)
       // save the invariant
       // which is the frame that just had all terms
       // from the previous frames propagated
-      invar_ = get_frame_term(j + 1);
+      set_invar(j + 1);
       return ProverResult::TRUE;
     }
   }

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -184,6 +184,9 @@ class IC3Base : public Prover
 
   // *************************** Main Methods *********************************
 
+  // HACK
+  virtual void set_invar(size_t k) { invar_ = get_frame_term(k); }
+
   // ************************** Virtual Methods *******************************
   // IMPORTANT for derived classes
   // These methods should be implemented by a derived class for a particular

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -38,7 +38,10 @@
 **             flavor of IC3
 **           - override reset_solver if you need to add back in constraints
 **             to the reset solver that aren't handled by the default
-*8             implementation
+**             implementation
+**           - if you decide to use additional labels, make sure to add
+**             them to solver_ and reducer_ (with assume_label)
+**             in both initialize and reset_solver
 **
 **        Important Notes:
 **           - be sure to use [push/pop]_solver_context instead of using

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -170,11 +170,14 @@ class IC3Base : public Prover
   // labels for activating assertions
   smt::Term init_label_;       ///< label to activate init
   smt::Term trans_label_;      ///< label to activate trans
+  smt::Term bad_label_;        ///< label to activate bad
   smt::TermVec frame_labels_;  ///< labels to activate frames
   smt::UnorderedTermMap labels_;  //< labels for unsat cores
 
   // useful terms
   smt::Term solver_true_;
+
+  smt::Sort boolsort_;
 
   // re-usable data structures
   // NOTE: be sure not to overwrite these in nested function calls

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -41,6 +41,11 @@
 **             implementation
 **           - if you decide to use additional labels, make sure to add
 **             them to solver_ in both initialize and reset_solver
+**           - if your implementation tends to use the same labels often
+**             you can add the semantics (e.g. equality / implication)
+**             at the base context level, and just make sure that
+**             is_global_label returns true for those labels by overriding
+**             just don't forget to re-add those assertions in reset_solver
 **
 **        Important Notes:
 **           - be sure to use [push/pop]_solver_context instead of using
@@ -513,6 +518,11 @@ class IC3Base : public Prover
    *  @return the indicator variable label for this term
    */
   smt::Term label(const smt::Term & t);
+
+  /** Returns true iff this label
+   *  already has semantics assigned at the base context level
+   */
+  virtual bool is_global_label(const smt::Term & l) const;
 
   /** Negates a term by stripping the leading Not if it's there,
    ** or applying Not if the term is not already negated.

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -189,9 +189,6 @@ class IC3Base : public Prover
 
   // *************************** Main Methods *********************************
 
-  // HACK
-  virtual void set_invar(size_t k) { invar_ = get_frame_term(k); }
-
   // ************************** Virtual Methods *******************************
   // IMPORTANT for derived classes
   // These methods should be implemented by a derived class for a particular

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -40,8 +40,7 @@
 **             to the reset solver that aren't handled by the default
 **             implementation
 **           - if you decide to use additional labels, make sure to add
-**             them to solver_ and reducer_ (with assume_label)
-**             in both initialize and reset_solver
+**             them to solver_ in both initialize and reset_solver
 **
 **        Important Notes:
 **           - be sure to use [push/pop]_solver_context instead of using

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -79,12 +79,11 @@ IC3Formula IC3IA::get_model_ic3formula() const
 
 bool IC3IA::ic3formula_check_valid(const IC3Formula & u) const
 {
-  const Sort &boolsort = solver_->make_sort(BOOL);
   // check that children are literals
   Term pred;
   Op op;
   for (const auto &c : u.children) {
-    if (c->get_sort() != boolsort) {
+    if (c->get_sort() != boolsort_) {
       logger.log(3, "ERROR IC3IA IC3Formula contains non-boolean atom: {}", c);
       return false;
     }
@@ -358,11 +357,10 @@ bool IC3IA::add_predicate(const Term & pred)
   solver_->assert_formula(
       solver_->make_term(Implies, trans_label_, predabs_rel));
 
-  Sort boolsort = solver_->make_sort(BOOL);
-  assert(!is_lit(pred, boolsort));
+  assert(!is_lit(pred, boolsort_));
 
   Term predvar =
-      ts_.make_statevar(".pred" + std::to_string(pred2lbl_.size()), boolsort);
+      ts_.make_statevar(".pred" + std::to_string(pred2lbl_.size()), boolsort_);
   predvars_.insert(predvar);
   Term eq = solver_->make_term(Equal, predvar, pred);
   solver_->assert_formula(eq);

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -62,9 +62,9 @@ IC3IA::IC3IA(const Property & p,
 IC3Formula IC3IA::get_model_ic3formula() const
 {
   TermVec conjuncts;
-  conjuncts.reserve(predvars_.size());
+  conjuncts.reserve(predlbls_.size());
   Term val;
-  for (const auto &p : predvars_) {
+  for (const auto & p : predlbls_) {
     if ((val = solver_->get_value(p)) == solver_true_) {
       conjuncts.push_back(lbl2pred_.at(p));
     } else {
@@ -343,12 +343,11 @@ bool IC3IA::add_predicate(const Term & pred)
   Term npred = ts_.next(pred);
   Term nlbl = label(npred);
 
-  predvars_.insert(lbl);
+  predlbls_.insert(lbl);
 
   solver_->assert_formula(solver_->make_term(Equal, lbl, pred));
   solver_->assert_formula(solver_->make_term(Equal, nlbl, npred));
 
-  pred2lbl_[pred] = lbl;
   lbl2pred_[lbl] = pred;
 
   if (!is_lit(pred, boolsort_)) {

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -200,7 +200,7 @@ RefineResult IC3IA::refine()
   TermVec cex;
   const ProofGoal * tmp = cex_pg_;
   while (tmp) {
-    cex.push_back(solver_->substitute(tmp->target.term, lbl2pred_));
+    cex.push_back(tmp->target.term);
     assert(ts_.only_curr(tmp->target.term));
     tmp = tmp->next;
   }

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -324,6 +324,18 @@ void IC3IA::reset_solver()
     Term eq = solver_->make_term(Equal, elem.first, elem.second);
     solver_->assert_formula(eq);
     solver_->assert_formula(ts_.next(eq));
+
+    // reducer
+    reducer_.assume_label(elem.first, elem.second);
+    reducer_.assume_label(solver_->make_term(Not, elem.first),
+                          solver_->make_term(Not, elem.second));
+
+    Term npredvar = ts_.next(elem.first);
+    Term npred = ts_.next(elem.second);
+
+    reducer_.assume_label(npredvar, npred);
+    reducer_.assume_label(solver_->make_term(Not, npredvar),
+                          solver_->make_term(Not, npred));
   }
 }
 
@@ -355,6 +367,18 @@ bool IC3IA::add_predicate(const Term & pred)
   Term eq = solver_->make_term(Equal, predvar, pred);
   solver_->assert_formula(eq);
   solver_->assert_formula(ts_.next(eq));
+
+  // reducer
+  reducer_.assume_label(predvar, pred);
+  reducer_.assume_label(solver_->make_term(Not, predvar),
+                        solver_->make_term(Not, pred));
+
+  Term npredvar = ts_.next(predvar);
+  Term npred = ts_.next(pred);
+
+  reducer_.assume_label(npredvar, npred);
+  reducer_.assume_label(solver_->make_term(Not, npredvar),
+                        solver_->make_term(Not, npred));
 
   pred2lbl_[pred] = predvar;
   lbl2pred_[predvar] = pred;

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -351,7 +351,8 @@ bool IC3IA::add_predicate(const Term & pred)
   assert(ts_.only_curr(pred));
   logger.log(2, "adding predicate {}", pred);
   predset_.insert(pred);
-
+  assert(pred->get_sort() == boolsort_);
+  assert(pred->is_symbolic_const() || is_predicate(pred, boolsort_));
 
   Term lbl = label(pred);
   // set the negated label as well
@@ -370,7 +371,7 @@ bool IC3IA::add_predicate(const Term & pred)
 
   lbl2pred_[lbl] = pred;
 
-  if (!is_lit(pred, boolsort_)) {
+  if (!pred->is_symbolic_const()) {
     // only need to modify transition relation for non constants
     // boolean constants will be precise
 

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -78,7 +78,12 @@ class IC3IA : public IC3
   // predicates. This should still work fine with other solvers
   smt::UnorderedTermMap lbl2pred_;
   smt::UnorderedTermSet predlbls_;
-  smt::UnorderedTermSet nextpredlbls_;
+  smt::UnorderedTermSet all_lbls_;  ///< for debugging assertions only
+                                    ///< keeps track of both polarities
+                                    ///< mostly needed because some solvers
+                                    ///< do automatic top-level propagation
+                                    ///< which means you can't count on a symbol
+                                    ///< staying a symbol
 
   /** Overriding the method. This will return the concrete_ts_ because ts_ is an
    *  abstraction of concrete_ts_.

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -78,6 +78,7 @@ class IC3IA : public IC3
   // predicates. This should still work fine with other solvers
   smt::UnorderedTermMap lbl2pred_;
   smt::UnorderedTermSet predlbls_;
+  smt::UnorderedTermSet nextpredlbls_;
 
   /** Overriding the method. This will return the concrete_ts_ because ts_ is an
    *  abstraction of concrete_ts_.
@@ -100,6 +101,8 @@ class IC3IA : public IC3
   RefineResult refine() override;
 
   void reset_solver() override;
+
+  bool is_global_label(const smt::Term & l) const override;
 
   // specific to IC3IA
 

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -71,23 +71,14 @@ class IC3IA : public IC3
   size_t longest_cex_length_;  ///< keeps track of longest (abstract)
                                ///< counterexample
 
-  smt::UnorderedTermMap pred2lbl_;
   smt::UnorderedTermMap lbl2pred_;
-
-  smt::UnorderedTermSet predvars_;
+  smt::UnorderedTermSet predlbls_;
 
   /** Overriding the method. This will return the concrete_ts_ because ts_ is an
    *  abstraction of concrete_ts_.
    */
   TransitionSystem & prover_interface_ts() override { return conc_ts_; };
   // pure virtual method implementations
-
-  // HACK
-  void set_invar(size_t k) override
-  {
-    invar_ = get_frame_term(k);
-    invar_ = solver_->substitute(invar_, lbl2pred_);
-  }
 
   IC3Formula get_model_ic3formula() const override;
 

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -82,6 +82,13 @@ class IC3IA : public IC3
   TransitionSystem & prover_interface_ts() override { return conc_ts_; };
   // pure virtual method implementations
 
+  // HACK
+  void set_invar(size_t k) override
+  {
+    invar_ = get_frame_term(k);
+    invar_ = solver_->substitute(invar_, lbl2pred_);
+  }
+
   IC3Formula get_model_ic3formula() const override;
 
   bool ic3formula_check_valid(const IC3Formula & u) const override;

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -71,6 +71,11 @@ class IC3IA : public IC3
   size_t longest_cex_length_;  ///< keeps track of longest (abstract)
                                ///< counterexample
 
+  smt::UnorderedTermMap pred2lbl_;
+  smt::UnorderedTermMap lbl2pred_;
+
+  smt::UnorderedTermSet predvars_;
+
   /** Overriding the method. This will return the concrete_ts_ because ts_ is an
    *  abstraction of concrete_ts_.
    */
@@ -90,6 +95,8 @@ class IC3IA : public IC3
   void abstract() override;
 
   RefineResult refine() override;
+
+  void reset_solver() override;
 
   // specific to IC3IA
 

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -71,6 +71,11 @@ class IC3IA : public IC3
   size_t longest_cex_length_;  ///< keeps track of longest (abstract)
                                ///< counterexample
 
+  // Since MathSAT is the best solver for IC3IA it helps to use
+  // its bool_model_generation option which doesn't enable
+  // model generation for theories
+  // instead, we assign indicator labels to check the value of
+  // predicates. This should still work fine with other solvers
   smt::UnorderedTermMap lbl2pred_;
   smt::UnorderedTermSet predlbls_;
 

--- a/pono.cpp
+++ b/pono.cpp
@@ -167,7 +167,10 @@ int main(int argc, char ** argv)
     // no logging by default
     // could create an option for logging solvers in the future
     SmtSolver s = create_solver_for(
-        pono_options.smt_solver_, pono_options.engine_, false);
+        pono_options.smt_solver_,
+        pono_options.engine_,
+        false,
+        pono_options.engine_ == IC3IA_ENGINE ? BOOL_MODEL : FULL_MODEL);
 
     // limitations with COI
     if (pono_options.static_coi_) {

--- a/pono.cpp
+++ b/pono.cpp
@@ -167,10 +167,7 @@ int main(int argc, char ** argv)
     // no logging by default
     // could create an option for logging solvers in the future
     SmtSolver s = create_solver_for(
-        pono_options.smt_solver_,
-        pono_options.engine_,
-        false,
-        pono_options.engine_ == IC3IA_ENGINE ? BOOL_MODEL : FULL_MODEL);
+        pono_options.smt_solver_, pono_options.engine_, false);
 
     // limitations with COI
     if (pono_options.static_coi_) {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -112,25 +112,10 @@ SmtSolver create_solver(SolverEnum se,
 
 SmtSolver create_solver_for(SolverEnum se, Engine e, bool logging)
 {
-  if (se != MSAT && se != BTOR) {
+  bool ic3_engine = ic3_variants.find(e) != ic3_variants.end();
+  if (se != MSAT) {
     // no special options yet for solvers other than mathsat
     return create_solver(se, logging);
-  }
-
-  bool ic3_engine = ic3_variants.find(e) != ic3_variants.end();
-  // special cases
-  if (se == BTOR && e == IC3IA_ENGINE) {
-    // for IC3IA it's best to be able to reset the solver
-    // and boolector will do substitutions when there
-    // are assertions at the base level
-    // e.g. pred1 <-> p(X, Y)
-    // then pred1 will be substituted for and no longer be
-    // a symbol which causes problems for substitution, etc.
-    // TODO adjust this based on whether we settle on using
-    // variables for predicates in ic3ia
-    SmtSolver s = create_solver(se, logging);
-    s->set_opt("base-context-1", "true");
-    return s;
   }
 #ifdef WITH_MSAT
   else if (se == MSAT && ic3_engine) {
@@ -172,10 +157,6 @@ SmtSolver create_reducer_for(SolverEnum se, Engine e, bool logging)
     s = create_solver_base(se, logging);
     s->set_opt("incremental", "true");
     s->set_opt("produce-unsat-cores", "true");
-  }
-
-  if (se == BTOR && e == IC3IA_ENGINE) {
-    s->set_opt("base-context-1", "true");
   }
 
   assert(s);

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -173,6 +173,11 @@ SmtSolver create_reducer_for(SolverEnum se, Engine e, bool logging)
     s->set_opt("incremental", "true");
     s->set_opt("produce-unsat-cores", "true");
   }
+
+  if (se == BTOR && e == IC3IA_ENGINE) {
+    s->set_opt("base-context-1", "true");
+  }
+
   assert(s);
   return s;
 }

--- a/smt/available_solvers.h
+++ b/smt/available_solvers.h
@@ -16,10 +16,22 @@
 
 #pragma once
 
+#include <iostream>
+
 #include "options/options.h"
 #include "smt-switch/smt.h"
 
 namespace pono {
+
+// trying different msat options
+enum ModelOption
+{
+  FULL_MODEL = 0,
+  BOOL_MODEL,
+  NO_MODEL
+};
+
+std::ostream & operator<<(std::ostream & os, ModelOption m);
 
 /** Creates an SmtSolver of the provided type
  *  @param se the SolverEnum to identify which type of solver
@@ -34,7 +46,10 @@ smt::SmtSolver create_solver(smt::SolverEnum se, bool logging=false,
 
 // same as create_solver but will set reasonable options
 // for particular engines (mostly IC3-variants)
-smt::SmtSolver create_solver_for(smt::SolverEnum se, Engine e, bool logging);
+smt::SmtSolver create_solver_for(smt::SolverEnum se,
+                                 Engine e,
+                                 bool logging,
+                                 ModelOption m = FULL_MODEL);
 
 /** Creates an interpolating SmtSolver of the provided type */
 smt::SmtSolver create_interpolating_solver(smt::SolverEnum se);

--- a/smt/available_solvers.h
+++ b/smt/available_solvers.h
@@ -23,16 +23,6 @@
 
 namespace pono {
 
-// trying different msat options
-enum ModelOption
-{
-  FULL_MODEL = 0,
-  BOOL_MODEL,
-  NO_MODEL
-};
-
-std::ostream & operator<<(std::ostream & os, ModelOption m);
-
 /** Creates an SmtSolver of the provided type
  *  @param se the SolverEnum to identify which type of solver
  *  @param logging whether or not to keep track of term DAG at smt-switch level
@@ -46,10 +36,13 @@ smt::SmtSolver create_solver(smt::SolverEnum se, bool logging=false,
 
 // same as create_solver but will set reasonable options
 // for particular engines (mostly IC3-variants)
-smt::SmtSolver create_solver_for(smt::SolverEnum se,
-                                 Engine e,
-                                 bool logging,
-                                 ModelOption m = FULL_MODEL);
+smt::SmtSolver create_solver_for(smt::SolverEnum se, Engine e, bool logging);
+
+// same as create_solver but will set reasonable options
+// for a reducing solver (e.g. produce-models off)
+// unsat cores on
+// and other solver-specific options where appropriate
+smt::SmtSolver create_reducer_for(smt::SolverEnum se, Engine e, bool logging);
 
 /** Creates an interpolating SmtSolver of the provided type */
 smt::SmtSolver create_interpolating_solver(smt::SolverEnum se);

--- a/smt/msat_options.h
+++ b/smt/msat_options.h
@@ -18,11 +18,12 @@
 #ifdef WITH_MSAT
 
 #include "mathsat.h"
+#include "utils/exceptions.h"
 
 namespace pono {
 // configuration options copied from open-source ic3ia implementation
 // https://es-static.fbk.eu/people/griggio/ic3ia/index.html
-msat_config get_msat_config_for_ic3(bool interp)
+msat_config get_msat_config_for_ic3(bool interp, ModelOption m)
 {
   msat_config cfg = msat_create_config();
 
@@ -75,7 +76,20 @@ msat_config get_msat_config_for_ic3(bool interp)
     msat_set_option(cfg, "theory.bv.eager", "false");
   }
 
-  msat_set_option(cfg, "model_generation", interp ? "false" : "true");
+  if (interp && m != NO_MODEL) {
+    throw PonoException("interpolation doesn't need model");
+  }
+
+  msat_set_option(cfg, "model_generation", "false");
+  msat_set_option(cfg, "bool_model_generation", "false");
+
+  if (m == BOOL_MODEL) {
+    msat_set_option(cfg, "bool_model_generation", "true");
+  } else if (m == FULL_MODEL) {
+    msat_set_option(cfg, "model_generation", "true");
+  } else {
+    assert(m == NO_MODEL);
+  }
 
   return cfg;
 }

--- a/utils/term_analysis.cpp
+++ b/utils/term_analysis.cpp
@@ -121,27 +121,6 @@ vector<TermVec> get_combinations(const vector<TermVec> & options)
 
 // end helper functions
 
-bool is_lit(const Term & l, const Sort & boolsort)
-{
-  // take a boolsort as an argument for sort aliasing solvers
-  if (l->get_sort() != boolsort) {
-    return false;
-  }
-
-  if (l->is_symbolic_const()) {
-    return true;
-  }
-
-  Op op = l->get_op();
-  // check both for sort aliasing solvers
-  if (op == Not || op == BVNot) {
-    Term first_child = *(l->begin());
-    return first_child->is_symbolic_const();
-  }
-
-  return false;
-}
-
 bool is_predicate(const Term & t, const Sort & boolsort)
 {
   if (t->get_sort() != boolsort) {

--- a/utils/term_analysis.h
+++ b/utils/term_analysis.h
@@ -20,16 +20,6 @@
 
 namespace pono {
 
-/** returns true iff l is a literal
- *  e.g. either a boolean symbolic constant or its negation
- *  NOTE will return false for nested negations, i.e. (not (not (not l)))
- *  @param l the term to check
- *  @param boolsort a boolean sort from the corresponding solver
- *         this way sort aliasing solvers are still supported
- *  @return true iff l is a literal
- */
-bool is_lit(const smt::Term & l, const smt::Sort & boolsort);
-
 /** returns true iff t is a predicate
  *  @param t the term to check
  *  @param boolsort a boolean sort from the corresponding solver


### PR DESCRIPTION
This PR gives some better options to mathsat for the IC3IA backend. Instead of using predicate variables though, this PR just uses indicator variables for evaluating a model. I think this is a better solution than https://github.com/upscale-project/pono/pull/191.