### PR TITLE
Ic3ia: exclude unused symbols from cubes

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -530,12 +530,12 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   predset_.clear();
   predlbls_.clear();
 
+  // don't add boolean symbols that are never used in the system
   // this is an optimization and a fix for some options
   // if using mathsat with bool_model_generation
   // it will fail to get the value of symbols that don't
   // appear in the query
   // thus we don't include those symbols in our cubes
-
   UnorderedTermSet used_symbols;
   get_free_symbolic_consts(ts_.init(), used_symbols);
   get_free_symbolic_consts(ts_.trans(), used_symbols);

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -530,10 +530,24 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
   predset_.clear();
   predlbls_.clear();
 
+  // this is an optimization and a fix for some options
+  // if using mathsat with bool_model_generation
+  // it will fail to get the value of symbols that don't
+  // appear in the query
+  // thus we don't include those symbols in our cubes
+
+  UnorderedTermSet used_symbols;
+  get_free_symbolic_consts(ts_.init(), used_symbols);
+  get_free_symbolic_consts(ts_.trans(), used_symbols);
+  get_free_symbolic_consts(bad_, used_symbols);
+
   // reset init and trans -- done with calling ia_.do_abstraction
   // then add all boolean constants as (precise) predicates
   for (const auto & p : ia_.do_abstraction()) {
-    preds.insert(p);
+    assert(p->is_symbolic_const());
+    if (used_symbols.find(p) != used_symbols.end()) {
+      preds.insert(p);
+    }
   }
 
   // reset the solver
@@ -548,7 +562,7 @@ void CegProphecyArrays<IC3IA>::refine_subprover_ts(const UnorderedTermSet & cons
 // ceg-prophecy is incremental for ic3ia
 template class CegProphecyArrays<IC3IA>;
 
-// the below engines work when ceg-prophecy is non-incremental. 
+// the below engines work when ceg-prophecy is non-incremental.
 template class CegProphecyArrays<Bmc>;
 template class CegProphecyArrays<BmcSimplePath>;
 template class CegProphecyArrays<KInduction>;

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -183,12 +183,12 @@ void IC3IA::abstract()
 {
   const UnorderedTermSet &bool_symbols = ia_.do_abstraction();
 
+  // don't add boolean symbols that are never used in the system
   // this is an optimization and a fix for some options
   // if using mathsat with bool_model_generation
   // it will fail to get the value of symbols that don't
   // appear in the query
   // thus we don't include those symbols in our cubes
-
   UnorderedTermSet used_symbols;
   get_free_symbolic_consts(ts_.init(), used_symbols);
   get_free_symbolic_consts(ts_.trans(), used_symbols);

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -182,11 +182,26 @@ void IC3IA::initialize()
 void IC3IA::abstract()
 {
   const UnorderedTermSet &bool_symbols = ia_.do_abstraction();
+
+  // this is an optimization and a fix for some options
+  // if using mathsat with bool_model_generation
+  // it will fail to get the value of symbols that don't
+  // appear in the query
+  // thus we don't include those symbols in our cubes
+
+  UnorderedTermSet used_symbols;
+  get_free_symbolic_consts(ts_.init(), used_symbols);
+  get_free_symbolic_consts(ts_.trans(), used_symbols);
+  get_free_symbolic_consts(bad_, used_symbols);
+
   // add predicates automatically added by ia_
   // to our predset_
   // needed to prevent adding duplicate predicates later
   for (const auto & sym : bool_symbols) {
-    add_predicate(sym);
+    assert(sym->is_symbolic_const());
+    if (used_symbols.find(sym) != used_symbols.end()) {
+      add_predicate(sym);
+    }
   }
 
   assert(ts_.init());  // should be non-null

--- a/modifiers/implicit_predicate_abstractor.cpp
+++ b/modifiers/implicit_predicate_abstractor.cpp
@@ -119,7 +119,7 @@ UnorderedTermSet ImplicitPredicateAbstractor::do_abstraction()
   abstracted_ = true;
 
   UnorderedTermSet conc_predicates;
-  
+
   // need to add all state variables and set behavior
   // due to incrementality, most of the variables will be already present
   // so make sure to check that


### PR DESCRIPTION
Note: as discussed offline, in the future we could consider having a `finalize` method for transition systems that cleans up unused symbols like this. Should probably keep the original transition system around untouched for counterexamples and whatnot though.