### PR TITLE
Fix in mod-init-prop

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -530,10 +530,24 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   predset_.clear();
   predlbls_.clear();
 
+  // this is an optimization and a fix for some options
+  // if using mathsat with bool_model_generation
+  // it will fail to get the value of symbols that don't
+  // appear in the query
+  // thus we don't include those symbols in our cubes
+
+  UnorderedTermSet used_symbols;
+  get_free_symbolic_consts(ts_.init(), used_symbols);
+  get_free_symbolic_consts(ts_.trans(), used_symbols);
+  get_free_symbolic_consts(bad_, used_symbols);
+
   // reset init and trans -- done with calling ia_.do_abstraction
   // then add all boolean constants as (precise) predicates
   for (const auto & p : ia_.do_abstraction()) {
-    preds.insert(p);
+    assert(p->is_symbolic_const());
+    if (used_symbols.find(p) != used_symbols.end()) {
+      preds.insert(p);
+    }
   }
 
   // reset the solver
@@ -548,7 +562,7 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
 // ceg-prophecy is incremental for ic3ia
 template class CegProphecyArrays<IC3IA>;
 
-// the below engines work when ceg-prophecy is non-incremental. 
+// the below engines work when ceg-prophecy is non-incremental.
 template class CegProphecyArrays<Bmc>;
 template class CegProphecyArrays<BmcSimplePath>;
 template class CegProphecyArrays<KInduction>;

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -182,11 +182,26 @@ void IC3IA::initialize()
 void IC3IA::abstract()
 {
   const UnorderedTermSet &bool_symbols = ia_.do_abstraction();
+
+  // this is an optimization and a fix for some options
+  // if using mathsat with bool_model_generation
+  // it will fail to get the value of symbols that don't
+  // appear in the query
+  // thus we don't include those symbols in our cubes
+
+  UnorderedTermSet used_symbols;
+  get_free_symbolic_consts(ts_.init(), used_symbols);
+  get_free_symbolic_consts(ts_.trans(), used_symbols);
+  get_free_symbolic_consts(bad_, used_symbols);
+
   // add predicates automatically added by ia_
   // to our predset_
   // needed to prevent adding duplicate predicates later
   for (const auto & sym : bool_symbols) {
-    add_predicate(sym);
+    assert(sym->is_symbolic_const());
+    if (used_symbols.find(sym) != used_symbols.end()) {
+      add_predicate(sym);
+    }
   }
 
   assert(ts_.init());  // should be non-null

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -119,7 +119,7 @@ UnorderedTermSet ImplicitPredicateAbstractor::do_abstraction()
   abstracted_ = true;
 
   UnorderedTermSet conc_predicates;
-  
+
   // need to add all state variables and set behavior
   // due to incrementality, most of the variables will be already present
   // so make sure to check that

--- a/modifiers/mod_init_prop.h
+++ b/modifiers/mod_init_prop.h
@@ -57,7 +57,11 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
   // adding the constraints above might have put constraints in init
   // overwrite that now
   ts.set_init(initstate1);
-  ts.constrain_init(new_prop);
+  if (new_prop != prop)
+  {
+    // if created a delayed prop, need to assume it in the initial state
+    ts.constrain_init(new_prop);
+  }
 
   // add initial state constraints for initstate1
   for (const auto & ic : init_constraints) {

--- a/modifiers/mod_init_prop.h
+++ b/modifiers/mod_init_prop.h
@@ -39,34 +39,39 @@ smt::Term modify_init_and_prop(TransitionSystem & ts, const smt::Term & prop)
   }
 
   // replace initial states
-  smt::Term initstate1 = ts.make_statevar("__initstate1",
-                                          ts.make_sort(smt::BOOL));
+  // will become the new initial state, by itself
+  smt::Term fake_init =
+      ts.make_statevar("__fake_init", ts.make_sort(smt::BOOL));
+
+  // indicator for the actual initial state constraints
+  // which will be true in the second state of the execution
+  smt::Term initstate =
+      ts.make_statevar("__initstate", ts.make_sort(smt::BOOL));
 
   smt::Term init = ts.init();
   smt::TermVec init_constraints;
   conjunctive_partition(init, init_constraints, true);
 
-  // NOTE: relies on feature of ts to not add constraint to init
-  for (const auto & e : constraints) {
-    ts.add_constraint(ts.make_term(smt::Implies, initstate1, e.first),
-                      e.second);
+  // add initial state constraints for initstate1
+  for (const auto & ic : init_constraints) {
+    assert(ts.only_curr(ic));
+    ts.add_constraint(ts.make_term(smt::Implies, initstate, ic), true);
   }
 
-  ts.assign_next(initstate1, ts.make_term(false));
+  // NOTE: relies on feature of ts to not add constraint to init
+  for (const auto & e : constraints) {
+    ts.add_constraint(ts.make_term(smt::Implies, initstate, e.first), e.second);
+  }
+
+  ts.assign_next(fake_init, ts.make_term(false));
+  ts.assign_next(initstate,
+                 fake_init);  // becomes true one state after fake_init
 
   // adding the constraints above might have put constraints in init
   // overwrite that now
-  ts.set_init(initstate1);
-  if (new_prop != prop)
-  {
-    // if created a delayed prop, need to assume it in the initial state
-    ts.constrain_init(new_prop);
-  }
-
-  // add initial state constraints for initstate1
-  for (const auto & ic : init_constraints) {
-    ts.add_constraint(ts.make_term(smt::Implies, initstate1, ic), false);
-  }
+  ts.set_init(fake_init);
+  ts.constrain_init(ts.make_term(smt::Not, initstate));
+  ts.constrain_init(new_prop);
 
   return new_prop;
 }


### PR DESCRIPTION
I got a couple incorrect results using `--mod-init-prop` on some SMV benchmarks. It turns out it was related to an (incorrect) optimization. I thought that if the property was already a propositional literal, I didn't need to make a new one. However, due to the initstate transformation, it's important to use a delayed property regardless.