### PR TITLE
IC3SA lemma learning and fallback refinement

### DIFF
--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -235,9 +235,9 @@ RefineResult IC3SA::refine()
 
   push_solver_context();
 
-  // TODO also use conjunctive partitions to split up constraints
-  // as much as possible
-
+  // due to simplifications can end up with the same terms
+  // for the constraints, avoid duplicating labels by keeping
+  // track with a set
   UnorderedTermSet used_lbls;
   TermVec lbls, assumps;
   Term unrolled;

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -156,7 +156,14 @@ void IC3SA::predecessor_generalization(size_t i,
   assert(all_coi_symbols.size());
 
   for (const auto & elem : ts_.constraints()) {
+    // TODO look into optimizing this
+    // might be able to only consider
+    // current state version that has common symbols
     justify_coi(elem.first, all_coi_symbols);
+    if (elem.second)
+    {
+      justify_coi(ts_.next(elem.first), all_coi_symbols);
+    }
   }
 
   // get rid of next-state variables

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -155,16 +155,8 @@ void IC3SA::predecessor_generalization(size_t i,
   justify_coi(ts_.next(c), all_coi_symbols);
   assert(all_coi_symbols.size());
 
-  for (const auto & fv : all_coi_symbols) {
-    // need to process any constraints that this variable is involved in
-    for (const auto & elem : constraint_vars_) {
-      const auto & s = elem.second;
-      if (s.find(fv) != s.end()) {
-        // this variable occurs in this constraint
-        // add the constraint
-        justify_coi(elem.first, all_coi_symbols);
-      }
-    }
+  for (const auto & elem : ts_.constraints()) {
+    justify_coi(elem.first, all_coi_symbols);
   }
 
   // get rid of next-state variables

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -309,6 +309,7 @@ RefineResult IC3SA::refine()
   // and it was untimed
   // thus there should only be current state variables left
   assert(ts_.only_curr(m));
+  assert(!m->is_value());
 
   // add to the projection set permanently
   get_free_symbolic_consts(m, projection_set_);

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -591,11 +591,20 @@ void IC3SA::initialize()
 
   // populate the map used in justify_coi to take constraints into account
   UnorderedTermSet tmp_vars;
+  Term next_constraint;
   for (const auto & elem : ts_.constraints()) {
     assert(ts_.no_next(elem.first));
     tmp_vars.clear();
     get_free_symbolic_consts(elem.first, tmp_vars);
     constraint_vars_[elem.first] = tmp_vars;
+
+    if (elem.second) {
+      // need to add next state version also
+      next_constraint = ts_.next(elem.first);
+      tmp_vars.clear();
+      get_free_symbolic_consts(next_constraint, tmp_vars);
+      constraint_vars_[next_constraint] = tmp_vars;
+    }
   }
 }
 

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -768,7 +768,9 @@ void IC3SA::justify_coi(Term c, UnorderedTermSet & projection)
       }
     } else if (t->get_sort() == boolsort_
                && is_controlled(t->get_op().prim_op, solver_->get_value(t))) {
-      to_visit_.push_back(get_controlling(t));
+      for (const auto & cc : get_controlling(t)) {
+        to_visit_.push_back(cc);
+      }
     } else if (ts_.is_next_var(t)
                && state_updates.find(ts_.curr(t)) != state_updates.end()) {
       to_visit_.push_back(state_updates.at(ts_.curr(t)));
@@ -814,9 +816,10 @@ bool IC3SA::is_controlled(PrimOp po, const Term & val) const
   }
 }
 
-Term IC3SA::get_controlling(Term t) const
+TermVec IC3SA::get_controlling(Term t) const
 {
   assert(solver_context_);
+
   Op op = t->get_op();
   assert(is_controlled(op.prim_op, solver_->get_value(t)));
   assert(!op.is_null());
@@ -837,15 +840,14 @@ Term IC3SA::get_controlling(Term t) const
     controlling_val = solver_->make_term(false);
   }
 
-  Term controlling_term;
+  TermVec controlling_terms;
   for (const auto & tt : t) {
     if (solver_->get_value(tt) == controlling_val) {
-      controlling_term = tt;
-      break;
+      controlling_terms.push_back(tt);
     }
   }
-  assert(controlling_term);
-  return controlling_term;
+  assert(controlling_terms.size());
+  return controlling_terms;
 }
 
 void IC3SA::debug_print_equivalence_classes(EquivalenceClasses ec) const

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -158,7 +158,8 @@ void IC3SA::predecessor_generalization(size_t i,
   for (const auto & fv : all_coi_symbols) {
     // need to process any constraints that this variable is involved in
     for (const auto & elem : constraint_vars_) {
-      if (elem.second.find(fv) != elem.second.end()) {
+      const auto & s = elem.second;
+      if (s.find(fv) != s.end()) {
         // this variable occurs in this constraint
         // add the constraint
         justify_coi(elem.first, all_coi_symbols);

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -285,9 +285,14 @@ RefineResult IC3SA::refine()
   }
 
   assert(!ts_.is_functional());
+  assert(!solver_context_);
+  solver_->assert_formula(solver_->make_term(Implies, trans_label_, learned_lemma));
   if (ts_.only_curr(learned_lemma)) {
     static_cast<RelationalTransitionSystem &>(ts_).add_constraint(
         learned_lemma);
+    solver_->assert_formula(solver_->make_term(Implies,
+                                               trans_label_,
+                                               ts_.next(learned_lemma)));
   } else {
     static_cast<RelationalTransitionSystem &>(ts_).constrain_trans(
         learned_lemma);

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -100,11 +100,11 @@ class IC3SA : public IC3
   // previous version was overriding intersects_bad for generalization
   // bool intersects_bad(IC3Formula & out) override;
 
-  void initialize() override;
-
   void abstract() override;
 
   RefineResult refine() override;
+
+  void initialize() override;
 
   // IC3SA specific methods
 

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -76,6 +76,9 @@ class IC3SA : public IC3
   smt::TermVec to_visit_;          ///< temporary var for justify_coi
   smt::UnorderedTermSet visited_;  ///< temporary var for justify_coi
 
+  // temporary data structure for conjunctive_assumptions
+  smt::TermVec tmp_;
+
   // useful sort
   smt::Sort boolsort_;
 
@@ -100,6 +103,18 @@ class IC3SA : public IC3
   RefineResult refine() override;
 
   // IC3SA specific methods
+
+  /** Helper function to create labels for conjuncts of a constraint
+   *  and assume the implication
+   *  @param term the term to break into conjuncts and assume labels for
+   *  @param used_lbls a set to keep track of used labels
+   *  @param lbls the vector of labels to add to
+   *  @param assumps the vector of assumptions to add to
+   */
+  void conjunctive_assumptions(const smt::Term & term,
+                               smt::UnorderedTermSet & used_lbls,
+                               smt::TermVec & lbls,
+                               smt::TermVec & assumps);
 
   /** Get equivalence classes over all current terms in term_abstraction_
    *  from the current model

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -108,6 +108,10 @@ class IC3SA : public IC3
 
   // IC3SA specific methods
 
+  RefineResult ic3sa_refine_functional(smt::Term & learned_lemma);
+
+  RefineResult ic3sa_refine_value(smt::Term & learned_lemma);
+
   /** Helper function to create labels for conjuncts of a constraint
    *  and assume the implication
    *  @param term the term to break into conjuncts and assume labels for

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -142,10 +142,10 @@ class IC3SA : public IC3
 
   /** Add all subterms from term to the term abstraction
    *  @param axiom the term to mine for subterms
-   *  @return true iff new terms were added
+   *  @return a set of new terms
    *  @modifies term_abstraction_ and predset_
    */
-  bool add_to_term_abstraction(const smt::Term & term);
+  smt::UnorderedTermSet add_to_term_abstraction(const smt::Term & term);
 
   void justify_coi(smt::Term c, smt::UnorderedTermSet & projection);
 

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -152,7 +152,7 @@ class IC3SA : public IC3
   bool is_controlled(smt::PrimOp po, const smt::Term & val) const;
 
   // helper function for justify_coi
-  smt::Term get_controlling(smt::Term t) const;
+  smt::TermVec get_controlling(smt::Term t) const;
 
   /** Check if a term is in the projection
    *  @param t the term to check

--- a/engines/ic3sa.h
+++ b/engines/ic3sa.h
@@ -48,6 +48,8 @@ class IC3SA : public IC3
   typedef IC3 super;
 
  protected:
+  TransitionSystem conc_ts_;
+
   FunctionalUnroller f_unroller_;
 
   smt::UnorderedTermSet predset_;  ///< stores all predicates in abstraction
@@ -99,6 +101,8 @@ class IC3SA : public IC3
   // bool intersects_bad(IC3Formula & out) override;
 
   void initialize() override;
+
+  void abstract() override;
 
   RefineResult refine() override;
 

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -62,7 +62,7 @@ const std::vector<SolverEnum> solver_enums({
 // IC3 uses the solver in a different way, so different
 // options are appropriate than for other engines
 std::unordered_set<Engine> ic3_variants(
-    { IC3_BOOL, MBIC3, IC3IA_ENGINE, MSAT_IC3IA });
+                                        { IC3_BOOL, MBIC3, IC3IA_ENGINE, MSAT_IC3IA, IC3SA_ENGINE });
 
 // internal method for creating a particular solver
 // doesn't set any options

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -37,7 +37,7 @@ TransitionSystem simple_uvw_system(const SmtSolver & solver)
 
   fts.assign_next(u, fts.make_term(Ite, cond, ifb, elseb));
   fts.assign_next(v, fts.make_term(BVAdd, v, one));
-  fts.assign_next(w, fts.make_term(BVAdd, v, one));
+  fts.assign_next(w, fts.make_term(BVAdd, w, one));
 
   return fts;
 }

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -87,6 +87,26 @@ TEST_P(IC3SAUnitTests, SimpleSystemUnsafe)
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
+TEST_P(IC3SAUnitTests, Simple)
+{
+  FunctionalTransitionSystem fts(s);
+  Sort bvsort8 = fts.make_sort(BV, 8);
+  Sort boolsort = fts.make_sort(BOOL);
+  Term one = fts.make_term(1, bvsort8);
+  Term eight = fts.make_term(8, bvsort8);
+  Term x = fts.make_statevar("x", bvsort8);
+
+  fts.set_init(fts.make_term(Equal, x, fts.make_term(0, bvsort8)));
+  fts.assign_next(x, fts.make_term(BVAdd, x, one));
+
+  Term prop_term = fts.make_term(BVUlt, x, eight);
+  Property prop(fts.solver(), prop_term);
+
+  IC3SA ic3sa(prop, fts, s);
+  ProverResult r = ic3sa.check_until(10);
+  ASSERT_EQ(r, ProverResult::FALSE);
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverIC3SAUnitTests,
                          IC3SAUnitTests,
                          testing::ValuesIn(available_solver_enums()));

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -87,7 +87,7 @@ TEST_P(IC3SAUnitTests, SimpleSystemUnsafe)
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
-TEST_P(IC3SAUnitTests, Simple)
+TEST_P(IC3SAUnitTests, SimpleCounter)
 {
   FunctionalTransitionSystem fts(s);
   Sort bvsort8 = fts.make_sort(BV, 8);
@@ -98,6 +98,29 @@ TEST_P(IC3SAUnitTests, Simple)
 
   fts.set_init(fts.make_term(Equal, x, fts.make_term(0, bvsort8)));
   fts.assign_next(x, fts.make_term(BVAdd, x, one));
+
+  Term prop_term = fts.make_term(BVUlt, x, eight);
+  Property prop(fts.solver(), prop_term);
+
+  IC3SA ic3sa(prop, fts, s);
+  ProverResult r = ic3sa.check_until(10);
+  ASSERT_EQ(r, ProverResult::FALSE);
+}
+
+TEST_P(IC3SAUnitTests, SimpleCounterVar)
+{
+  FunctionalTransitionSystem fts(s);
+  Sort bvsort1 = fts.make_sort(BV, 1);
+  Sort bvsort8 = fts.make_sort(BV, 8);
+  Sort boolsort = fts.make_sort(BOOL);
+  Term one = fts.make_term(1, bvsort8);
+  Term eight = fts.make_term(8, bvsort8);
+  Term x = fts.make_statevar("x", bvsort8);
+  Term in = fts.make_statevar("in", bvsort1);
+  Term ext_in = fts.make_term(Op(Zero_Extend, 7), in);
+
+  fts.set_init(fts.make_term(Equal, x, fts.make_term(0, bvsort8)));
+  fts.assign_next(x, fts.make_term(BVAdd, x, ext_in));
 
   Term prop_term = fts.make_term(BVUlt, x, eight);
   Property prop(fts.solver(), prop_term);


### PR DESCRIPTION
This PR addresses some errors in the `IC3SA` implementation. In particular, it ensures that a path lemma is learned during refinement and adds a fallback procedure in case functional unrolling ends up being simplified by the SMT solver to a constant value.