### PR TITLE
Temporary configuration fix for CegProphecyArrays

### DIFF
--- a/pono.cpp
+++ b/pono.cpp
@@ -166,8 +166,15 @@ int main(int argc, char ** argv)
   try {
     // no logging by default
     // could create an option for logging solvers in the future
-    SmtSolver s = create_solver_for(
-        pono_options.smt_solver_, pono_options.engine_, false);
+
+    // HACK bool_model_generation for IC3IA breaks CegProphecyArrays
+    // longer term fix will use a different solver in CegProphecyArrays,
+    // but for now just force full model generation in that case
+
+    SmtSolver s = create_solver_for(pono_options.smt_solver_,
+                                    pono_options.engine_,
+                                    false,
+                                    pono_options.ceg_prophecy_arrays_);
 
     // limitations with COI
     if (pono_options.static_coi_) {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -110,7 +110,10 @@ SmtSolver create_solver(SolverEnum se,
   return s;
 }
 
-SmtSolver create_solver_for(SolverEnum se, Engine e, bool logging)
+SmtSolver create_solver_for(SolverEnum se,
+                            Engine e,
+                            bool logging,
+                            bool full_model)
 {
   bool ic3_engine = ic3_variants.find(e) != ic3_variants.end();
   if (se != MSAT) {
@@ -122,16 +125,11 @@ SmtSolver create_solver_for(SolverEnum se, Engine e, bool logging)
     // These will be managed by the solver object
     // don't need to destroy
     unordered_map<string, string> opts({ { "model_generation", "true" } });
-    // TEMPORARY FIX
-    // this breaks CegProphecyArrays as-is
-    // because the model evaluation doesn't work
-    // longer term fix will use a different solver
-    // TODO replace this once CegProphecyArrays is updated
-    // if (e == IC3IA_ENGINE) {
-    //   // only need boolean model
-    //   opts["bool_model_generation"] = "true";
-    //   opts["model_generation"] = "false";
-    // }
+    if (!full_model && e == IC3IA_ENGINE) {
+      // only need boolean model
+      opts["bool_model_generation"] = "true";
+      opts["model_generation"] = "false";
+    }
     msat_config cfg = get_msat_config_for_ic3(false, opts);
     msat_env env = msat_create_env(cfg);
     SmtSolver s = std::make_shared<MsatSolver>(cfg, env);

--- a/smt/available_solvers.h
+++ b/smt/available_solvers.h
@@ -36,7 +36,15 @@ smt::SmtSolver create_solver(smt::SolverEnum se, bool logging=false,
 
 // same as create_solver but will set reasonable options
 // for particular engines (mostly IC3-variants)
-smt::SmtSolver create_solver_for(smt::SolverEnum se, Engine e, bool logging);
+// the full_model parameter forces a solver configuration that supports full
+// model generation if it is false, it can still enable model generation
+// depending on the engine
+// TODO that is a hack fix for CegProphecyArrays. Remove it once
+// CegProphecyArrays uses it's own solver
+smt::SmtSolver create_solver_for(smt::SolverEnum se,
+                                 Engine e,
+                                 bool logging,
+                                 bool full_model = false);
 
 // same as create_solver but will set reasonable options
 // for a reducing solver (e.g. produce-models off)


### PR DESCRIPTION
As discussed on Zoom, this PR creates a temporary (hack) fix for the `--ceg-prophecy-arrays` option. The best configuration for `IC3IA` with `mathsat` as the underlying solver uses the `bool_model_generation` option, but unfortunately that breaks `CegProphecyArrays`. The long term fix is to use a fresh solver in `CegProphecyArrays` without that configuration but since that is fairly nontrivial, we are leaving that fix for later. For now, just disable that option if we're running `CegProphecyArrays`.