### PR TITLE
Maintain contract that witness length refers to number of transitions

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -95,7 +95,8 @@ ProverResult CegProphecyArrays<Prover_T>::prove()
 
       if (res == ProverResult::FALSE) {
         // use witness length
-        reached_k_ = prover->witness_length();
+        // reached_k_ is the last k without a counterexample trace
+        reached_k_ = prover->witness_length() - 1;
       }
 
     } else {
@@ -142,7 +143,8 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
 
       if (res == ProverResult::FALSE) {
         // use witness length
-        reached_k_ = prover->witness_length();
+        // reached_k_ is the last k without a counterexample trace
+        reached_k_ = prover->witness_length() - 1;
       } else if (res == ProverResult::TRUE) {
         try {
           // set the invariant

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -95,7 +95,7 @@ ProverResult CegProphecyArrays<Prover_T>::prove()
 
       if (res == ProverResult::FALSE) {
         // use witness length
-        reached_k_ = prover->witness_length() - 1;
+        reached_k_ = prover->witness_length();
       }
 
     } else {
@@ -142,7 +142,7 @@ ProverResult CegProphecyArrays<Prover_T>::check_until(int k)
 
       if (res == ProverResult::FALSE) {
         // use witness length
-        reached_k_ = prover->witness_length() - 1;
+        reached_k_ = prover->witness_length();
       } else if (res == ProverResult::TRUE) {
         try {
           // set the invariant

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -198,7 +198,7 @@ size_t IC3Base::witness_length() const
 {
   // expecting there to have been a witness computed
   assert(cex_.size());
-  return cex_.size();
+  return cex_.size() - 1;
 }
 
 // Protected Methods


### PR DESCRIPTION
Within Pono, we consider the length of a trace to be the number of transitions. This was incorrect in the `IC3Base` implementation of `witness_length` and this PR fixes that.