### PR TITLE
Adjust error vs unknown result

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -175,7 +175,8 @@ ProverResult IC3Base::check_until(int k)
         return ProverResult::FALSE;
       } else {
         assert(s == REFINE_FAIL);
-        throw PonoException("Refinement failed");
+        logger.log(1, "IC3Base: refinement failure, returning unknown");
+        return ProverResult::UNKNOWN;
       }
     } else {
       ++i;

--- a/pono.cpp
+++ b/pono.cpp
@@ -151,19 +151,22 @@ ProverResult check_prop(PonoOptions pono_options,
           "Only got a partial witness from engine. Not suitable for printing.");
     }
   } else if (r == TRUE && pono_options.check_invar_) {
+    Term invar = nullptr;
     try {
-      Term invar = prover->invar();
+      invar = prover->invar();
+    }
+    catch (PonoException & e) {
+      std::cout << "Engine " << pono_options.engine_
+                << " does not support getting the invariant." << std::endl;
+    }
+    if (invar) {
       bool invar_passes = check_invar(ts, p.prop(), invar);
       std::cout << "Invariant Check " << (invar_passes ? "PASSED" : "FAILED")
                 << std::endl;
       if (!invar_passes) {
         // shouldn't return true if invariant is incorrect
-        r = ProverResult::UNKNOWN;
+        throw PonoException("Invariant Check FAILED");
       }
-    }
-    catch (PonoException & e) {
-      std::cout << "Engine " << pono_options.engine_
-                << " does not support getting the invariant." << std::endl;
     }
   }
   return r;


### PR DESCRIPTION
This PR makes it so that refinement failure in an IC3 variant returns `unknown` rather than throwing an exception. It also makes it so that a failed invariant check throws an exception instead of returning `unknown`. This is for the purposes of testing, where it makes sense to ignore refinement failures (which can happen) but not failed invariant checks which indicates a bug.