### PR TITLE
IC3Base: Add option to disable unsat core generalization

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -839,7 +839,6 @@ bool IC3Base::check_intersects_initial(const Term & t)
 
 void IC3Base::fix_if_intersects_initial(TermVec & to_keep, const TermVec & rem)
 {
-  assert(!solver_context_);
   // TODO: there's a tricky issue here. The reducer doesn't have the label
   // assumptions so we can't use init_label_ here. need to come up with a
   // better interface. Should we add label assumptions to reducer?

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -527,18 +527,18 @@ bool IC3Base::rel_ind_check(size_t i,
       }
     }
     assert(ic3formula_check_valid(out));
-    pop_solver_context();
-  } else {
-    // Use unsat core to get cheap generalization
+  } else if (options_.ic3_unsatcore_gen_) {
+    assert(r.is_unsat());  // not expecting to get unknown
 
+    // Use unsat core to get cheap generalization
     UnorderedTermSet core;
     solver_->get_unsat_core(core);
     assert(core.size());
 
     TermVec gen;  // cheap unsat-core generalization of c
     TermVec rem;  // conjuncts removed by unsat core
-                  // might need to be re-added if it
-                  // ends up intersecting with initial
+    // might need to be re-added if it
+    // ends up intersecting with initial
     assert(assumps_.size() == c.children.size());
     for (size_t i = 0; i < assumps_.size(); ++i) {
       if (core.find(assumps_.at(i)) == core.end()) {
@@ -548,14 +548,18 @@ bool IC3Base::rel_ind_check(size_t i,
       }
     }
 
-    pop_solver_context();
-
     fix_if_intersects_initial(gen, rem);
     assert(gen.size() >= core.size());
 
     // keep it as a conjunction for now
     out = ic3formula_conjunction(gen);
+  } else {
+    assert(r.is_unsat());  // not expecting to get unknown
+    // don't generalize with an unsat core, just keep c
+    out = c;
   }
+
+  pop_solver_context();
   assert(!solver_context_);
 
   if (r.is_sat() && get_pred) {

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -335,9 +335,12 @@ class IC3Base : public Prover
    *  @param i the frame number
    *  @param c the IC3Formula to check
    *  @param out the output collateral:
-   *         if query is UNSAT, it will do a cheap unsat-core based
-   *           generalization of c and set out to a subset
-   *           (as a conjunction still)
+   *         if query is UNSAT and ic3_unsatcore_gen is true it will
+   *           do a cheap unsat-core based generalization of c and set
+   *           out to a subset (as a conjunction still)
+   *           NOTE: depending on the IC3 variant and particular problem
+   *           this can either be helpful or over-generalize
+   *           it's worth experimenting with this option
    *         if query is SAT and get_pred is TRUE, will set out to
    *           the predecessor CTI after generalizing the predecessor
    *           (if that option is enabled)

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -243,12 +243,11 @@ const option::Descriptor usage[] = {
     "",
     "no-ic3-unsatcore-gen",
     Arg::None,
-    "  --no-ic3-unsatcore-gen \tDisable unsat core generalization during "
-    "relative "
-    " induction check. That extra generalization helps several IC3 variants "
-    " but also runs the risk of myopic over-generalization. Some IC3 variants "
-    " have better inductive generalization and do better with this "
-    "disabled. " },
+    "  --no-ic3-unsatcore-gen \tDisable unsat core generalization during"
+    " relative induction check. That extra generalization helps several IC3"
+    " variants but also runs the risk of myopic over-generalization. Some IC3"
+    " variants have better inductive generalization and do better with this"
+    " option." },
   { MBIC3_INDGEN_MODE,
     0,
     "",

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -50,6 +50,7 @@ enum optionIndex
   IC3_RESET_INTERVAL,
   IC3_GEN_MAX_ITER,
   IC3_FUNCTIONAL_PREIMAGE,
+  NO_IC3_UNSATCORE_GEN,
   MBIC3_INDGEN_MODE,
   PROFILING_LOG_FILENAME,
   PSEUDO_INIT_PROP,
@@ -237,6 +238,17 @@ const option::Descriptor usage[] = {
     "ic3-functional-preimage",
     Arg::None,
     "  --ic3-functional-preimage \tUse functional preimage in ic3." },
+  { NO_IC3_UNSATCORE_GEN,
+    0,
+    "",
+    "no-ic3-unsatcore-gen",
+    Arg::None,
+    "  --no-ic3-unsatcore-gen \tDisable unsat core generalization during "
+    "relative "
+    " induction check. That extra generalization helps several IC3 variants "
+    " but also runs the risk of myopic over-generalization. Some IC3 variants "
+    " have better inductive generalization and do better with this "
+    "disabled. " },
   { MBIC3_INDGEN_MODE,
     0,
     "",
@@ -389,6 +401,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
                 "--ic3-indgen-mode value must be between 0 and 2.");
           break;
         case IC3_FUNCTIONAL_PREIMAGE: ic3_functional_preimage_ = true; break;
+        case NO_IC3_UNSATCORE_GEN: ic3_unsatcore_gen_ = false; break;
         case PROFILING_LOG_FILENAME:
 #ifndef WITH_PROFILING
           throw PonoException(

--- a/options/options.h
+++ b/options/options.h
@@ -77,6 +77,7 @@ class PonoOptions
         ic3_reset_interval_(default_ic3_reset_interval_),
         mbic3_indgen_mode(default_mbic3_indgen_mode),
         ic3_functional_preimage_(default_ic3_functional_preimage_),
+        ic3_unsatcore_gen_(default_ic3_unsatcore_gen_),
         ceg_prophecy_arrays_(default_ceg_prophecy_arrays_),
         cegp_axiom_red_(default_cegp_axiom_red_),
         profiling_log_filename_(default_profiling_log_filename_),
@@ -118,6 +119,8 @@ class PonoOptions
                                   ///means unbounded
   unsigned int mbic3_indgen_mode;  ///< inductive generalization mode [0,2]
   bool ic3_functional_preimage_; ///< functional preimage in IC3
+  bool ic3_unsatcore_gen_;  ///< generalize a cube during relative inductiveness
+                            ///< check with unsatcore
   // ceg-prophecy-arrays options
   bool ceg_prophecy_arrays_;
   bool cegp_axiom_red_;  ///< reduce axioms with an unsat core in ceg prophecy
@@ -149,6 +152,7 @@ class PonoOptions
   static const unsigned int default_ic3_gen_max_iter_ = 2;
   static const unsigned int default_mbic3_indgen_mode = 0;
   static const bool default_ic3_functional_preimage_ = false;
+  static const bool default_ic3_unsatcore_gen_ = true;
   static const bool default_cegp_axiom_red_ = true;
   static const std::string default_profiling_log_filename_;
   static const bool default_pseudo_init_prop_ = false;


### PR DESCRIPTION
Note for future reference: the unsat core generalization is in `rel_ind_check` because for some variants the extra generalization can help, and it's not in a separate function because it's less confusing in my opinion to not pop the context of a solver in a different function (and the unsat core has to be obtained within the same context).