### PR TITLE
Strengthen prop in IC3 variants

### DIFF
--- a/engines/ic3.cpp
+++ b/engines/ic3.cpp
@@ -73,7 +73,7 @@ bool IC3::ic3formula_check_valid(const IC3Formula & u) const
 }
 
 void IC3::predecessor_generalization(size_t i,
-                                     const IC3Formula & c,
+                                     const Term & c,
                                      IC3Formula & pred)
 {
   // TODO: change this so we don't have to depend on the solver context to be
@@ -97,8 +97,8 @@ void IC3::predecessor_generalization(size_t i,
     // NOTE: need to use full trans, not just trans_label_ here
     //       because we are passing it to the reducer_
     formula = solver_->make_term(And, formula, ts_.trans());
-    formula = solver_->make_term(
-        And, formula, solver_->make_term(Not, ts_.next(c.term)));
+    formula =
+        solver_->make_term(And, formula, solver_->make_term(Not, ts_.next(c)));
   } else {
     formula = solver_->make_term(And, formula, make_and(next_lits));
 
@@ -112,8 +112,8 @@ void IC3::predecessor_generalization(size_t i,
     Term pre_formula = get_frame_term(i - 1);
     pre_formula = solver_->make_term(And, pre_formula, ts_.trans());
     pre_formula =
-        solver_->make_term(And, pre_formula, solver_->make_term(Not, c.term));
-    pre_formula = solver_->make_term(And, pre_formula, ts_.next(c.term));
+        solver_->make_term(And, pre_formula, solver_->make_term(Not, c));
+    pre_formula = solver_->make_term(And, pre_formula, ts_.next(c));
     formula =
         solver_->make_term(And, formula, solver_->make_term(Not, pre_formula));
   }

--- a/engines/ic3.h
+++ b/engines/ic3.h
@@ -36,7 +36,7 @@ class IC3 : public IC3Base
   bool ic3formula_check_valid(const IC3Formula & u) const override;
 
   void predecessor_generalization(size_t i,
-                                  const IC3Formula & c,
+                                  const smt::Term & c,
                                   IC3Formula & pred) override;
 
   void check_ts() const override;

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -342,9 +342,7 @@ void IC3Base::predecessor_generalization(size_t i,
   return;
 }
 
-// TODO change name if we keep this update
-//      because it's no longer intersects_bad
-bool IC3Base::intersects_bad(IC3Formula & out)
+bool IC3Base::reaches_bad(IC3Formula & out)
 {
   push_solver_context();
   // assert the last frame (conjunction over clauses)
@@ -572,11 +570,11 @@ bool IC3Base::block_all()
 {
   assert(!solver_context_);
   ProofGoalQueue proof_goals;
-  IC3Formula bad_goal;
-  while (intersects_bad(bad_goal)) {
-    assert(bad_goal.term);  // expecting non-null
+  IC3Formula goal;
+  while (reaches_bad(goal)) {
+    assert(goal.term);            // expecting non-null
     assert(proof_goals.empty());  // bad should be the first goal each iteration
-    proof_goals.new_proof_goal(bad_goal, frontier_idx(), nullptr);
+    proof_goals.new_proof_goal(goal, frontier_idx(), nullptr);
 
     while (!proof_goals.empty()) {
       const ProofGoal * pg = proof_goals.top();
@@ -665,8 +663,8 @@ bool IC3Base::block_all()
       }
     }  // end while(!proof_goals.empty())
 
-    assert(!(bad_goal = IC3Formula()).term);  // in debug mode, reset it
-  }                                           // end while(intersects_bad())
+    assert(!(goal = IC3Formula()).term);  // in debug mode, reset it
+  }                                       // end while(reaches_bad(goal))
 
   assert(proof_goals.empty());
   return true;

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -335,7 +335,7 @@ IC3Formula IC3Base::inductive_generalization(size_t i, const IC3Formula & c)
 }
 
 void IC3Base::predecessor_generalization(size_t i,
-                                         const IC3Formula & c,
+                                         const Term & c,
                                          IC3Formula & pred)
 {
   // by default does no generalization
@@ -362,28 +362,14 @@ bool IC3Base::intersects_bad(IC3Formula & out)
     assert(out.children.size());
     assert(ic3formula_check_valid(out));
 
-    // disable generalization
-    // TODO maybe allow predecessor generalization here
-    // main problem now is that bad_ might not be an IC3Formula
-    // could always use a label for it though
+    if (options_.ic3_pregen_) {
+      // try to generalize if predecessor generalization enabled
+      predecessor_generalization(frames_.size(), bad_, out);
+    }
 
-    // // reduce
-    // TermVec red_c;
-    // // with abstraction can't guarantee this is unsat
-    // if (reducer_.reduce_assump_unsatcore(
-    //         smart_not(bad_), out.children, red_c)) {
-    //   logger.log(1,
-    //              "generalized bad cube to {}/{}",
-    //              red_c.size(),
-    //              out.children.size());
-    //   out = ic3formula_conjunction(red_c);
-
-    //   assert(out.term);
-    //   assert(out.children.size());
-    //   assert(ic3formula_check_valid(out));
-    // } else {
-    //   logger.log(1, "generalizing bad failed");
-    // }
+    assert(out.term);
+    assert(out.children.size());
+    assert(ic3formula_check_valid(out));
   }
 
   pop_solver_context();
@@ -524,7 +510,7 @@ bool IC3Base::rel_ind_check(size_t i,
     if (get_pred) {
       out = get_model_ic3formula();
       if (options_.ic3_pregen_) {
-        predecessor_generalization(i, c, out);
+        predecessor_generalization(i, c.term, out);
         assert(out.term);
         assert(out.children.size());
         assert(!out.disjunction);  // expecting a conjunction

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -422,6 +422,7 @@ ProverResult IC3Base::step(int i)
       // which is the frame that just had all terms
       // from the previous frames propagated
       invar_ = get_frame_term(j + 1);
+      invar_ = solver_->make_term(And, invar_, smart_not(bad_));
       return ProverResult::TRUE;
     }
   }

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -164,6 +164,10 @@ void IC3Base::initialize()
   solver_->assert_formula(
       solver_->make_term(Implies, trans_label_, ts_.trans()));
 
+  // assume property in pre-state
+  Term prop = smart_not(bad_);
+  solver_->assert_formula(solver_->make_term(Implies, trans_label_, prop));
+
   bad_label_ = solver_->make_symbol("__bad_label", boolsort_);
   solver_->assert_formula(solver_->make_term(Implies, bad_label_, bad_));
 }
@@ -932,6 +936,10 @@ void IC3Base::reset_solver()
 
     solver_->assert_formula(
         solver_->make_term(Implies, trans_label_, ts_.trans()));
+
+    // assume property in pre-state
+    Term prop = smart_not(bad_);
+    solver_->assert_formula(solver_->make_term(Implies, trans_label_, prop));
 
     solver_->assert_formula(solver_->make_term(Implies, bad_label_, bad_));
 

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -342,16 +342,18 @@ void IC3Base::predecessor_generalization(size_t i,
   return;
 }
 
+// TODO change name if we keep this update
+//      because it's no longer intersects_bad
 bool IC3Base::intersects_bad(IC3Formula & out)
 {
   push_solver_context();
   // assert the last frame (conjunction over clauses)
   assert_frame_labels(reached_k_ + 1);
-  // see if it intersects with bad
-  solver_->assert_formula(bad_label_);
+  // see if it intersects with bad in next states
+  solver_->assert_formula(ts_.next(bad_));
   // don't need transition relation for this check
   // can deactivate it
-  solver_->assert_formula(solver_->make_term(Not, trans_label_));
+  solver_->assert_formula(trans_label_);
   Result r = check_sat();
 
   if (r.is_sat()) {
@@ -360,23 +362,28 @@ bool IC3Base::intersects_bad(IC3Formula & out)
     assert(out.children.size());
     assert(ic3formula_check_valid(out));
 
-    // reduce
-    TermVec red_c;
-    // with abstraction can't guarantee this is unsat
-    if (reducer_.reduce_assump_unsatcore(
-            smart_not(bad_), out.children, red_c)) {
-      logger.log(1,
-                 "generalized bad cube to {}/{}",
-                 red_c.size(),
-                 out.children.size());
-      out = ic3formula_conjunction(red_c);
+    // disable generalization
+    // TODO maybe allow predecessor generalization here
+    // main problem now is that bad_ might not be an IC3Formula
+    // could always use a label for it though
 
-      assert(out.term);
-      assert(out.children.size());
-      assert(ic3formula_check_valid(out));
-    } else {
-      logger.log(1, "generalizing bad failed");
-    }
+    // // reduce
+    // TermVec red_c;
+    // // with abstraction can't guarantee this is unsat
+    // if (reducer_.reduce_assump_unsatcore(
+    //         smart_not(bad_), out.children, red_c)) {
+    //   logger.log(1,
+    //              "generalized bad cube to {}/{}",
+    //              red_c.size(),
+    //              out.children.size());
+    //   out = ic3formula_conjunction(red_c);
+
+    //   assert(out.term);
+    //   assert(out.children.size());
+    //   assert(ic3formula_check_valid(out));
+    // } else {
+    //   logger.log(1, "generalizing bad failed");
+    // }
   }
 
   pop_solver_context();

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -340,7 +340,7 @@ class IC3Base : public Prover
 
   /** Perform the base IC3 step (zero case)
    */
-  ProverResult step_0();
+  ProverResult step_01();
 
   /** Do a relative inductiveness check at frame i-1
    *  aka see if c at frame i is reachable from frame i-1

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -66,15 +66,6 @@
 
 namespace pono {
 
-// TODO for this branch
-// change step_0 to step_01 which checks one transition also
-// add property to fresh frame (maybe don't need it in label then)
-//    could consider only adding it once a frame is done
-//    might be a simpler implementation
-// update intersects_bad and possible get_model_ic3formula
-//    maybe ic3formula can stay the same? e.g. bad cube is actually
-//    something that transitions to bad, isn't bad itself
-
 struct IC3Formula
 {
   // nullary constructor
@@ -322,14 +313,12 @@ class IC3Base : public Prover
     return REFINE_NONE;
   }
 
-  /** Check if a transition from the second to last frame can result in a bad
-   * state
-   *  @return true iff the last frame intersects with bad
-   *  post-condition: if true is returned, a bad IC3Formula is added to proof
-   * goals This method can be overriden if you want to add more than a single
-   *  IC3Formula that intersects bad to the proof goals
+  /** Check if a transition from the frontier can result in a bad state
+   *  @param out an IC3Formula to populate with a state in the frontier
+   *         that can reach bad in one step
+   *  @return true iff bad is reachable from a state in the frontier
    */
-  virtual bool intersects_bad(IC3Formula & out);
+  virtual bool reaches_bad(IC3Formula & out);
 
   // ********************************** Common Methods
   // These methods are common to all flavors of IC3 currently implemented

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -277,7 +277,8 @@ class IC3Base : public Prover
    *  @requires rel_ind_check(i, c)
    *  @requires the solver_ context is currently satisfiable
    *  @param i the frame number
-   *  @param c the IC3Formula conjunction to find a general predecessor for
+   *  @param c the term that failed to be blocked at i
+   *         (over current state vars)
    *  @param pred the predecessor. originally passed as full assignment
    *         and then is updated in to be a generalized predecessor
    *  @ensures pred -> F[i-1] /\
@@ -286,7 +287,7 @@ class IC3Base : public Prover
    *           other assertions
    */
   virtual void predecessor_generalization(size_t i,
-                                          const IC3Formula & c,
+                                          const smt::Term & c,
                                           IC3Formula & pred);
 
   /** Generates an abstract transition system

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -66,6 +66,15 @@
 
 namespace pono {
 
+// TODO for this branch
+// change step_0 to step_01 which checks one transition also
+// add property to fresh frame (maybe don't need it in label then)
+//    could consider only adding it once a frame is done
+//    might be a simpler implementation
+// update intersects_bad and possible get_model_ic3formula
+//    maybe ic3formula can stay the same? e.g. bad cube is actually
+//    something that transitions to bad, isn't bad itself
+
 struct IC3Formula
 {
   // nullary constructor

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -204,6 +204,8 @@ RefineResult IC3IA::refine()
     assert(ts_.only_curr(tmp->target.term));
     tmp = tmp->next;
   }
+  // always assume the last step goes to a bad state
+  cex.push_back(bad_);
 
   if (cex.size() == 1) {
     // if there are no transitions, then this is a concrete CEX

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -195,24 +195,14 @@ void IC3IA::abstract()
 
 RefineResult IC3IA::refine()
 {
-  // recover the counterexample trace
-  assert(check_intersects_initial(cex_pg_->target.term));
-  TermVec cex;
-  const ProofGoal * tmp = cex_pg_;
-  while (tmp) {
-    cex.push_back(tmp->target.term);
-    assert(ts_.only_curr(tmp->target.term));
-    tmp = tmp->next;
-  }
-  // always assume the last step goes to a bad state
-  cex.push_back(bad_);
-
-  if (cex.size() == 1) {
+  // counterexample trace should have been populated
+  assert(cex_.size());
+  if (cex_.size() == 1) {
     // if there are no transitions, then this is a concrete CEX
     return REFINE_NONE;
   }
 
-  size_t cex_length = cex.size();
+  size_t cex_length = cex_.size();
 
   // use interpolator to get predicates
   // remember -- need to transfer between solvers
@@ -223,7 +213,7 @@ RefineResult IC3IA::refine()
     // make sure to_solver_ cache is populated with unrolled symbols
     register_symbol_mappings(i);
 
-    Term t = unroller_.at_time(cex[i], i);
+    Term t = unroller_.at_time(cex_[i], i);
     if (i + 1 < cex_length) {
       t = solver_->make_term(And, t, unroller_.at_time(conc_ts_.trans(), i));
     }
@@ -243,7 +233,7 @@ RefineResult IC3IA::refine()
   // important to set it here because it's used in register_symbol_mapping
   // to determine if state variables unrolled to a certain length
   // have already been cached in to_solver_
-  longest_cex_length_ = cex.size();
+  longest_cex_length_ = cex_length;
 
   UnorderedTermSet preds;
   for (auto const&I : out_interpolants) {
@@ -281,7 +271,7 @@ RefineResult IC3IA::refine()
 
   // reduce new predicates
   TermVec red_preds;
-  if (ia_.reduce_predicates(cex, fresh_preds, red_preds)) {
+  if (ia_.reduce_predicates(cex_, fresh_preds, red_preds)) {
     // reduction successful
     logger.log(2,
                "reduce predicates successful {}/{}",

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -296,7 +296,7 @@ IC3Formula ModelBasedIC3::inductive_generalization(size_t i,
 }
 
 void ModelBasedIC3::predecessor_generalization(size_t i,
-                                               const IC3Formula & c,
+                                               const Term & c,
                                                IC3Formula & pred)
 {
   // NOTE: for now this implementation doesn't use pred
@@ -365,7 +365,7 @@ void ModelBasedIC3::predecessor_generalization(size_t i,
       // to the reducer_'s solver
       formula = solver_->make_term(And, formula, ts_.trans());
       formula = solver_->make_term(
-          And, formula, solver_->make_term(Not, ts_.next(c.term)));
+          And, formula, solver_->make_term(Not, ts_.next(c)));
     } else {
       formula = solver_->make_term(And, formula, make_and(next_lits));
 
@@ -379,8 +379,8 @@ void ModelBasedIC3::predecessor_generalization(size_t i,
       Term pre_formula = get_frame_term(i - 1);
       pre_formula = solver_->make_term(And, pre_formula, ts_.trans());
       pre_formula =
-          solver_->make_term(And, pre_formula, solver_->make_term(Not, c.term));
-      pre_formula = solver_->make_term(And, pre_formula, ts_.next(c.term));
+          solver_->make_term(And, pre_formula, solver_->make_term(Not, c));
+      pre_formula = solver_->make_term(And, pre_formula, ts_.next(c));
 
       formula = solver_->make_term(
           And, formula, solver_->make_term(Not, pre_formula));

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -434,28 +434,6 @@ void ModelBasedIC3::check_ts() const
   }
 }
 
-bool ModelBasedIC3::intersects_bad(IC3Formula & out)
-{
-  push_solver_context();
-  // assert the last frame (conjunction over clauses)
-  assert_frame_labels(reached_k_ + 1);
-  // see if it intersects with bad
-  solver_->assert_formula(bad_);
-  Result r = check_sat();
-
-  if (r.is_sat()) {
-    // push bad as a proof goal
-    TermVec conjuncts;
-    conjunctive_partition(bad_, conjuncts, true);
-    out = ic3formula_conjunction(conjuncts);
-  }
-
-  pop_solver_context();
-
-  assert(!r.is_unknown());
-  return r.is_sat();
-}
-
 void ModelBasedIC3::initialize()
 {
   if (initialized_) {

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -46,7 +46,7 @@ class ModelBasedIC3 : public IC3Base
   IC3Formula inductive_generalization(size_t i, const IC3Formula & c) override;
 
   void predecessor_generalization(size_t i,
-                                  const IC3Formula & c,
+                                  const smt::Term & c,
                                   IC3Formula & pred) override;
 
   void check_ts() const override;

--- a/engines/mbic3.h
+++ b/engines/mbic3.h
@@ -51,8 +51,6 @@ class ModelBasedIC3 : public IC3Base
 
   void check_ts() const override;
 
-  bool intersects_bad(IC3Formula & out) override;
-
   void initialize() override;
 };
 }  // namespace pono


### PR DESCRIPTION
Based on @zhanghongce's suggestion to use the original IC3 approach of finding bad cubes by checking with a transition while assume the property in the pre-state. Essentially this starts every fresh frame assuming the property, although the implementation doesn't do that because the property might not be representable by a single `IC3Formula` (e.g. the property might not be a clause).

This includes a few other edits. Most notably:
* it changes the `predecessor_generalization` interface to take a term instead of an `IC3Formula` for the term that we failed to block. This is because we might want to generalize the predecessor that can reach bad in one step. In that case, bad is the thing we failed to block but it might not be representable as an `IC3Formula` (e.g. usually a cube / clause).
* it gets rid of `cex_pg_` for recovering a counterexample trace and instead just reconstructs the trace immediately. I think this is better because now we have to add `bad_` to the end of the trace, and the function will take care of that for us

Overall I think this is better in terms of code quality in addition to performance. In particular I like that we now have the invariant that `reached_k_ == frontier_idx()`