### PR TITLE
Clean up in reset_solver of IC3IA

### DIFF
--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -978,14 +978,14 @@ Term IC3Base::make_and(TermVec vec, SmtSolver slv) const
   return res;
 }
 
-void IC3Base::reset_solver()
+bool IC3Base::reset_solver()
 {
   assert(solver_context_ == 0);
 
   if (failed_to_reset_solver_) {
     // don't even bother trying
     // this solver doesn't support reset_assertions
-    return;
+    return false;
   }
 
   try {
@@ -1029,6 +1029,7 @@ void IC3Base::reset_solver()
   }
 
   num_check_sat_since_reset_ = 0;
+  return !failed_to_reset_solver_;
 }
 
 Term IC3Base::label(const Term & t)

--- a/engines/ic3base.h
+++ b/engines/ic3base.h
@@ -572,9 +572,10 @@ class IC3Base : public Prover
 
   /** Attempts to reset the solver and re-add constraints
    *  NOTE: not all solvers support reset_assertions, in which case the
-   * exception is just caught and things continue on as normal
+   *  exception is just caught and things continue on as normal
+   *  @return true iff the solver was successfully reset
    */
-  virtual void reset_solver();
+  virtual bool reset_solver();
 
   inline size_t frontier_idx() const { return frames_.size() - 1; }
 

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -321,16 +321,19 @@ RefineResult IC3IA::refine()
   return RefineResult::REFINE_SUCCESS;
 }
 
-void IC3IA::reset_solver()
+bool IC3IA::reset_solver()
 {
-  super::reset_solver();
-
-  for (const auto & elem : lbl2pred_) {
-    solver_->assert_formula(solver_->make_term(Equal, elem.first, elem.second));
-    Term npred = ts_.next(elem.second);
-    Term nlbl = label(npred);
-    solver_->assert_formula(solver_->make_term(Equal, nlbl, npred));
+  bool reset_success = super::reset_solver();
+  if (reset_success) {
+    for (const auto & elem : lbl2pred_) {
+      solver_->assert_formula(
+          solver_->make_term(Equal, elem.first, elem.second));
+      Term npred = ts_.next(elem.second);
+      Term nlbl = label(npred);
+      solver_->assert_formula(solver_->make_term(Equal, nlbl, npred));
+    }
   }
+  return reset_success;
 }
 
 bool IC3IA::is_global_label(const Term & l) const

--- a/engines/ic3ia.h
+++ b/engines/ic3ia.h
@@ -105,7 +105,7 @@ class IC3IA : public IC3
 
   RefineResult refine() override;
 
-  void reset_solver() override;
+  bool reset_solver() override;
 
   bool is_global_label(const smt::Term & l) const override;
 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -49,7 +49,6 @@ enum optionIndex
   LOGGING_SMT_SOLVER,
   NO_IC3_PREGEN,
   NO_IC3_INDGEN,
-  IC3_RESET_INTERVAL,
   IC3_GEN_MAX_ITER,
   IC3_FUNCTIONAL_PREIMAGE,
   NO_IC3_UNSATCORE_GEN,
@@ -238,17 +237,6 @@ const option::Descriptor usage[] = {
     "ic3-no-indgen",
     Arg::None,
     "  --ic3-no-indgen \tDisable inductive generalization in ic3." },
-  { IC3_RESET_INTERVAL,
-    0,
-    "",
-    "ic3-reset-interval",
-    Arg::Numeric,
-    "  --ic3-reset-interval \tNumber of check-sat queries before "
-    "resetting the solver. "
-    "Setting it to 0 means an unbounded number of iterations."
-    "Note: some solvers don't support resetting assertions, in which "
-    "case it will just fail to reset and not try again. This will be "
-    "printed at verbosity 1." },
   { IC3_GEN_MAX_ITER,
     0,
     "",
@@ -468,7 +456,6 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
         case CLK: clock_name_ = opt.arg; break;
         case NO_IC3_PREGEN: ic3_pregen_ = false; break;
         case NO_IC3_INDGEN: ic3_indgen_ = false; break;
-        case IC3_RESET_INTERVAL: ic3_reset_interval_ = atoi(opt.arg); break;
         case IC3_GEN_MAX_ITER: ic3_gen_max_iter_ = atoi(opt.arg); break;
         case MBIC3_INDGEN_MODE:
           mbic3_indgen_mode = atoi(opt.arg);

--- a/options/options.h
+++ b/options/options.h
@@ -91,7 +91,6 @@ class PonoOptions
         ic3_pregen_(default_ic3_pregen_),
         ic3_indgen_(default_ic3_indgen_),
         ic3_gen_max_iter_(default_ic3_gen_max_iter_),
-        ic3_reset_interval_(default_ic3_reset_interval_),
         mbic3_indgen_mode(default_mbic3_indgen_mode),
         ic3_functional_preimage_(default_ic3_functional_preimage_),
         ic3_unsatcore_gen_(default_ic3_unsatcore_gen_),
@@ -144,8 +143,6 @@ class PonoOptions
   // ic3 options
   bool ic3_pregen_;  ///< generalize counterexamples in IC3
   bool ic3_indgen_;  ///< inductive generalization in IC3
-  unsigned int ic3_reset_interval_;  ///< number of check sat calls before
-                                     ///< resetting. 0 means unbounded
   unsigned int ic3_gen_max_iter_; ///< max iterations in ic3 generalization. 0
                                   ///means unbounded
   unsigned int mbic3_indgen_mode;  ///< inductive generalization mode [0,2]
@@ -195,7 +192,6 @@ class PonoOptions
   static const bool default_logging_smt_solver_ = false;
   static const bool default_ic3_pregen_ = true;
   static const bool default_ic3_indgen_ = true;
-  static const unsigned int default_ic3_reset_interval_ = 5000;
   static const unsigned int default_ic3_gen_max_iter_ = 2;
   static const unsigned int default_mbic3_indgen_mode = 0;
   static const bool default_ic3_functional_preimage_ = false;


### PR DESCRIPTION
This PR removes the unused reset interval option, and ensures that predicate constraints are not re-added if reset_solver fails in IC3IA.