### PR TITLE
Minor: Don't re-add property to invariant frame

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -416,7 +416,6 @@ ProverResult IC3Base::step(int i)
       // which is the frame that just had all terms
       // from the previous frames propagated
       invar_ = get_frame_term(j + 1);
-      invar_ = solver_->make_term(And, invar_, smart_not(bad_));
       return ProverResult::TRUE;
     }
   }


### PR DESCRIPTION
Adding the property to the frame to get the invariant is no longer needed after https://github.com/upscale-project/pono/pull/202.