### PR TITLE
Disable witness generation/printing by default

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -36,7 +36,7 @@ enum optionIndex
   VERBOSITY,
   RANDOM_SEED,
   VCDNAME,
-  NOWITNESS,
+  WITNESS,
   CEGPROPHARR,
   NO_CEGP_AXIOM_RED,
   STATICCOI,
@@ -142,12 +142,12 @@ const option::Descriptor usage[] = {
     "smt-solver",
     Arg::NonEmpty,
     "  --smt-solver \tSMT Solver to use: btor or msat or cvc4." },
-  { NOWITNESS,
+  { WITNESS,
     0,
     "",
-    "no-witness",
+    "witness",
     Arg::None,
-    "  --no-witness \tDisable printing of witness." },
+    "  --witness \tPrint witness if the property is false." },
   { CEGPROPHARR,
     0,
     "",
@@ -347,9 +347,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
         case RANDOM_SEED: random_seed_ = atoi(opt.arg); break;
         case VCDNAME:
           vcd_name_ = opt.arg;
-          if (no_witness_)
-            throw PonoException(
-                "Options '--vcd' and '--no-witness' are incompatible.");
+          witness_ = true;  // implicitly enabling witness
           break;
         case SMT_SOLVER: {
           if (opt.arg == std::string("btor")) {
@@ -364,12 +362,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
           }
           break;
         }
-        case NOWITNESS:
-          no_witness_ = true;
-          if (!vcd_name_.empty())
-            throw PonoException(
-                "Options '--vcd' and '--no-witness' are incompatible.");
-          break;
+        case WITNESS: witness_ = true; break;
         case CEGPROPHARR: ceg_prophecy_arrays_ = true; break;
         case NO_CEGP_AXIOM_RED: cegp_axiom_red_ = false; break;
         case STATICCOI: static_coi_ = true; break;

--- a/options/options.h
+++ b/options/options.h
@@ -65,7 +65,7 @@ class PonoOptions
         prop_idx_(default_prop_idx_),
         bound_(default_bound_),
         verbosity_(default_verbosity_),
-        no_witness_(default_no_witness_),
+        witness_(default_witness_),
         reset_bnd_(default_reset_bnd_),
         random_seed_(default_random_seed),
         smt_solver_(default_smt_solver_),
@@ -98,7 +98,7 @@ class PonoOptions
   unsigned int bound_;
   unsigned int verbosity_;
   unsigned int random_seed_;
-  bool no_witness_;
+  bool witness_;
   std::string vcd_name_;
   std::string reset_name_;
   size_t reset_bnd_;
@@ -132,7 +132,7 @@ class PonoOptions
   static const unsigned int default_bound_ = 10;
   static const unsigned int default_verbosity_ = 0;
   static const unsigned int default_random_seed = 0;
-  static const bool default_no_witness_ = false;
+  static const bool default_witness_ = false;
   static const bool default_ceg_prophecy_arrays_ = false;
   static const bool default_static_coi_ = false;
   static const bool default_check_invar_ = false;

--- a/pono.cpp
+++ b/pono.cpp
@@ -85,7 +85,7 @@ ProverResult check_prop(PonoOptions pono_options,
     r = prover->check_until(pono_options.bound_);
   }
 
-  if (r == FALSE && !pono_options.no_witness_) {
+  if (r == FALSE && pono_options.witness_) {
     bool success = prover->witness(cex);
     if (!success) {
       logger.log(
@@ -177,12 +177,12 @@ int main(int argc, char ** argv)
 
     // limitations with COI
     if (pono_options.static_coi_) {
-      if (!pono_options.no_witness_) {
+      if (pono_options.witness_) {
         logger.log(
             0,
             "Warning: disabling witness production. Temporary restriction -- "
             "Cannot produce witness with option --static-coi");
-        pono_options.no_witness_ = true;
+        pono_options.witness_ = false;
       }
       if (pono_options.mod_init_prop_) {
         // Issue explained here:
@@ -274,7 +274,7 @@ int main(int argc, char ** argv)
       if (res == FALSE) {
         cout << "sat" << endl;
         cout << "b" << pono_options.prop_idx_ << endl;
-        assert(!pono_options.no_witness_ || !cex.size());
+        assert(pono_options.witness_ || !cex.size());
         if (cex.size()) {
           print_witness_btor(btor_enc, cex);
           if (!pono_options.vcd_name_.empty()) {
@@ -358,14 +358,14 @@ int main(int argc, char ** argv)
 
       if (res == FALSE) {
         cout << "sat" << endl;
-        assert(!pono_options.no_witness_ || cex.size() == 0);
+        assert(pono_options.witness_ || cex.size() == 0);
         for (size_t t = 0; t < cex.size(); t++) {
           cout << "AT TIME " << t << endl;
           for (auto elem : cex[t]) {
             cout << "\t" << elem.first << " : " << elem.second << endl;
           }
         }
-        assert(!pono_options.no_witness_ || pono_options.vcd_name_.empty());
+        assert(pono_options.witness_ || pono_options.vcd_name_.empty());
         if (!pono_options.vcd_name_.empty()) {
           VCDWitnessPrinter vcdprinter(rts, cex);
           vcdprinter.dump_trace_to_file(pono_options.vcd_name_);

--- a/scripts/parallel_pono.py
+++ b/scripts/parallel_pono.py
@@ -38,15 +38,15 @@ if __name__ == "__main__":
     pono="./pono"
 
     commands = {
-        "BMC": [pono, '-e', 'bmc', '-v', verbosity_option, '-k', bound, btor_file],
+        "BMC": [pono, '-e', 'bmc', '-v', verbosity_option, '-k', bound, '--witness', btor_file],
         # "BMC+SimplePath": [pono, '--static-coi', '-e', 'bmc-sp', '-v', verbosity_option, '-k', bound, btor_file],
         "K-Induction": [pono, '--static-coi', '-e', 'ind', '-v', verbosity_option, '-k', bound, btor_file],
-        "IC3": [pono, '--check-invar', '--static-coi', '-e', 'mbic3', '-v', verbosity_option, '-k', bound, '--no-witness', btor_file],
-        "ItpIC3": [pono, '--check-invar', '--static-coi', '-e', 'mbic3', '-v', verbosity_option, '-k', bound, '--ic3-indgen-mode', '2', '--no-witness', btor_file],
+        "IC3": [pono, '--check-invar', '--static-coi', '-e', 'mbic3', '-v', verbosity_option, '-k', bound, btor_file],
+        "ItpIC3": [pono, '--check-invar', '--static-coi', '-e', 'mbic3', '-v', verbosity_option, '-k', bound, '--ic3-indgen-mode', '2', btor_file],
         # give interpolant based methods a shorter bound -- impractical to go too large
-        "Interpolant-based": [pono, '--check-invar', '--static-coi', '--smt-solver', 'msat', '-e', 'interp', '-v', verbosity_option, '-k', '100', '--no-witness', btor_file],
+        "Interpolant-based": [pono, '--check-invar', '--static-coi', '--smt-solver', 'msat', '-e', 'interp', '-v', verbosity_option, '-k', '100', btor_file],
         # ProphInterp-Arrays uses a relational system -- can't use static-coi
-        "ProphInterp-Arrays": [pono, '--static-coi', '--smt-solver', 'msat', '-e', 'interp', '-v', verbosity_option, '-k', '100', '--ceg-prophecy-arrays', '--no-witness', btor_file]
+        "ProphInterp-Arrays": [pono, '--static-coi', '--smt-solver', 'msat', '-e', 'interp', '-v', verbosity_option, '-k', '100', '--ceg-prophecy-arrays', btor_file]
     }
 
     all_processes = []


### PR DESCRIPTION
This PR turns witness printing off by default. This seems like better default behavior as opposed to dumping a potentially very long trace to the terminal.