### PR TITLE
CEGAR loop to abstract values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,7 @@ set(SOURCES
   "${PROJECT_SOURCE_DIR}/utils/term_analysis.cpp"
   "${PROJECT_SOURCE_DIR}/utils/term_walkers.cpp"
   "${PROJECT_SOURCE_DIR}/utils/ts_analysis.cpp"
+  "${PROJECT_SOURCE_DIR}/utils/ts_manipulation.cpp"
   "${PROJECT_SOURCE_DIR}/options/options.cpp"
   "${BISON_SMVParser_OUTPUTS}"
   "${FLEX_SMVScanner_OUTPUTS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(SOURCES
   "${PROJECT_SOURCE_DIR}/engines/prover.cpp"
   "${PROJECT_SOURCE_DIR}/engines/bmc.cpp"
   "${PROJECT_SOURCE_DIR}/engines/bmc_simplepath.cpp"
+  "${PROJECT_SOURCE_DIR}/engines/cegar_values.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ceg_prophecy_arrays.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ic3.cpp"
   "${PROJECT_SOURCE_DIR}/engines/ic3base.cpp"

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -120,8 +120,8 @@ TransitionSystem::TransitionSystem(const TransitionSystem & other_ts,
   /* Constraints collected in vector 'constraints_' were part of init_
      and/or trans_ and were transferred already above. Hence these
      terms should be in the term translator cache. */
-  for (const auto & constr : other_ts.constraints_) {
-    constraints_.push_back(transfer_as(constr, BOOL));
+  for (const auto & e : other_ts.constraints_) {
+    constraints_.push_back({ transfer_as(e.first, BOOL), e.second });
   }
   functional_ = other_ts.functional_;
   deterministic_ = other_ts.deterministic_;
@@ -216,8 +216,7 @@ void TransitionSystem::add_invar(const Term & constraint)
     Term next_constraint = solver_->substitute(constraint, next_map_);
     // add the next-state version
     trans_ = solver_->make_term(And, trans_, next_constraint);
-    constraints_.push_back(constraint);
-    constraints_.push_back(next_constraint);
+    constraints_.push_back({ constraint, true });
   } else {
     throw PonoException("Invariants should be over current states only.");
   }
@@ -231,37 +230,31 @@ void TransitionSystem::constrain_inputs(const Term & constraint)
 
   if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
-    constraints_.push_back(constraint);
+    constraints_.push_back({ constraint, false });
   } else {
     throw PonoException("Cannot have next-states in an input constraint.");
   }
 }
 
 void TransitionSystem::add_constraint(const Term & constraint,
-                                      bool to_init,
-                                      bool to_next)
+                                      bool to_init_and_next)
 {
   // constraints can make it so not every state has a next state
   // TODO: revisit this and possibly rename functional/deterministic
   deterministic_ = false;
 
   if (only_curr(constraint)) {
-    if (to_init) {
-      init_ = solver_->make_term(And, init_, constraint);
-    }
     trans_ = solver_->make_term(And, trans_, constraint);
-    constraints_.push_back(constraint);
 
-    if (to_next) {
-      // add over next states
+    if (to_init_and_next) {
+      init_ = solver_->make_term(And, init_, constraint);
       Term next_constraint = solver_->substitute(constraint, next_map_);
       trans_ = solver_->make_term(And, trans_, next_constraint);
-      constraints_.push_back(next_constraint);
     }
-
+    constraints_.push_back({ constraint, to_init_and_next });
   } else if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
-    constraints_.push_back(constraint);
+    constraints_.push_back({ constraint, false });
   } else {
     throw PonoException("Constraint cannot have next states");
   }
@@ -498,8 +491,8 @@ void TransitionSystem::rebuild_trans_based_on_coi(
 
   /* Add global constraints added to previous 'trans_'. */
   // TODO: check potential optimizations in removing global constraints
-  for (const auto & constr : constraints_) {
-    trans_ = solver_->make_term(And, trans_, constr);
+  for (const auto & e : constraints_) {
+    add_constraint(e.first, e.second);
   }
 
   statevars_.clear();
@@ -642,8 +635,8 @@ void TransitionSystem::drop_state_updates(const TermVec & svs)
   }
 
   /* Add global constraints added to previous 'trans_'. */
-  for (const auto & constr : constraints_) {
-    trans_ = solver_->make_term(And, trans_, constr);
+  for (const auto & e : constraints_) {
+    add_constraint(e.first, e.second);
   }
 }
 
@@ -715,10 +708,10 @@ void TransitionSystem::replace_terms(const UnorderedTermMap & to_replace)
   next_map_ = new_next_map_;
   curr_map_ = new_curr_map_;
 
-  TermVec new_constraints;
+  vector<pair<Term, bool>> new_constraints;
   new_constraints.reserve(constraints_.size());
-  for (auto c : constraints_) {
-    new_constraints.push_back(sw.visit(c));
+  for (const auto & e : constraints_) {
+    new_constraints.push_back(e);
   }
   constraints_ = new_constraints;
 }

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -97,7 +97,7 @@ ProverResult CegProphecyArrays<Prover_T>::prove()
     }
   }
 
-  if (res == ProverResult::TRUE) {
+  if (res == ProverResult::TRUE && super::invar_) {
     // update the invariant
     super::invar_ = aa_.concrete(super::invar_);
   }
@@ -129,6 +129,16 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
       shared_ptr<Prover> prover = make_prover(super::engine_, latest_prop,
                                               abs_ts_, s, super::options_);
       res = prover->check_until(k);
+      if (res == ProverResult::TRUE) {
+        try {
+          // set the invariant
+          super::invar_ = prover->invar();
+        }
+        catch (std::exception & e) {
+          logger.log(3, "Failed to set invariant because {}", e.what());
+          continue;
+        }
+      }
     } else {
       res = super::check_until(k);
     }
@@ -140,7 +150,7 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
     return ProverResult::UNKNOWN;
   }
 
-  if (res == ProverResult::TRUE) {
+  if (res == ProverResult::TRUE && super::invar_) {
     // update the invariant
     super::invar_ = aa_.concrete(super::invar_);
   }

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -97,6 +97,11 @@ ProverResult CegProphecyArrays<Prover_T>::prove()
     }
   }
 
+  if (res == ProverResult::TRUE) {
+    // update the invariant
+    super::invar_ = aa_.concrete(super::invar_);
+  }
+
   return res;
 }
 
@@ -133,6 +138,11 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
     // can't count on false result over abstraction when only checking up until
     // a bound
     return ProverResult::UNKNOWN;
+  }
+
+  if (res == ProverResult::TRUE) {
+    // update the invariant
+    super::invar_ = aa_.concrete(super::invar_);
   }
 
   return res;

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -145,7 +145,7 @@ void CegProphecyArrays<Prover_T>::initialize()
     return;
   }
 
-  cegar_abstract();
+  CegProphecyArrays::cegar_abstract();
   // call super initializer after abstraction
   super::initialize();
 

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -178,12 +178,8 @@ void CegProphecyArrays<Prover_T>::cegar_abstract()
   aae_.initialize();
   // the ArrayAbstractor already abstracted the transition system on
   // construction -- only need to abstract bad
-  Term prop_term = (abs_ts_.solver() == super::orig_property_.solver())
-                       ? super::orig_property_.prop()
-                       : super::to_prover_solver_.transfer_term(
-                           super::orig_property_.prop(), BOOL);
-  super::bad_ =
-      super::solver_->make_term(smt::PrimOp::Not, aa_.abstract(prop_term));
+  assert(super::bad_);
+  super::bad_ = aa_.abstract(super::bad_);
 
   // the abstract system should have all the same state and input variables
   // but abstracted

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -77,7 +77,7 @@ ProverResult CegProphecyArrays<Prover_T>::prove()
     // Refine the system
     // heuristic -- stop refining when no new axioms are needed.
     do {
-      if (!cegar_refine()) {
+      if (!CegProphecyArrays::cegar_refine()) {
         // real counterexample
         return ProverResult::FALSE;
       }

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -145,6 +145,8 @@ void CegProphecyArrays<Prover_T>::initialize()
     return;
   }
 
+  // specify which cegar_abstract in case
+  // we're inheriting from another cegar algorithm
   CegProphecyArrays::cegar_abstract();
   // call super initializer after abstraction
   super::initialize();

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -110,7 +110,7 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
     // Refine the system
     // heuristic -- stop refining when no new axioms are needed.
     do {
-      if (!cegar_refine()) {
+      if (!CegProphecyArrays::cegar_refine()) {
         return ProverResult::FALSE;
       }
       reached_k_++;

--- a/engines/ceg_prophecy_arrays.h
+++ b/engines/ceg_prophecy_arrays.h
@@ -49,6 +49,12 @@ class CegProphecyArrays : public CEGAR<Prover_T>
 
   void initialize() override;
 
+  size_t witness_length() const override
+  {
+    // regardless of super class want this to be the witness length
+    return reached_k_+1;
+  }
+
  protected:
   TransitionSystem conc_ts_;
   TransitionSystem & abs_ts_;

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -33,11 +33,6 @@ using namespace std;
 
 namespace pono {
 
-// TODO add a value abstractor
-//      make sure not to introduce nonlinearities
-//      implement generic backend
-//      then specialize for IC3IA
-
 static unordered_set<PrimOp> nl_ops({ Mult,
                                       Div,
                                       Mod,

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -272,8 +272,11 @@ bool CegarValues<Prover_T>::cegar_refine()
         logger.log(2, "CegarValues adding refinement axiom {}", equalities[i]);
         // need to refine both systems
         cegval_ts_.add_constraint(equalities[i]);
-        prover_ts_.add_constraint(
-            from_cegval_solver_.transfer_term(equalities[i], BOOL));
+        Term transferred_eq =
+            from_cegval_solver_.transfer_term(equalities[i], BOOL);
+        // TODO this should be more modular
+        //      can't assume super::abs_ts_ is the right one to constrain
+        super::abs_ts_.add_constraint(transferred_eq);
       }
     }
   }

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -116,7 +116,12 @@ CegarValues<Prover_T>::CegarValues(const Property & p,
                                    PonoOptions opt)
     : super(p, create_fresh_ts(ts.is_functional(), solver), solver, opt),
       conc_ts_(ts, super::to_prover_solver_),
-      prover_ts_(super::prover_interface_ts())
+      prover_ts_(super::prover_interface_ts()),
+      cegval_solver_(create_solver(solver->get_solver_enum())),
+      to_cegval_solver_(cegval_solver_),
+      from_cegval_solver_(super::solver_),
+      cegval_ts_(cegval_solver_),
+      cegval_un_(cegval_ts_)
 {
 }
 
@@ -152,6 +157,9 @@ void CegarValues<Prover_T>::initialize()
   // we're inheriting from another cegar algorithm
   CegarValues::cegar_abstract();
   super::initialize();
+
+  // update local version of ts over fresh solver
+  cegval_ts_ = TransitionSystem(prover_ts_, to_cegval_solver_);
 }
 
 template <class Prover_T>
@@ -189,7 +197,7 @@ void CegarValues<Prover_T>::cegar_abstract()
 template <class Prover_T>
 bool CegarValues<Prover_T>::cegar_refine()
 {
-  throw PonoException("NYI");
+  throw PonoException("CegarValues::cegar_refine NYI");
 }
 
 // TODO add other template classes

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -183,11 +183,6 @@ void CegarValues<Prover_T>::initialize()
                                       boolsort);
     cegval_labels_[elem.first] = lbl;
   }
-
-  // TODO clean this up -- managing the property / bad is a mess
-  // need to reset it a because super::initialize set it to the
-  // negated original (non-abstract) property
-  super::bad_ = from_cegval_solver_.transfer_term(cegval_bad_, BOOL);
 }
 
 template <class Prover_T>
@@ -207,13 +202,8 @@ void CegarValues<Prover_T>::cegar_abstract()
         .set_behavior(va.visit(init), va.visit(trans));
   }
 
-  // TODO clean this up -- it's a mess with the property
-  // and bad_ in Prover::initialize
-  Term prop_term = (super::solver_ == super::orig_property_.solver())
-                       ? super::orig_property_.prop()
-                       : super::to_prover_solver_.transfer_term(
-                           super::orig_property_.prop(), BOOL);
-  super::bad_ = super::solver_->make_term(Not, va.visit(prop_term));
+  assert(super::bad_);
+  super::bad_ = va.visit(super::bad_);
   cegval_bad_ = to_cegval_solver_.transfer_term(super::bad_, BOOL);
 
   // expecting to have had values to abstract

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -1,0 +1,64 @@
+/*********************                                                        */
+/*! \file cegar_values.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief A simple CEGAR loop that abstracts values with frozen variables
+**        and refines by constraining the variable to the value again
+**
+**/
+
+#include "engines/cegar_values.h"
+
+#include "utils/exceptions.h"
+
+using namespace smt;
+using namespace std;
+
+namespace pono {
+
+// TODO add a value abstractor
+//      make sure not to introduce nonlinearities
+//      implement generic backend
+//      then specialize for IC3IA
+
+template <class Prover_T>
+CegarValues<Prover_T>::CegarValues(const Property & p,
+                                   const TransitionSystem & ts,
+                                   const smt::SmtSolver & solver,
+                                   PonoOptions opt)
+    : super(p, ts, solver, opt)
+{
+}
+
+template <class Prover_T>
+ProverResult CegarValues<Prover_T>::check_until(int k)
+{
+  throw PonoException("NYI");
+}
+
+template <class Prover_T>
+void CegarValues<Prover_T>::initialize()
+{
+  throw PonoException("NYI");
+}
+
+template <class Prover_T>
+void CegarValues<Prover_T>::cegar_abstract()
+{
+  throw PonoException("NYI");
+}
+
+template <class Prover_T>
+bool CegarValues<Prover_T>::cegar_refine()
+{
+  throw PonoException("NYI");
+}
+
+}  // namespace pono

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -27,6 +27,7 @@
 #include "utils/exceptions.h"
 #include "utils/logger.h"
 #include "utils/make_provers.h"
+#include "utils/ts_manipulation.h"
 
 using namespace smt;
 using namespace std;
@@ -95,15 +96,6 @@ class ValueAbstractor : public smt::IdentityWalker
   TransitionSystem & ts_;
   UnorderedTermMap & abstracted_values_;
 };
-
-TransitionSystem create_fresh_ts(bool functional, const SmtSolver & solver)
-{
-  if (functional) {
-    return FunctionalTransitionSystem(solver);
-  } else {
-    return RelationalTransitionSystem(solver);
-  }
-}
 
 template <class Prover_T>
 CegarValues<Prover_T>::CegarValues(const Property & p,

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -55,7 +55,8 @@ class ValueAbstractor : public smt::IdentityWalker
   ValueAbstractor(TransitionSystem & ts, UnorderedTermMap & abstracted_values)
       : smt::IdentityWalker(ts.solver(), false),
         ts_(ts),
-        abstracted_values_(abstracted_values)
+        abstracted_values_(abstracted_values),
+        boolsort_(ts_.solver()->make_sort(BOOL))
   {
   }
 
@@ -63,7 +64,9 @@ class ValueAbstractor : public smt::IdentityWalker
   smt::WalkerStepResult visit_term(smt::Term & term) override
   {
     if (!preorder_) {
-      if (term->is_value() && term->get_sort()->get_sort_kind() != ARRAY) {
+      Sort sort = term->get_sort();
+      if (term->is_value() && sort != boolsort_
+          && sort->get_sort_kind() != ARRAY) {
         // create a frozen variable
         Term frozen_var =
             ts_.make_statevar("__abs_" + term->to_string(), term->get_sort());
@@ -95,6 +98,7 @@ class ValueAbstractor : public smt::IdentityWalker
 
   TransitionSystem & ts_;
   UnorderedTermMap & abstracted_values_;
+  Sort boolsort_;
 };
 
 template <class Prover_T>

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -160,6 +160,18 @@ void CegarValues<Prover_T>::initialize()
 
   // update local version of ts over fresh solver
   cegval_ts_ = TransitionSystem(prover_ts_, to_cegval_solver_);
+  // update cache
+  UnorderedTermMap & cache = from_cegval_solver_.get_cache();
+  Term nv;
+  for (const auto & sv : prover_ts_.statevars()) {
+    nv = prover_ts_.next(sv);
+    cache[to_cegval_solver_.transfer_term(sv)] = sv;
+    cache[to_cegval_solver_.transfer_term(nv)] = nv;
+  }
+
+  for (const auto & iv : prover_ts_.inputvars()) {
+    cache[to_cegval_solver_.transfer_term(iv)] = iv;
+  }
 }
 
 template <class Prover_T>

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -23,7 +23,9 @@
 #include "engines/ceg_prophecy_arrays.h"
 #include "engines/ic3ia.h"
 #include "smt-switch/identity_walker.h"
+#include "smt/available_solvers.h"
 #include "utils/exceptions.h"
+#include "utils/make_provers.h"
 
 using namespace smt;
 using namespace std;
@@ -121,7 +123,22 @@ CegarValues<Prover_T>::CegarValues(const Property & p,
 template <class Prover_T>
 ProverResult CegarValues<Prover_T>::check_until(int k)
 {
-  throw PonoException("NYI");
+  initialize();
+
+  ProverResult res = ProverResult::FALSE;
+  while (res == ProverResult::FALSE) {
+    // need to call parent's check_until in case it
+    // is another cegar loop rather than an engine
+    res = super::check_until(k);
+
+    if (res == ProverResult::FALSE) {
+      if (!cegar_refine()) {
+        return ProverResult::FALSE;
+      }
+    }
+  }
+
+  return res;
 }
 
 template <class Prover_T>

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -192,20 +192,20 @@ void CegarValues<Prover_T>::cegar_abstract()
   UnorderedTermMap prover_to_vals;
   ValueAbstractor va(prover_ts_, prover_to_vals);
 
+  // add variables
+  for (const auto & sv : conc_ts_.statevars()) {
+    prover_ts_.add_statevar(sv, conc_ts_.next(sv));
+  }
+
+  for (const auto & iv : conc_ts_.inputvars()) {
+    prover_ts_.add_inputvar(iv);
+  }
+
+  Term init = conc_ts_.init();
+  prover_ts_.set_init(va.visit(init));
+
   // now update with abstraction
   if (prover_ts_.is_functional()) {
-    // add variables
-    for (const auto & sv : conc_ts_.statevars()) {
-      prover_ts_.add_statevar(sv, conc_ts_.next(sv));
-    }
-
-    for (const auto & iv : conc_ts_.inputvars()) {
-      prover_ts_.add_inputvar(iv);
-    }
-
-    Term init = prover_ts_.init();
-    prover_ts_.set_init(va.visit(init));
-
     // state updates
     for (auto elem : conc_ts_.state_updates()) {
       prover_ts_.assign_next(elem.first, va.visit(elem.second));
@@ -219,9 +219,7 @@ void CegarValues<Prover_T>::cegar_abstract()
       }
     }
   } else {
-    prover_ts_ = conc_ts_;
-    Term init = prover_ts_.init();
-    Term trans = prover_ts_.trans();
+    Term trans = conc_ts_.trans();
     static_cast<RelationalTransitionSystem &>(prover_ts_)
         .set_behavior(va.visit(init), va.visit(trans));
   }

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -145,6 +145,16 @@ ProverResult CegarValues<Prover_T>::check_until(int k)
     }
   }
 
+  if (res == ProverResult::TRUE) {
+    // update the invariant
+    UnorderedTermMap super_to_vals;
+    for (const auto & elem : to_vals_) {
+      super_to_vals[from_cegval_solver_.transfer_term(elem.first)] =
+          from_cegval_solver_.transfer_term(elem.second);
+    }
+    super::invar_ = super::solver_->substitute(super::invar_, super_to_vals);
+  }
+
   return res;
 }
 

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -282,17 +282,31 @@ bool CegarValues<Prover_T>::cegar_refine()
         logger.log(2, "CegarValues adding refinement axiom {}", equalities[i]);
         // need to refine both systems
         cegval_ts_.add_constraint(equalities[i]);
-        Term transferred_eq =
-            from_cegval_solver_.transfer_term(equalities[i], BOOL);
         // TODO this should be more modular
         //      can't assume super::abs_ts_ is the right one to constrain
-        super::abs_ts_.add_constraint(transferred_eq);
+        refine_subprover_ts(equalities[i]);
       }
     }
   }
   cegval_solver_->pop();
 
   return r.is_unsat();
+}
+
+template <class Prover_T>
+void CegarValues<Prover_T>::refine_subprover_ts(const Term & constraint)
+{
+  throw PonoException("CegarValues::refine_subprover_ts NYI for generic case");
+}
+
+template <>
+void CegarValues<CegProphecyArrays<IC3IA>>::refine_subprover_ts(
+    const Term & constraint)
+{
+  Term transferred_constraint =
+      from_cegval_solver_.transfer_term(constraint, BOOL);
+  assert(super::abs_ts_.only_curr(transferred_constraint));
+  super::abs_ts_.add_constraint(transferred_constraint);
 }
 
 // TODO add other template classes

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -214,9 +214,7 @@ void CegarValues<Prover_T>::cegar_abstract()
     for (auto con : conc_ts_.constraints()) {
       // NOTE: there should be better infrastructure for re-adding constraints
       // currently have to avoid re-adding the next version
-      if (conc_ts_.no_next(con)) {
-        prover_ts_.add_constraint(va.visit(con));
-      }
+      prover_ts_.add_constraint(va.visit(con.first), con.second);
     }
   } else {
     Term trans = conc_ts_.trans();

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -145,7 +145,7 @@ ProverResult CegarValues<Prover_T>::check_until(int k)
     }
   }
 
-  if (res == ProverResult::TRUE) {
+  if (res == ProverResult::TRUE && super::invar_) {
     // update the invariant
     UnorderedTermMap super_to_vals;
     for (const auto & elem : to_vals_) {

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -120,7 +120,7 @@ CegarValues<Prover_T>::CegarValues(const Property & p,
       prover_ts_(super::prover_interface_ts()),
       cegval_solver_(create_solver(solver->get_solver_enum())),
       to_cegval_solver_(cegval_solver_),
-      from_cegval_solver_(super::solver_),
+      from_cegval_solver_(super::prover_interface_ts().solver()),
       cegval_ts_(cegval_solver_),
       cegval_un_(cegval_ts_)
 {

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -54,6 +54,8 @@ class CegarValues : public CEGAR<Prover_T>
   void cegar_abstract() override;
 
   bool cegar_refine() override;
+
+  void refine_subprover_ts(const smt::Term & constraint);
 };
 
 }  // namespace pono

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -38,7 +38,6 @@ class CegarValues : public CEGAR<Prover_T>
  protected:
   TransitionSystem conc_ts_;
   TransitionSystem & prover_ts_;
-  smt::UnorderedTermMap to_vals_;
 
   // solver and associated infrastructure for
   // unrolling based refinement
@@ -47,6 +46,10 @@ class CegarValues : public CEGAR<Prover_T>
   smt::TermTranslator from_cegval_solver_;
   TransitionSystem cegval_ts_;
   Unroller cegval_un_;
+  smt::UnorderedTermMap to_vals_;
+  smt::Term cegval_bad_;
+
+  smt::UnorderedTermMap cegval_labels_;  // labels for each abstract value
 
   void cegar_abstract() override;
 

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -36,7 +36,7 @@ class CegarValues : public CEGAR<Prover_T>
 
  protected:
   TransitionSystem conc_ts_;
-  TransitionSystem & abs_ts_;
+  TransitionSystem & prover_ts_;
   smt::UnorderedTermMap to_vals_;
 
   void cegar_abstract() override;

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "core/unroller.h"
 #include "engines/cegar.h"
 
 namespace pono {
@@ -38,6 +39,14 @@ class CegarValues : public CEGAR<Prover_T>
   TransitionSystem conc_ts_;
   TransitionSystem & prover_ts_;
   smt::UnorderedTermMap to_vals_;
+
+  // solver and associated infrastructure for
+  // unrolling based refinement
+  smt::SmtSolver cegval_solver_;
+  smt::TermTranslator to_cegval_solver_;
+  smt::TermTranslator from_cegval_solver_;
+  TransitionSystem cegval_ts_;
+  Unroller cegval_un_;
 
   void cegar_abstract() override;
 

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -35,6 +35,8 @@ class CegarValues : public CEGAR<Prover_T>
   void initialize() override;
 
  protected:
+  TransitionSystem conc_ts_;
+  TransitionSystem & abs_ts_;
   smt::UnorderedTermMap to_vals_;
 
   void cegar_abstract() override;

--- a/engines/cegar_values.h
+++ b/engines/cegar_values.h
@@ -1,0 +1,45 @@
+/*********************                                                        */
+/*! \file cegar_values.h
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief A simple CEGAR loop that abstracts values with frozen variables
+**        and refines by constraining the variable to the value again
+**
+**/
+
+#pragma once
+
+#include "engines/cegar.h"
+
+namespace pono {
+template <class Prover_T>
+class CegarValues : public CEGAR<Prover_T>
+{
+  typedef CEGAR<Prover_T> super;
+
+ public:
+  CegarValues(const Property & p,
+              const TransitionSystem & ts,
+              const smt::SmtSolver & solver,
+              PonoOptions opt = PonoOptions());
+
+  ProverResult check_until(int k) override;
+
+  void initialize() override;
+
+ protected:
+  smt::UnorderedTermMap to_vals_;
+
+  void cegar_abstract() override;
+
+  bool cegar_refine() override;
+};
+
+}  // namespace pono

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -193,6 +193,13 @@ bool IC3Base::witness(std::vector<smt::UnorderedTermMap> & out)
   throw PonoException("IC3 witness NYI");
 }
 
+size_t IC3Base::witness_length() const
+{
+  // expecting there to have been a witness computed
+  assert(cex_.size());
+  return cex_.size();
+}
+
 // Protected Methods
 
 IC3Formula IC3Base::ic3formula_disjunction(const TermVec & c) const

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -147,6 +147,8 @@ class IC3Base : public Prover
 
   bool witness(std::vector<smt::UnorderedTermMap> & out) override;
 
+  size_t witness_length() const;
+
  protected:
 
   smt::UnsatCoreReducer reducer_;

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -30,8 +30,10 @@ using namespace std;
 
 namespace pono {
 
-Prover::Prover(const Property & p, const TransitionSystem & ts,
-               const smt::SmtSolver & s, PonoOptions opt)
+Prover::Prover(const Property & p,
+               const TransitionSystem & ts,
+               const smt::SmtSolver & s,
+               PonoOptions opt)
     : initialized_(false),
       solver_(s),
       to_prover_solver_(s),
@@ -39,6 +41,11 @@ Prover::Prover(const Property & p, const TransitionSystem & ts,
       orig_ts_(ts),
       ts_(ts, to_prover_solver_),
       unroller_(ts_),
+      bad_(solver_->make_term(
+          smt::PrimOp::Not,
+          ts_.solver() == orig_property_.solver()
+              ? orig_property_.prop()
+              : to_prover_solver_.transfer_term(orig_property_.prop(), BOOL))),
       options_(opt),
       engine_(Engine::NONE)
 {
@@ -53,16 +60,6 @@ void Prover::initialize()
   }
 
   reached_k_ = -1;
-
-  if (!bad_) {
-    // initialize bad_ if it is not set already
-    const Term & prop_term =
-        (ts_.solver() == orig_property_.solver())
-            ? orig_property_.prop()
-            : to_prover_solver_.transfer_term(orig_property_.prop(), BOOL);
-    bad_ = solver_->make_term(smt::PrimOp::Not, prop_term);
-    assert(ts_.only_curr(bad_));
-  }
 
   if (!ts_.only_curr(bad_)) {
     throw PonoException("Property should not contain inputs or next state variables");

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -160,6 +160,8 @@ bool Prover::witness(std::vector<UnorderedTermMap> & out)
   return success;
 }
 
+size_t Prover::witness_length() const { return reached_k_ + 1; }
+
 Term Prover::invar()
 {
   if (!invar_)

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -192,6 +192,7 @@ Term Prover::to_orig_ts(Term t, SortKind sk)
     for (const auto &v : orig_ts_.inputvars()) {
       cache[to_prover_solver_.transfer_term(v)] = v;
     }
+    // TODO: need a to add UFs to the cache also
     return to_orig_ts_solver.transfer_term(t, sk);
   }
 }

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -120,7 +120,7 @@ class Prover
 
   Engine engine_;
 
-  // NOTE: both witness_ and invar_ are use terms from the engine's solver
+  // NOTE: both witness_ and invar_ use terms from the engine's solver
 
   std::vector<smt::UnorderedTermMap> witness_; ///< populated by a witness if a CEX is found
 

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -52,6 +52,14 @@ class Prover
 
   virtual bool witness(std::vector<smt::UnorderedTermMap> & out);
 
+  /** Returns length of the witness
+   *  this can be cheaper than actually computing the witness
+   *  by default returns reached_k_+1, because reached_k_ was the
+   *  last step that completed without finding a bug
+   *  but some algorithms such as IC3 might need to follow the trace
+   */
+  virtual size_t witness_length() const;
+
   /** Gives a term representing an inductive invariant over current state
    * variables. Only valid if the property has been proven true. Only supported
    * by some engines

--- a/modifiers/mod_init_prop.h
+++ b/modifiers/mod_init_prop.h
@@ -28,7 +28,7 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
   logger.log(1, "Modifying init and prop");
 
   // copy constraints from before we start modifying the system
-  smt::TermVec constraints = ts.constraints();
+  std::vector<std::pair<smt::Term, bool>> constraints = ts.constraints();
 
   // replace prop if it's not already a literal
   smt::Sort boolsort = ts.make_sort(smt::BOOL);
@@ -49,12 +49,8 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
   ts.set_init(initstate1);
 
   // NOTE: relies on feature of ts to not add constraint to init
-  for (const auto & c : constraints) {
-    // TODO possibly refactor constraints so next state versions aren't
-    // automatically added
-    if (ts.no_next(c)) {
-      ts.add_constraint(ts.make_term(smt::Implies, initstate1, c), false);
-    }
+  for (const auto & e : constraints) {
+    ts.add_constraint(ts.make_term(smt::Implies, initstate1, e.first), false);
   }
 
   ts.assign_next(initstate1, ts.make_term(false));
@@ -73,9 +69,10 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
 // for a property violation over the next-state variables
 void prop_in_trans(TransitionSystem & ts, const smt::Term & prop)
 {
-  // NOTE: CRUCIAL that we pass false, false here
+  // NOTE: CRUCIAL that we pass false here
   // cannot add to init or the next states
-  ts.add_constraint(prop, false, false);
+  // passing false prevents that
+  ts.add_constraint(prop, false);
 }
 
 }  // namespace pono

--- a/modifiers/mod_init_prop.h
+++ b/modifiers/mod_init_prop.h
@@ -46,15 +46,17 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
   smt::TermVec init_constraints;
   conjunctive_partition(init, init_constraints, true);
 
-  ts.set_init(initstate1);
-
   // NOTE: relies on feature of ts to not add constraint to init
   for (const auto & e : constraints) {
-    // TODO fix this! Need to allow adding to next but not init
-    ts.add_constraint(ts.make_term(smt::Implies, initstate1, e.first), false);
+    ts.add_constraint(ts.make_term(smt::Implies, initstate1, e.first),
+                      e.second);
   }
 
   ts.assign_next(initstate1, ts.make_term(false));
+
+  // adding the constraints above might have put constraints in init
+  // overwrite that now
+  ts.set_init(initstate1);
   ts.constrain_init(new_prop);
 
   // add initial state constraints for initstate1

--- a/modifiers/mod_init_prop.h
+++ b/modifiers/mod_init_prop.h
@@ -50,6 +50,7 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
 
   // NOTE: relies on feature of ts to not add constraint to init
   for (const auto & e : constraints) {
+    // TODO fix this! Need to allow adding to next but not init
     ts.add_constraint(ts.make_term(smt::Implies, initstate1, e.first), false);
   }
 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -389,9 +389,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
           profiling_log_filename_ = opt.arg;
 #endif
           break;
-        case MOD_INIT_PROP: mod_init_prop_ = true;
-        case NO_ASSUME_PROP: assume_prop_ = false;
-        case CEGP_ABS_VALS: cegp_abs_vals_ = true;
+        case MOD_INIT_PROP: mod_init_prop_ = true; break;
+        case NO_ASSUME_PROP: assume_prop_ = false; break;
+        case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -53,7 +53,8 @@ enum optionIndex
   MBIC3_INDGEN_MODE,
   PROFILING_LOG_FILENAME,
   MOD_INIT_PROP,
-  NO_ASSUME_PROP
+  NO_ASSUME_PROP,
+  CEGP_ABS_VALS
 };
 
 struct Arg : public option::Arg
@@ -263,6 +264,13 @@ const option::Descriptor usage[] = {
     Arg::None,
     "  --no-assume-prop \tdisable assuming property in pre-state (default "
     "enabled)" },
+  { CEGP_ABS_VALS,
+    0,
+    "",
+    "cegp-abs-vals",
+    Arg::None,
+    "  --cegp-abs-vals \tabstract values in ceg-prophecy-arrays (only "
+    "supported for IC3IA)" },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -383,6 +391,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
           break;
         case MOD_INIT_PROP: mod_init_prop_ = true;
         case NO_ASSUME_PROP: assume_prop_ = false;
+        case CEGP_ABS_VALS: cegp_abs_vals_ = true;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -81,7 +81,8 @@ class PonoOptions
         cegp_axiom_red_(default_cegp_axiom_red_),
         profiling_log_filename_(default_profiling_log_filename_),
         mod_init_prop_(default_mod_init_prop_),
-        assume_prop_(default_assume_prop_)
+        assume_prop_(default_assume_prop_),
+        cegp_abs_vals_(default_cegp_abs_vals_)
   {
   }
 
@@ -121,6 +122,7 @@ class PonoOptions
   std::string profiling_log_filename_;
   bool mod_init_prop_;  ///< replace init and prop with boolean state vars
   bool assume_prop_;    ///< assume property in pre-state
+  bool cegp_abs_vals_;  ///< abstract values on top of ceg-prophecy-arrays
 
  private:
   // Default options
@@ -147,6 +149,7 @@ class PonoOptions
   static const std::string default_profiling_log_filename_;
   static const bool default_mod_init_prop_ = false;
   static const bool default_assume_prop_ = true;
+  static const bool default_cegp_abs_vals_ = false;
 };
 
 }  // namespace pono

--- a/pono.cpp
+++ b/pono.cpp
@@ -28,6 +28,11 @@
 #endif
 
 #include "core/fts.h"
+// TODO hide these in make_prover
+#include "engines/ceg_prophecy_arrays.h"
+#include "engines/cegar_values.h"
+#include "engines/ic3ia.h"
+// end TODO
 #include "frontends/btor2_encoder.h"
 #include "frontends/smv_encoder.h"
 #include "modifiers/control_signals.h"
@@ -64,7 +69,14 @@ ProverResult check_prop(PonoOptions pono_options,
   Engine eng = pono_options.engine_;
 
   std::shared_ptr<Prover> prover;
-  if (pono_options.ceg_prophecy_arrays_) {
+  if (pono_options.cegp_abs_vals_) {
+    if (eng != IC3IA_ENGINE || !pono_options.ceg_prophecy_arrays_) {
+      throw PonoException(
+          "--cegp-abs-vals only supported with -e ic3ia --ceg-prophecy-arrays");
+    }
+    prover = std::make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(
+        p, ts, s, pono_options);
+  } else if (pono_options.ceg_prophecy_arrays_) {
     prover = make_ceg_proph_prover(eng, p, ts, s, pono_options);
   } else {
     prover = make_prover(eng, p, ts, s, pono_options);

--- a/pono.cpp
+++ b/pono.cpp
@@ -28,11 +28,6 @@
 #endif
 
 #include "core/fts.h"
-// TODO hide these in make_prover
-#include "engines/ceg_prophecy_arrays.h"
-#include "engines/cegar_values.h"
-#include "engines/ic3ia.h"
-// end TODO
 #include "frontends/btor2_encoder.h"
 #include "frontends/smv_encoder.h"
 #include "modifiers/control_signals.h"
@@ -46,9 +41,6 @@
 #include "utils/logger.h"
 #include "utils/make_provers.h"
 #include "utils/ts_analysis.h"
-
-// TEMP do array abstraction directly here
-#include "modifiers/array_abstractor.h"
 
 using namespace pono;
 using namespace smt;
@@ -70,12 +62,7 @@ ProverResult check_prop(PonoOptions pono_options,
 
   std::shared_ptr<Prover> prover;
   if (pono_options.cegp_abs_vals_) {
-    if (eng != IC3IA_ENGINE || !pono_options.ceg_prophecy_arrays_) {
-      throw PonoException(
-          "--cegp-abs-vals only supported with -e ic3ia --ceg-prophecy-arrays");
-    }
-    prover = std::make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(
-        p, ts, s, pono_options);
+    prover = make_cegar_values_prover(eng, p, ts, s, pono_options);
   } else if (pono_options.ceg_prophecy_arrays_) {
     prover = make_ceg_proph_prover(eng, p, ts, s, pono_options);
   } else {

--- a/python/pono_imp.pxd
+++ b/python/pono_imp.pxd
@@ -1,4 +1,6 @@
 from libc.stdint cimport uint64_t
+from libcpp cimport bool
+from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
 from libcpp.unordered_set cimport unordered_set
@@ -19,7 +21,7 @@ cdef extern from "core/ts.h" namespace "pono":
         void assign_next(const c_Term & state, const c_Term & val) except +
         void add_invar(const c_Term & constraint) except +
         void constrain_inputs(const c_Term & constraint) except +
-        void add_constraint(const c_Term & constraint) except +
+        void add_constraint(const c_Term & constraint, bint to_init_and_next) except +
         void name_term(const string name, const c_Term & t) except +
         c_Term make_inputvar(const string name, const c_Sort & sort) except +
         c_Term make_statevar(const string name, const c_Sort & sort) except +
@@ -34,7 +36,7 @@ cdef extern from "core/ts.h" namespace "pono":
         c_Term trans() except +
         const c_UnorderedTermMap & state_updates() except +
         unordered_map[string, c_Term] & named_terms() except +
-        const c_TermVec & constraints() except +
+        const vector[pair[c_Term, bool]] & constraints() except +
         bint is_functional() except +
         bint is_deterministic() except +
         void drop_state_updates(const c_TermVec & svs) except +

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -1,5 +1,7 @@
 from cython.operator cimport dereference as dref, preincrement as inc
 from libc.stdint cimport uintptr_t
+from libcpp cimport bool as cbool
+from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.unordered_set cimport unordered_set
 from libcpp.unordered_map cimport unordered_map
@@ -77,8 +79,8 @@ cdef class __AbstractTransitionSystem:
     def constrain_inputs(self, Term constraint):
         dref(self.cts).constrain_inputs(constraint.ct)
 
-    def add_constraint(self, Term constraint):
-        dref(self.cts).add_constraint(constraint.ct)
+    def add_constraint(self, Term constraint, bint to_init_and_next=True):
+        dref(self.cts).add_constraint(constraint.ct, to_init_and_next)
 
     def name_term(self, str name, Term t):
         dref(self.cts).name_term(name.encode(), t.ct)
@@ -187,11 +189,11 @@ cdef class __AbstractTransitionSystem:
     @property
     def constraints(self):
         convec = []
-        cdef c_TermVec c_cons = dref(self.cts).constraints()
-        for t in c_cons:
+        cdef vector[pair[c_Term, cbool]] c_cons = dref(self.cts).constraints()
+        for e in c_cons:
             python_term = Term(self._solver)
-            python_term.ct = t
-            convec.append(python_term)
+            python_term.ct = e.first
+            convec.append((python_term, e.second))
         return convec
 
     @property

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ pono_add_test(test_ic3)
 pono_add_test(test_ic3ia)
 pono_add_test(test_msat_ic3ia)
 pono_add_test(test_ceg_prophecy_arrays)
+pono_add_test(test_cegar_values)
 pono_add_test(test_term_analysis)
 pono_add_test(test_walkers)
 

--- a/tests/python/test_ts.py
+++ b/tests/python/test_ts.py
@@ -31,7 +31,7 @@ def test_query_fts(create_solver):
     assert len(ts.statevars) == 2
     assert len(ts.state_updates) == 1
     assert len(ts.named_terms) == 5, "expecting a named term for each curr/next state var and explicitly named term"
-    assert len(ts.constraints) == 2, "expecting the added constraint over current and next state vars"
+    assert len(ts.constraints) == 1, "expecting the added constraint over current state vars only"
     assert ts.is_functional()
     assert not ts.is_deterministic(), "not deterministic because no update for y"
 
@@ -67,7 +67,7 @@ def test_query_rts(create_solver):
     assert len(ts.statevars) == 2
     assert len(ts.state_updates) == 1
     assert len(ts.named_terms) == 5, "expecting a named term for each curr/next state var and explicitly named term"
-    assert len(ts.constraints) == 2, "expecting the added constraint over current and next state vars"
+    assert len(ts.constraints) == 1, "expecting the added constraint over current state vars only"
     assert not ts.is_functional()
 
     states = list(ts.statevars)

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 #include "smt/available_solvers.h"
 #include "utils/logger.h"
+#include "utils/ts_analysis.h"
 
 // need mathsat for ic3ia
 #ifdef WITH_MSAT
@@ -47,6 +48,11 @@ TEST(CegValues, Simple)
 
   ProverResult r = ceg->check_until(5);
   ASSERT_EQ(r, ProverResult::TRUE);
+
+  Term invar = ceg->invar();
+  cout << "got invariant " << invar << endl;
+  // can't check invariant because it has prophecy variables in it
+  // TODO consider checking the universally quantified version with CVC4
 }
 
 }  // namespace pono_tests

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -1,0 +1,55 @@
+#include "engines/ceg_prophecy_arrays.h"
+#include "engines/cegar_values.h"
+#include "engines/ic3ia.h"
+#include "gtest/gtest.h"
+#include "smt/available_solvers.h"
+#include "utils/logger.h"
+
+// need mathsat for ic3ia
+#ifdef WITH_MSAT
+
+using namespace pono;
+using namespace smt;
+using namespace std;
+
+namespace pono_tests {
+
+TEST(CegValues, Simple)
+{
+  set_global_logger_verbosity(1);
+
+  SmtSolver s = create_solver(MSAT);
+  RelationalTransitionSystem rts(s);
+  Sort bvsort8 = rts.make_sort(BV, 8);
+  Sort bvsort32 = rts.make_sort(BV, 32);
+  Sort arrsort = rts.make_sort(ARRAY, bvsort8, bvsort32);
+  Term i = rts.make_statevar("i", bvsort8);
+  Term j = rts.make_statevar("j", bvsort8);
+  Term d = rts.make_statevar("d", bvsort32);
+  Term a = rts.make_statevar("a", arrsort);
+
+  Term constarr0 = rts.make_term(rts.make_term(0, bvsort32), arrsort);
+  rts.set_init(rts.make_term(Equal, a, constarr0));
+  rts.assign_next(
+      a,
+      rts.make_term(Ite,
+                    rts.make_term(BVUlt, d, rts.make_term(200, bvsort32)),
+                    rts.make_term(Store, a, i, d),
+                    a));
+
+  Term prop_term = rts.make_term(
+      BVUlt, rts.make_term(Select, a, j), rts.make_term(200, bvsort32));
+  Property prop(s, prop_term);
+
+  // TODO create a make_ command for this
+  shared_ptr<Prover> ceg =
+      make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(prop, rts, s);
+
+  // TODO actually run the system
+  // ProverResult r = ceg->check_until(5);
+  // ASSERT_EQ(r, ProverResult::TRUE);
+}
+
+}  // namespace pono_tests
+
+#endif

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 namespace pono_tests {
 
-TEST(CegValues, Simple)
+TEST(CegValues, SimpleSafe)
 {
   set_global_logger_verbosity(1);
 
@@ -53,6 +53,43 @@ TEST(CegValues, Simple)
   cout << "got invariant " << invar << endl;
   // can't check invariant because it has prophecy variables in it
   // TODO consider checking the universally quantified version with CVC4
+}
+
+TEST(CegValues, SimpleUnsafe)
+{
+  set_global_logger_verbosity(1);
+
+  SmtSolver s = create_solver(MSAT);
+  RelationalTransitionSystem rts(s);
+  Sort bvsort8 = rts.make_sort(BV, 8);
+  Sort bvsort32 = rts.make_sort(BV, 32);
+  Sort arrsort = rts.make_sort(ARRAY, bvsort8, bvsort32);
+  Term i = rts.make_statevar("i", bvsort8);
+  Term j = rts.make_statevar("j", bvsort8);
+  Term d = rts.make_statevar("d", bvsort32);
+  Term a = rts.make_statevar("a", arrsort);
+
+  Term constarr0 = rts.make_term(rts.make_term(0, bvsort32), arrsort);
+  rts.set_init(rts.make_term(Equal, a, constarr0));
+  rts.assign_next(
+      a,
+      rts.make_term(Ite,
+                    // off by one in the update
+                    // e.g. using <= instead of <
+                    rts.make_term(BVUle, d, rts.make_term(200, bvsort32)),
+                    rts.make_term(Store, a, i, d),
+                    a));
+
+  Term prop_term = rts.make_term(
+      BVUlt, rts.make_term(Select, a, j), rts.make_term(200, bvsort32));
+  Property prop(s, prop_term);
+
+  // TODO create a make_ command for this
+  shared_ptr<Prover> ceg =
+      make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(prop, rts, s);
+
+  ProverResult r = ceg->check_until(5);
+  ASSERT_EQ(r, ProverResult::FALSE);
 }
 
 }  // namespace pono_tests

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -45,11 +45,8 @@ TEST(CegValues, Simple)
   shared_ptr<Prover> ceg =
       make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(prop, rts, s);
 
-  ceg->initialize();
-
-  // TODO actually run the system
-  // ProverResult r = ceg->check_until(5);
-  // ASSERT_EQ(r, ProverResult::TRUE);
+  ProverResult r = ceg->check_until(5);
+  ASSERT_EQ(r, ProverResult::TRUE);
 }
 
 }  // namespace pono_tests

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -45,6 +45,8 @@ TEST(CegValues, Simple)
   shared_ptr<Prover> ceg =
       make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(prop, rts, s);
 
+  ceg->initialize();
+
   // TODO actually run the system
   // ProverResult r = ceg->check_until(5);
   // ASSERT_EQ(r, ProverResult::TRUE);

--- a/utils/fcoi.cpp
+++ b/utils/fcoi.cpp
@@ -160,7 +160,7 @@ void FunctionalConeOfInfluence::print_coi_info(const TermVec & terms)
   for (auto statevar : ts_.statevars()) cout << "  " << statevar << "\n";
 
   cout << "constraints: \n";
-  for (auto constr : ts_.constraints()) cout << "  " << constr << "\n";
+  for (auto constr : ts_.constraints()) cout << "  " << constr.first << "\n";
 }
 
 /* Add 'term' to 'set' if it does not already appear there. */
@@ -261,9 +261,9 @@ void FunctionalConeOfInfluence::compute_coi_trans_constraints()
   UnorderedTermSet new_coi_state_vars;
   UnorderedTermSet new_coi_input_vars;
 
-  for (auto constr : ts_.constraints()) {
-    logger.log(3, "  trans constraints--constr: {}", constr);
-    compute_term_coi(constr, new_coi_state_vars, new_coi_input_vars);
+  for (const auto & e : ts_.constraints()) {
+    logger.log(3, "  trans constraints--constr: {}", e.first);
+    compute_term_coi(e.first, new_coi_state_vars, new_coi_input_vars);
   }
 
   /* Add newly collected variables to global collections. */

--- a/utils/make_provers.cpp
+++ b/utils/make_provers.cpp
@@ -19,6 +19,7 @@
 #include "engines/bmc.h"
 #include "engines/bmc_simplepath.h"
 #include "engines/ceg_prophecy_arrays.h"
+#include "engines/cegar_values.h"
 #include "engines/ic3ia.h"
 #include "engines/interpolantmc.h"
 #include "engines/kinduction.h"
@@ -105,6 +106,20 @@ shared_ptr<Prover> make_ceg_proph_prover(Engine e,
   else {
     throw PonoException("Unhandled engine");
   }
+}
+
+shared_ptr<Prover> make_cegar_values_prover(Engine e,
+                                            const Property & p,
+                                            const TransitionSystem & ts,
+                                            const SmtSolver & slv,
+                                            PonoOptions opts)
+{
+  if (e != IC3IA_ENGINE || !opts.ceg_prophecy_arrays_) {
+    throw PonoException(
+        "CegarValues currently only supports IC3IA with CegProphecyArrays");
+  }
+
+  return make_shared<CegarValues<CegProphecyArrays<IC3IA>>>(p, ts, slv, opts);
 }
 
 }  // namespace pono

--- a/utils/make_provers.h
+++ b/utils/make_provers.h
@@ -34,4 +34,11 @@ std::shared_ptr<Prover> make_ceg_proph_prover(Engine e,
                                               const smt::SmtSolver & slv,
                                               PonoOptions opts = PonoOptions());
 
+std::shared_ptr<Prover> make_cegar_values_prover(
+    Engine e,
+    const Property & p,
+    const TransitionSystem & ts,
+    const smt::SmtSolver & slv,
+    PonoOptions opts = PonoOptions());
+
 }  // namespace pono

--- a/utils/ts_manipulation.cpp
+++ b/utils/ts_manipulation.cpp
@@ -1,0 +1,36 @@
+/*********************                                                        */
+/*! \file ts_manipulation.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Useful functions for creating and manipulating transition systems
+**
+**
+**/
+
+#include "utils/ts_manipulation.h"
+
+#include "core/fts.h"
+#include "core/rts.h"
+
+using namespace smt;
+using namespace std;
+
+namespace pono {
+
+TransitionSystem create_fresh_ts(bool functional, const SmtSolver & solver)
+{
+  if (functional) {
+    return FunctionalTransitionSystem(solver);
+  } else {
+    return RelationalTransitionSystem(solver);
+  }
+}
+
+}  // namespace pono

--- a/utils/ts_manipulation.h
+++ b/utils/ts_manipulation.h
@@ -1,0 +1,26 @@
+/*********************                                                        */
+/*! \file ts_manipulation.h
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Useful functions for creating and manipulating transition systems
+**
+**
+**/
+#pragma once
+
+#include "core/ts.h"
+
+namespace pono {
+
+// returns an empty system over the given solver
+TransitionSystem create_fresh_ts(bool functional,
+                                 const smt::SmtSolver & solver);
+
+}  // namespace pono


### PR DESCRIPTION
This PR adds initial support for a CEGAR loop that abstracts values. There are several limitations, but those can be removed with future PRs. In particular,

* it currently **only** supports `CegProphecyArrays<IC3IA>` as the backend prover, because that is the main motivation for this
* it currently abstracts **all** values. A future PR could allow a cutoff size

A few things I needed to change:
* since we are nesting CEGAR loops, we needed to specify which version of `cegar_abstract/cegar_refine` was running
* similarly, it was difficult to abstract `bad_` as-is because that happened before `initialize`. Instead, I just set `bad_` in the constructor initializer list

I ran into some unrelated issues here which are out-of-scope for this PR, but I left a TODO. The issue was with transferring the engine's view of an invariant to the original TS. We need to cache all the symbols, but it was not considering UFs. This came up because there are UFs in the invariant from the `CegProphecyArrays` abstraction.