### PR TITLE
Remove set from SMV grammar

### DIFF
--- a/frontends/smvparser.l
+++ b/frontends/smvparser.l
@@ -80,7 +80,6 @@ boolean   {return pono::smvparser::make_bool_type(_encoder.loc);}
 real  {return pono::smvparser::make_real_type(_encoder.loc);}
 integer   {return pono::smvparser::make_integer_type(_encoder.loc);}
 word   {return pono::smvparser::make_tok_word(_encoder.loc);}
-set {return pono::smvparser::make_tok_set(_encoder.loc);}
 clock {return pono::smvparser::make_time_type(_encoder.loc);}
 in {return pono::smvparser::make_OP_IN(_encoder.loc);}
 

--- a/frontends/smvparser.y
+++ b/frontends/smvparser.y
@@ -50,7 +50,7 @@
 %token ENDL
 
 %token <std::string> integer_val neg_integer_val real_val fraction_prefix exponential_prefix
-%token bool_type integer_type real_type set_tok array_tok
+%token bool_type integer_type real_type array_tok
 %token <std::string> word_index1 word_index2
 %token <std::string> tok_name
 %token <bool> TOK_TRUE TOK_FALSE
@@ -1225,7 +1225,7 @@ simple_expr: constant {
                throw PonoException("No union");
             }
             |"{" set_body_expr "}" {
-               throw PonoException("No set");
+               throw PonoException("No enumerated types or sets");
             }
             | basic_expr OP_IN basic_expr {
                throw PonoException("No array");


### PR DESCRIPTION
Sets and enumerated types are not currently supported. Furthermore, there are some benchmarks with variables named `set` that `nuXmv` accepts but Pono fails to parse. Since it's not supported, this PR just removes `set` from the grammar for now.