### PR TITLE
Fix for constraints after promoting inputvars

### DIFF
--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -386,19 +386,6 @@ void TransitionSystem::add_inputvar(const Term & v)
   name_term(v->to_string(), v);
 }
 
-Term TransitionSystem::promote_inputvar(Term iv)
-{
-  assert(iv);
-  size_t num_erased = inputvars_.erase(iv);
-  if (!num_erased) {
-    throw PonoException("Cannot promote non-inputvars: " + iv->to_string());
-  }
-
-  Term nv = solver_->make_symbol(iv->to_string() + ".next", iv->get_sort());
-  add_statevar(iv, nv);
-  return nv;
-}
-
 // term building methods -- forwards to SmtSolver solver_
 
 Sort TransitionSystem::make_sort(const std::string name, uint64_t arity)

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -230,7 +230,7 @@ void TransitionSystem::constrain_inputs(const Term & constraint)
 
   if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
-    constraints_.push_back({ constraint, false });
+    constraints_.push_back({ constraint, true });
   } else {
     throw PonoException("Cannot have next-states in an input constraint.");
   }
@@ -254,7 +254,7 @@ void TransitionSystem::add_constraint(const Term & constraint,
     constraints_.push_back({ constraint, to_init_and_next });
   } else if (no_next(constraint)) {
     trans_ = solver_->make_term(And, trans_, constraint);
-    constraints_.push_back({ constraint, false });
+    constraints_.push_back({ constraint, to_init_and_next });
   } else {
     throw PonoException("Constraint cannot have next states");
   }

--- a/core/ts.h
+++ b/core/ts.h
@@ -228,6 +228,10 @@ class TransitionSystem
    *  better to copy the set first
    *  (e.g. an unused input)
    *  and once that's removed from the input set, it's gone
+   *  NOTE another issues is that constraints over input
+   *  variables might not appear in the right places anymore
+   *  better to use the promote_inputvars pass in
+   *  modifiers/mod_ts_prop.h
    */
   smt::Term promote_inputvar(smt::Term iv);
 

--- a/core/ts.h
+++ b/core/ts.h
@@ -217,24 +217,6 @@ class TransitionSystem
    */
   void add_inputvar(const smt::Term & v);
 
-  /** EXPERTS ONLY
-   *  Promote an input variable to a state variable
-   *  @param iv the input variable to promote
-   *  @return the newly created next state variable
-   *  NOTE takes by value because if taken by reference,
-   *  there could be only one reference to that variable
-   *  TRICKY: additionally, since it modifies inputvars_
-   *  should not directly iterate over ts_.inputvars()
-   *  better to copy the set first
-   *  (e.g. an unused input)
-   *  and once that's removed from the input set, it's gone
-   *  NOTE another issues is that constraints over input
-   *  variables might not appear in the right places anymore
-   *  better to use the promote_inputvars pass in
-   *  modifiers/mod_ts_prop.h
-   */
-  smt::Term promote_inputvar(smt::Term iv);
-
   // getters
   const smt::SmtSolver & solver() const { return solver_; };
 

--- a/modifiers/mod_ts_prop.cpp
+++ b/modifiers/mod_ts_prop.cpp
@@ -108,4 +108,19 @@ void prop_in_trans(TransitionSystem & ts, const Term & prop)
   ts.add_constraint(prop, false);
 }
 
+void promote_inputvars(TransitionSystem & ts)
+{
+  // this is a bit tricky. because promote_inputvar
+  // modifies inputvars_, should copy the set first
+  UnorderedTermSet inputvars = ts.inputvars();
+  for (const auto & iv : inputvars) {
+    ts.promote_inputvar(iv);
+  }
+  // need to re-evaluate all constraints that used to be over inputs
+  for (const auto & elem : ts.constraints()) {
+    ts.add_constraint(elem.first, elem.second);
+  }
+  assert(!ts.inputvars().size());
+}
+
 }  // namespace pono

--- a/modifiers/mod_ts_prop.cpp
+++ b/modifiers/mod_ts_prop.cpp
@@ -20,6 +20,7 @@
 #include "smt-switch/utils.h"
 #include "utils/logger.h"
 #include "utils/term_analysis.h"
+#include "utils/ts_manipulation.h"
 
 using namespace smt;
 using namespace std;
@@ -108,19 +109,46 @@ void prop_in_trans(TransitionSystem & ts, const Term & prop)
   ts.add_constraint(prop, false);
 }
 
-void promote_inputvars(TransitionSystem & ts)
+TransitionSystem promote_inputvars(const TransitionSystem & ts)
 {
-  // this is a bit tricky. because promote_inputvar
-  // modifies inputvars_, should copy the set first
-  UnorderedTermSet inputvars = ts.inputvars();
-  for (const auto & iv : inputvars) {
-    ts.promote_inputvar(iv);
+  SmtSolver solver = ts.solver();
+  TransitionSystem new_ts = create_fresh_ts(ts.is_functional(), solver);
+  assert(new_ts.is_functional() == ts.is_functional());
+
+  // copy over all state variables
+  for (const auto & sv : ts.statevars()) {
+    new_ts.add_statevar(sv, ts.next(sv));
   }
+
+  // copy over inputs but make them statevars
+  for (const auto & iv : ts.inputvars()) {
+    Term iv_next =
+        solver->make_symbol(iv->to_string() + ".next", iv->get_sort());
+    new_ts.add_statevar(iv, iv_next);
+  }
+
+  // set init
+  new_ts.set_init(ts.init());
+
+  // copy over state updates
+  for (const auto & elem : ts.state_updates()) {
+    new_ts.assign_next(elem.first, elem.second);
+  }
+
   // need to re-evaluate all constraints that used to be over inputs
   for (const auto & elem : ts.constraints()) {
-    ts.add_constraint(elem.first, elem.second);
+    new_ts.add_constraint(elem.first, elem.second);
   }
-  assert(!ts.inputvars().size());
+
+  // relational systems could have things added by constrain_trans
+  if (!new_ts.is_functional()) {
+    RelationalTransitionSystem & rts_view =
+        static_cast<RelationalTransitionSystem &>(new_ts);
+    rts_view.set_trans(ts.trans());
+  }
+
+  assert(!new_ts.inputvars().size());
+  return new_ts;
 }
 
 }  // namespace pono

--- a/modifiers/mod_ts_prop.h
+++ b/modifiers/mod_ts_prop.h
@@ -39,4 +39,6 @@ TransitionSystem pseudo_init_and_prop(TransitionSystem & ts, smt::Term & prop);
 // for a property violation over the next-state variables
 void prop_in_trans(TransitionSystem & ts, const smt::Term & prop);
 
+void promote_inputvars(TransitionSystem & ts);
+
 }  // namespace pono

--- a/modifiers/mod_ts_prop.h
+++ b/modifiers/mod_ts_prop.h
@@ -39,6 +39,15 @@ TransitionSystem pseudo_init_and_prop(TransitionSystem & ts, smt::Term & prop);
 // for a property violation over the next-state variables
 void prop_in_trans(TransitionSystem & ts, const smt::Term & prop);
 
-void promote_inputvars(TransitionSystem & ts);
+/** Returns a new transition system with all input variables
+ *  promoted to state variables with no update (e.g. implicit inputs)
+ *  This pass automatically re-evaluates constraints
+ *  which might need to be added differently over state variables
+ *  vs input variables
+ *  @param ts the transition system to promote input variables in
+ *  @return a transition system that is semantically the same but
+ *          with no input variables (only implicit inputs)
+ */
+TransitionSystem promote_inputvars(const TransitionSystem & ts);
 
 }  // namespace pono

--- a/modifiers/prop_monitor.h
+++ b/modifiers/prop_monitor.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "core/rts.h"
 #include "core/ts.h"
 #include "utils/logger.h"
 

--- a/pono.cpp
+++ b/pono.cpp
@@ -94,13 +94,7 @@ ProverResult check_prop(PonoOptions pono_options,
   }
 
   if (pono_options.promote_inputvars_) {
-    // this is a bit tricky. because promote_inputvar
-    // modifies inputvars_, should copy the set first
-    UnorderedTermSet inputvars = ts.inputvars();
-    for (const auto & iv : inputvars) {
-      ts.promote_inputvar(iv);
-    }
-    assert(!ts.inputvars().size());
+    promote_inputvars(ts);
   }
 
   if (!ts.only_curr(prop)) {

--- a/pono.cpp
+++ b/pono.cpp
@@ -94,7 +94,8 @@ ProverResult check_prop(PonoOptions pono_options,
   }
 
   if (pono_options.promote_inputvars_) {
-    promote_inputvars(ts);
+    ts = promote_inputvars(ts);
+    assert(!ts.inputvars().size());
   }
 
   if (!ts.only_curr(prop)) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,5 +61,6 @@ pono_add_test(test_cegar_values)
 pono_add_test(test_term_analysis)
 pono_add_test(test_walkers)
 pono_add_test(test_pseudo_init_and_prop)
+pono_add_test(test_promote_inputvars)
 
 add_subdirectory(encoders)

--- a/tests/test_promote_inputvars.cpp
+++ b/tests/test_promote_inputvars.cpp
@@ -1,0 +1,73 @@
+#include <utility>
+
+#include "core/fts.h"
+#include "engines/kinduction.h"
+#include "gtest/gtest.h"
+#include "modifiers/mod_ts_prop.h"
+#include "modifiers/prop_monitor.h"
+#include "smt/available_solvers.h"
+#include "tests/common_ts.h"
+
+using namespace pono;
+using namespace smt;
+using namespace std;
+
+namespace pono_tests {
+
+pair<Term, TransitionSystem> input_property_sys(SmtSolver & solver)
+{
+  Sort bvsort8 = solver->make_sort(BV, 8);
+  FunctionalTransitionSystem fts(solver);
+  Term max_val = fts.make_term(10, bvsort8);
+  counter_system(fts, max_val);
+  Term x = fts.named_terms().at("x");
+
+  // add an input variable
+  Term in = fts.make_inputvar("in", bvsort8);
+  // constrain input to be less than a value
+  fts.add_constraint(fts.make_term(BVUlt, in, fts.make_term(5, bvsort8)));
+
+  Term prop_term = solver->make_term(
+      BVUlt, solver->make_term(BVAdd, x, in), solver->make_term(15, bvsort8));
+  return { prop_term, fts };
+}
+
+class PromoteInputvarsTests : public ::testing::Test,
+                              public ::testing::WithParamInterface<SolverEnum>
+{
+ protected:
+  void SetUp() override { s = create_solver(GetParam()); }
+  SmtSolver s;
+};
+
+TEST_P(PromoteInputvarsTests, NoPromotion)
+{
+  auto res = input_property_sys(s);
+  // need a property monitor
+  TransitionSystem & ts = res.second;
+  Term prop = add_prop_monitor(ts, res.first);
+
+  Property p(s, prop);
+  KInduction kind(p, ts, s);
+  ProverResult r = kind.check_until(20);
+  ASSERT_EQ(r, TRUE);
+}
+
+TEST_P(PromoteInputvarsTests, WithPromotion)
+{
+  auto res = input_property_sys(s);
+  // need a property monitor
+  Term prop = res.first;
+  TransitionSystem ts = promote_inputvars(res.second);
+
+  Property p(s, prop);
+  KInduction kind(p, ts, s);
+  ProverResult r = kind.check_until(20);
+  ASSERT_EQ(r, TRUE);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParameterizedPromoteInputvarsTests,
+                         PromoteInputvarsTests,
+                         testing::ValuesIn(available_solver_enums()));
+
+}  // namespace pono_tests


### PR DESCRIPTION
This PR fixes a soundness bug that can show up when using option `--promote-inputvars`. This is because after promoting input variables to state variables with no next state update (e.g. implicit inputs), we should re-evaluate all the constraints. A constraint that was previously only added over current because it had inputs in it, should now be added over next as well. It was correct before the pass, because input variables are only relevant for a transition, but once they're promoted that's no longer true.

Since it is so unsafe to promote input variables directly, this PR removes that functionality of a `TransitionSystem`. Instead there is now a pass that (safely) rebuilds the transition system without input variables.

Note: This is of course a recurring issue, see https://github.com/upscale-project/pono/issues/73. I think there could be a better solution long term. Basically, we should pick a representation and stick with it. It is a bit tough because there are some algorithms that do better with all state variables, and others that make more sense to have "true" input variables. In principle, I like both for different reasons. The implicit inputs are the simplest and this is typically the formalism in papers. On the other hand, it's not very intuitive since inputs should not be part of the state representation, and I think it's nice to show syntactically that they're only important for transitions.

Regardless, for now, I think this is a reasonable fix. We can return to this when we have more time.