### PR TITLE
Allow quoted symbol names in SMV

### DIFF
--- a/frontends/smvparser.l
+++ b/frontends/smvparser.l
@@ -135,6 +135,17 @@ in {return pono::smvparser::make_OP_IN(_encoder.loc);}
 <WORD_VALUE>[0-9a-fA-F]+ {BEGIN(INITIAL); return pono::smvparser::make_integer_val(yytext,_encoder.loc);}
 
 [a-zA-Z_][A-Za-z0-9_\$#-]*  {return pono::smvparser::make_tok_name(yytext,_encoder.loc);}
+\"(\\.|[^\"\\])*\"    {
+                        for (const char * c=yytext; *c; ++c)
+                        {
+                          if(*c == '\n')
+                          {
+                            _encoder.loc.lines(1);
+                          }
+                        }
+                        _encoder.loc.step();
+                        return pono::smvparser::make_tok_name(yytext, _encoder.loc);
+                      }
 \n   {_encoder.loc.lines(yyleng);}
 .    {}
 <<EOF>>    return pono::smvparser::make_END(_encoder.loc);

--- a/frontends/smvparser.l
+++ b/frontends/smvparser.l
@@ -16,6 +16,8 @@
 %option yyclass="SMVscanner"
 %option yylineno
 %option noyywrap
+/** Uncomment to enable debug tracing */
+/** %option debug */
 
 %x COMMENT
 %x WORD_INIT WORD_BASE WORD_VALUE

--- a/frontends/smvscanner.h
+++ b/frontends/smvscanner.h
@@ -14,7 +14,11 @@ class SMVEncoder;
 class SMVscanner : public yyFlexLexer
 {
  public:
-  SMVscanner(SMVEncoder & encoder) : _encoder(encoder) {}
+  SMVscanner(SMVEncoder & encoder) : _encoder(encoder)
+  {
+    // Uncomment this and debug option in smvparser.l for output
+    // yy_flex_debug = 1;
+  }
   virtual ~SMVscanner() {}
   virtual pono::smvparser::symbol_type yylex(SMVEncoder & encoder);
 


### PR DESCRIPTION
This PR would allow symbol names in quotes that have characters which are not normally allowed in identifiers, such as `[` or `!`.