### PR TITLE
Various fixes for using Pono as a library or through Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,10 +304,6 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/core/"
         DESTINATION include/pono/core
         FILES_MATCHING PATTERN "*.h")
 
-install(DIRECTORY "${PROJECT_SOURCE_DIR}/utils/"
-        DESTINATION include/pono/utils
-        FILES_MATCHING PATTERN "*.h")
-
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/engines/"
         DESTINATION include/pono/engines
         FILES_MATCHING PATTERN "*.h")
@@ -316,14 +312,22 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/frontends/"
         DESTINATION include/pono/frontends
         FILES_MATCHING PATTERN "*.h")
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/smvparser.h"
-        DESTINATION include/pono/)
-
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/location.hh"
         DESTINATION include/pono/)
 
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/modifiers/"
+        DESTINATION include/pono/modifiers
+        FILES_MATCHING PATTERN "*.h")
+
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/options/"
         DESTINATION include/pono/options
+        FILES_MATCHING PATTERN "*.h")
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/smvparser.h"
+        DESTINATION include/pono/)
+
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/utils/"
+        DESTINATION include/pono/utils
         FILES_MATCHING PATTERN "*.h")
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/contrib/fmt/"

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -54,6 +54,9 @@ IC3IA::IC3IA(const Property & p,
       to_solver_(solver_),
       longest_cex_length_(0)
 {
+  // since we passed a fresh RelationalTransitionSystem as the main TS
+  // need to point orig_ts_ to the right place
+  orig_ts_ = ts;
   engine_ = Engine::IC3IA_ENGINE;
   approx_pregen_ = true;
 }

--- a/python/pono_imp.pxd
+++ b/python/pono_imp.pxd
@@ -193,3 +193,8 @@ cdef extern from "printers/vcd_witness_printer.h" namespace "pono":
 cdef extern from "utils/logger.h" namespace "pono":
     void set_global_logger_verbosity(unsigned int v) except +
 
+cdef extern from "utils/ts_analysis.h" namespace "pono":
+    bint check_invar(const TransitionSystem & ts,
+                     const c_Term & prop,
+                     const c_Term & invar) except +
+

--- a/python/pono_imp.pxd
+++ b/python/pono_imp.pxd
@@ -99,6 +99,7 @@ cdef extern from "engines/prover.h" namespace "pono":
         void initialize() except +
         ProverResult check_until(int k) except +
         bint witness(vector[c_UnorderedTermMap] & out) except +
+        c_Term invar() except +
         ProverResult prove() except +
 
 

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -441,6 +441,11 @@ cdef class __AbstractProver:
 
         return w
 
+    def invar(self):
+        cdef Term inv = Term(self._solver)
+        inv.ct = dref(self.cp).invar()
+        return inv
+
     def prove(self):
         '''
         Tries to prove property unboundedly, returns True, False or None (if unknown)

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -35,6 +35,7 @@ from pono_imp cimport StaticConeOfInfluence as c_StaticConeOfInfluence
 from pono_imp cimport add_prop_monitor as c_add_prop_monitor
 from pono_imp cimport VCDWitnessPrinter as c_VCDWitnessPrinter
 from pono_imp cimport set_global_logger_verbosity as c_set_global_logger_verbosity
+from pono_imp cimport check_invar as c_check_invar
 
 from smt_switch cimport SmtSolver, PrimOp, Op, c_SortKind, SortKind, \
     c_Sort, c_SortVec, Sort, Term, c_Term, c_TermVec, c_UnorderedTermMap
@@ -611,6 +612,9 @@ cdef class VCDWitnessPrinter:
 
 def set_global_logger_verbosity(int v):
     c_set_global_logger_verbosity(v)
+
+def check_invar(__AbstractTransitionSystem ts, Term prop, Term invar):
+    return c_check_invar(dref(ts.cts), prop.ct, invar.ct)
 
 def coi_reduction(__AbstractTransitionSystem ts, to_keep, verbosity=1):
     '''


### PR DESCRIPTION
This PR includes several fixes:
* Adds modifiers folder to install headers
* Adds `check_invar` and `Prover::invar` to Python API
* Updates `orig_ts_` in `IC3IA`