### PR TITLE
Turn off assume-prop in pre-state by default

### DIFF
--- a/modifiers/mod_ts_prop.cpp
+++ b/modifiers/mod_ts_prop.cpp
@@ -100,4 +100,12 @@ TransitionSystem pseudo_init_and_prop(TransitionSystem & ts, Term & prop)
   return rts;
 }
 
+void prop_in_trans(TransitionSystem & ts, const Term & prop)
+{
+  // NOTE: CRUCIAL that we pass false here
+  // cannot add to init or the next states
+  // passing false prevents that
+  ts.add_constraint(prop, false);
+}
+
 }  // namespace pono

--- a/modifiers/mod_ts_prop.h
+++ b/modifiers/mod_ts_prop.h
@@ -37,12 +37,6 @@ TransitionSystem pseudo_init_and_prop(TransitionSystem & ts, smt::Term & prop);
 // optimization to assume the property in the pre-state
 // although confusing, this is sound as long as you always check
 // for a property violation over the next-state variables
-void prop_in_trans(TransitionSystem & ts, const smt::Term & prop)
-{
-  // NOTE: CRUCIAL that we pass false here
-  // cannot add to init or the next states
-  // passing false prevents that
-  ts.add_constraint(prop, false);
-}
+void prop_in_trans(TransitionSystem & ts, const smt::Term & prop);
 
 }  // namespace pono

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -53,7 +53,7 @@ enum optionIndex
   MBIC3_INDGEN_MODE,
   PROFILING_LOG_FILENAME,
   PSEUDO_INIT_PROP,
-  NO_ASSUME_PROP,
+  ASSUME_PROP,
   CEGP_ABS_VALS,
   CEGP_ABS_VALS_CUTOFF,
   PROMOTE_INPUTVARS
@@ -260,13 +260,13 @@ const option::Descriptor usage[] = {
     "  --pseudo-init-prop \tReplace init and prop with state variables -- can "
     "extend trace by up to two steps. Recommended for use with ic3ia. "
     "Important note: will promote system to be relational" },
-  { NO_ASSUME_PROP,
+  { ASSUME_PROP,
     0,
     "",
-    "no-assume-prop",
+    "assume-prop",
     Arg::None,
-    "  --no-assume-prop \tdisable assuming property in pre-state (default "
-    "enabled)" },
+    "  --assume-prop \tenable assuming property in pre-state (default "
+    "disabled)" },
   { CEGP_ABS_VALS,
     0,
     "",
@@ -399,7 +399,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
 #endif
           break;
         case PSEUDO_INIT_PROP: pseudo_init_prop_ = true; break;
-        case NO_ASSUME_PROP: assume_prop_ = false; break;
+        case ASSUME_PROP: assume_prop_ = true; break;
         case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;
         case CEGP_ABS_VALS_CUTOFF: cegp_abs_vals_cutoff_ = atoi(opt.arg); break;
         case PROMOTE_INPUTVARS: promote_inputvars_ = true; break;

--- a/options/options.h
+++ b/options/options.h
@@ -152,7 +152,7 @@ class PonoOptions
   static const bool default_cegp_axiom_red_ = true;
   static const std::string default_profiling_log_filename_;
   static const bool default_pseudo_init_prop_ = false;
-  static const bool default_assume_prop_ = true;
+  static const bool default_assume_prop_ = false;
   static const bool default_cegp_abs_vals_ = false;
   static const size_t default_cegp_abs_vals_cutoff_ = 100;
   static const bool default_promote_inputvars_ = false;


### PR DESCRIPTION
This PR sets `assume_prop_` to false by default. It can now be enabled with `--assume-prop`.