### PR TITLE
Add multi-sort operator and arithmetic support

### DIFF
--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -223,7 +223,8 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
   cvc4a::Term start_bool = cvc4_solver.mkVar(boolean, "Start");
   vector<cvc4a::Term> start_terms;
 
-  unordered_map<cvc4a::Sort, cvc4a::Term, cvc4a::SortHashFunction> sort2start;
+  unordered_map<cvc4a::Sort, cvc4a::Term, cvc4a::SortHashFunction> sort2start(
+      { { boolean, start_bool } });
   for (const auto & cvc4_bv : cvc4_boundvars)
   {
     cvc4a::Sort sort = cvc4_bv.getSort();

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -51,25 +51,6 @@ namespace cvc4a = ::CVC4::api;
 using CVC4SortSet = std::unordered_set<cvc4a::Sort, cvc4a::SortHashFunction>;
 using CVC4TermVec = std::vector<cvc4a::Term>;
 
-// TODO remove these
-// const unordered_set<PrimOp> bv_ops(
-//     { Equal, Concat, Extract, BVNot, BVNeg, BVAnd, BVOr, BVXor, BVNand,
-//     BVNor,
-//       BVXnor, BVComp, BVAdd, BVSub, BVMul, BVUdiv, BVSdiv, BVUrem, BVSrem,
-//       BVSmod, BVShl, BVAshr, BVLshr, BVUlt, BVUle, BVUgt, BVUge, BVSlt,
-//       BVSle, BVSgt, BVSge, Zero_Extend, Sign_Extend, Repeat, Rotate_Left } );
-
-// const unordered_set<PrimOp> relational_ops(
-//                                            { And, Or, Xor, Not, Implies,
-//                                            Equal, Distinct, Lt, Le, Gt, Ge,
-//                                              BVUlt, BVUle, BVUgt, BVUge,
-//                                              BVSlt, BVSle, BVSgt, BVSge} );
-
-// // these operations are not relational but also operate on multiple sorts
-// const unordered_set<PrimOp> multisort_ops(
-//                                           { Extract, Zero_Extend, BVComp,
-//                                           Concat });
-
 const unordered_set<cvc4a::Kind> bv_ops({ cvc4a::EQUAL,
                                           cvc4a::BITVECTOR_CONCAT,
                                           cvc4a::BITVECTOR_EXTRACT,
@@ -130,104 +111,6 @@ const unordered_set<cvc4a::Kind> unary_ops({ cvc4a::BITVECTOR_NEG,
                                              cvc4a::BITVECTOR_EXTRACT,
                                              cvc4a::BITVECTOR_ZERO_EXTEND });
 
-// TODO: get rid of this if not needed
-const unordered_map<PrimOp, cvc4a::Kind> to_cvc4_ops(
-    { { And, cvc4a::AND },
-      { Or, cvc4a::OR },
-      { Xor, cvc4a::XOR },
-      { Not, cvc4a::NOT },
-      { Implies, cvc4a::IMPLIES },
-      { Ite, cvc4a::ITE },
-      { Equal, cvc4a::EQUAL },
-      { Distinct, cvc4a::DISTINCT },
-      /* Uninterpreted Functions */
-      { Apply, cvc4a::APPLY_UF },
-      /* Arithmetic Theories */
-      { Plus, cvc4a::PLUS },
-      { Minus, cvc4a::MINUS },
-      { Negate, cvc4a::UMINUS },
-      { Mult, cvc4a::MULT },
-      { Div, cvc4a::DIVISION },
-      { Lt, cvc4a::LT },
-      { Le, cvc4a::LEQ },
-      { Gt, cvc4a::GT },
-      { Ge, cvc4a::GEQ },
-      { Mod, cvc4a::INTS_MODULUS },
-      { Abs, cvc4a::ABS },
-      { Pow, cvc4a::POW },
-      { To_Real, cvc4a::TO_REAL },
-      { To_Int, cvc4a::TO_INTEGER },
-      { Is_Int, cvc4a::IS_INTEGER },
-      /* Fixed Size BitVector Theory */
-      { Concat, cvc4a::BITVECTOR_CONCAT },
-      // Indexed Op
-      { Extract, cvc4a::BITVECTOR_EXTRACT },
-      { BVNot, cvc4a::BITVECTOR_NOT },
-      { BVNeg, cvc4a::BITVECTOR_NEG },
-      { BVAnd, cvc4a::BITVECTOR_AND },
-      { BVOr, cvc4a::BITVECTOR_OR },
-      { BVXor, cvc4a::BITVECTOR_XOR },
-      { BVNand, cvc4a::BITVECTOR_NAND },
-      { BVNor, cvc4a::BITVECTOR_NOR },
-      { BVXnor, cvc4a::BITVECTOR_XNOR },
-      { BVComp, cvc4a::BITVECTOR_COMP },
-      { BVAdd, cvc4a::BITVECTOR_PLUS },
-      { BVSub, cvc4a::BITVECTOR_SUB },
-      { BVMul, cvc4a::BITVECTOR_MULT },
-      { BVUdiv, cvc4a::BITVECTOR_UDIV },
-      { BVSdiv, cvc4a::BITVECTOR_SDIV },
-      { BVUrem, cvc4a::BITVECTOR_UREM },
-      { BVSrem, cvc4a::BITVECTOR_SREM },
-      { BVSmod, cvc4a::BITVECTOR_SMOD },
-      { BVShl, cvc4a::BITVECTOR_SHL },
-      { BVAshr, cvc4a::BITVECTOR_ASHR },
-      { BVLshr, cvc4a::BITVECTOR_LSHR },
-      { BVUlt, cvc4a::BITVECTOR_ULT },
-      { BVUle, cvc4a::BITVECTOR_ULE },
-      { BVUgt, cvc4a::BITVECTOR_UGT },
-      { BVUge, cvc4a::BITVECTOR_UGE },
-      { BVSlt, cvc4a::BITVECTOR_SLT },
-      { BVSle, cvc4a::BITVECTOR_SLE },
-      { BVSgt, cvc4a::BITVECTOR_SGT },
-      { BVSge, cvc4a::BITVECTOR_SGE },
-      // Indexed Op
-      { Zero_Extend, cvc4a::BITVECTOR_ZERO_EXTEND },
-      // Indexed Op
-      { Sign_Extend, cvc4a::BITVECTOR_SIGN_EXTEND },
-      // Indexed Op
-      { Repeat, cvc4a::BITVECTOR_REPEAT },
-      // Indexed Op
-      { Rotate_Left, cvc4a::BITVECTOR_ROTATE_LEFT },
-      // Indexed Op
-      { Rotate_Right, cvc4a::BITVECTOR_ROTATE_RIGHT },
-      // Conversion
-      { BV_To_Nat, cvc4a::BITVECTOR_TO_NAT },
-      // Indexed Op
-      { Int_To_BV, cvc4a::INT_TO_BITVECTOR },
-      { Select, cvc4a::SELECT },
-      { Store, cvc4a::STORE },
-      { Forall, cvc4a::FORALL },
-      { Exists, cvc4a::EXISTS },
-      // Datatype
-      { Apply_Constructor, cvc4a::APPLY_CONSTRUCTOR },
-      { Apply_Tester, cvc4a::APPLY_TESTER },
-      { Apply_Selector, cvc4a::APPLY_SELECTOR } });
-
-// TODO remove this
-// void get_bv_ops_subset(const UnorderedOpSet &in, UnorderedOpSet &out)
-// {
-//   for (const auto & o : in) {
-//     if (bv_ops.find(o.prim_op) != bv_ops.end()) {
-//       out.insert(o);
-//     }
-//   }
-// }
-
-void collect_values(const Term term, UnorderedTermSet & out)
-{
-  auto f = [](const smt::Term & t) { return t->is_value(); };
-  get_matching_terms(term, out, f);
-}
 
 // Helpers for CVC4 SyGuS Predicate Search
 // should eventually be moved elsewhere

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -391,7 +391,11 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
             if (sort2start.find(sort) == sort2start.end()) {
               // no start term for this sort
               failed = true;
-              assert(!all_sorts_);  // should never happen if adding all sorts
+              logger.log(
+                  3,
+                  "IC3IA SyGuS pred: skipping op {} because missing sort {}",
+                  op.toString(),
+                  sort.toString());
               break;
             }
             args.push_back(sort2start.at(sort));
@@ -400,9 +404,17 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
             break;
           }
 
-          cvc4a::Term return_start_term =
-              sort2start.at(signature.getFunctionCodomainSort());
-          constructs[return_start_term].push_back(cvc4_solver.mkTerm(op, args));
+          cvc4a::Sort codomain_sort = signature.getFunctionCodomainSort();
+          if (sort2start.find(codomain_sort) != sort2start.end()) {
+            cvc4a::Term return_start_term = sort2start.at(codomain_sort);
+            constructs[return_start_term].push_back(
+                cvc4_solver.mkTerm(op, args));
+          } else {
+            logger.log(3,
+                       "Skipping op {} because missing return sort {}",
+                       op.toString(),
+                       codomain_sort.toString());
+          }
         }
       }
     }

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -185,6 +185,7 @@ class CVC4GrammarSeed
         continue;
       } else {
         visited.insert(t);
+        to_visit.push_back(t);
         to_visit.insert(to_visit.end(), t.begin(), t.end());
 
         if (cvc4_term_is_value(t)) {

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -51,20 +51,86 @@ namespace cvc4a = ::CVC4::api;
 using CVC4SortSet = std::unordered_set<cvc4a::Sort, cvc4a::SortHashFunction>;
 using CVC4TermVec = std::vector<cvc4a::Term>;
 
-const unordered_set<PrimOp> bv_ops(
-    { Equal, Concat, Extract, BVNot, BVNeg, BVAnd, BVOr, BVXor, BVNand, BVNor,
-      BVXnor, BVComp, BVAdd, BVSub, BVMul, BVUdiv, BVSdiv, BVUrem, BVSrem,
-      BVSmod, BVShl, BVAshr, BVLshr, BVUlt, BVUle, BVUgt, BVUge, BVSlt, BVSle,
-      BVSgt, BVSge, Zero_Extend, Sign_Extend, Repeat, Rotate_Left } );
+// TODO remove these
+// const unordered_set<PrimOp> bv_ops(
+//     { Equal, Concat, Extract, BVNot, BVNeg, BVAnd, BVOr, BVXor, BVNand,
+//     BVNor,
+//       BVXnor, BVComp, BVAdd, BVSub, BVMul, BVUdiv, BVSdiv, BVUrem, BVSrem,
+//       BVSmod, BVShl, BVAshr, BVLshr, BVUlt, BVUle, BVUgt, BVUge, BVSlt,
+//       BVSle, BVSgt, BVSge, Zero_Extend, Sign_Extend, Repeat, Rotate_Left } );
 
-const unordered_set<PrimOp> relational_ops(
-    { And, Or, Xor, Not, Implies, Equal, Distinct, Lt, Le, Gt, Ge,
-      BVUlt, BVUle, BVUgt, BVUge, BVSlt, BVSle, BVSgt, BVSge} );
+// const unordered_set<PrimOp> relational_ops(
+//                                            { And, Or, Xor, Not, Implies,
+//                                            Equal, Distinct, Lt, Le, Gt, Ge,
+//                                              BVUlt, BVUle, BVUgt, BVUge,
+//                                              BVSlt, BVSle, BVSgt, BVSge} );
 
-// these operations are not relational but also operate on multiple sorts
-const unordered_set<PrimOp> multisort_ops(
-    { Extract, Zero_Extend, BVComp, Concat });
+// // these operations are not relational but also operate on multiple sorts
+// const unordered_set<PrimOp> multisort_ops(
+//                                           { Extract, Zero_Extend, BVComp,
+//                                           Concat });
 
+const unordered_set<cvc4a::Kind> bv_ops({ cvc4a::EQUAL,
+                                          cvc4a::BITVECTOR_CONCAT,
+                                          cvc4a::BITVECTOR_EXTRACT,
+                                          cvc4a::BITVECTOR_NOT,
+                                          cvc4a::BITVECTOR_NEG,
+                                          cvc4a::BITVECTOR_AND,
+                                          cvc4a::BITVECTOR_OR,
+                                          cvc4a::BITVECTOR_XOR,
+                                          cvc4a::BITVECTOR_NAND,
+                                          cvc4a::BITVECTOR_NOR,
+                                          cvc4a::BITVECTOR_XNOR,
+                                          cvc4a::BITVECTOR_COMP,
+                                          cvc4a::BITVECTOR_PLUS,
+                                          cvc4a::BITVECTOR_SUB,
+                                          cvc4a::BITVECTOR_MULT,
+                                          cvc4a::BITVECTOR_UDIV,
+                                          cvc4a::BITVECTOR_SDIV,
+                                          cvc4a::BITVECTOR_UREM,
+                                          cvc4a::BITVECTOR_SREM,
+                                          cvc4a::BITVECTOR_SMOD,
+                                          cvc4a::BITVECTOR_SHL,
+                                          cvc4a::BITVECTOR_ASHR,
+                                          cvc4a::BITVECTOR_LSHR,
+                                          cvc4a::BITVECTOR_ULT,
+                                          cvc4a::BITVECTOR_ULE,
+                                          cvc4a::BITVECTOR_UGT,
+                                          cvc4a::BITVECTOR_UGE,
+                                          cvc4a::BITVECTOR_SLT,
+                                          cvc4a::BITVECTOR_SLE,
+                                          cvc4a::BITVECTOR_SGT,
+                                          cvc4a::BITVECTOR_SGE,
+                                          cvc4a::BITVECTOR_ZERO_EXTEND,
+                                          cvc4a::BITVECTOR_SIGN_EXTEND,
+                                          cvc4a::BITVECTOR_REPEAT,
+                                          cvc4a::BITVECTOR_ROTATE_LEFT,
+                                          cvc4a::BITVECTOR_ROTATE_RIGHT });
+
+const unordered_set<cvc4a::Kind> relational_ops({
+    cvc4a::AND,           cvc4a::OR,
+    cvc4a::XOR,           cvc4a::NOT,
+    cvc4a::IMPLIES,       cvc4a::EQUAL,
+    cvc4a::DISTINCT,      cvc4a::LT,
+    cvc4a::LEQ,           cvc4a::GT,
+    cvc4a::GEQ,           cvc4a::BITVECTOR_ULT,
+    cvc4a::BITVECTOR_ULE, cvc4a::BITVECTOR_UGT,
+    cvc4a::BITVECTOR_UGE, cvc4a::BITVECTOR_SLT,
+    cvc4a::BITVECTOR_SLE, cvc4a::BITVECTOR_SGT,
+    cvc4a::BITVECTOR_SGE,
+});
+
+const unordered_set<cvc4a::Kind> multisort_ops({ cvc4a::BITVECTOR_EXTRACT,
+                                                 cvc4a::BITVECTOR_CONCAT,
+                                                 cvc4a::BITVECTOR_ZERO_EXTEND,
+                                                 cvc4a::BITVECTOR_COMP });
+
+const unordered_set<cvc4a::Kind> unary_ops({ cvc4a::BITVECTOR_NEG,
+                                             cvc4a::BITVECTOR_NOT,
+                                             cvc4a::BITVECTOR_EXTRACT,
+                                             cvc4a::BITVECTOR_ZERO_EXTEND });
+
+// TODO: get rid of this if not needed
 const unordered_map<PrimOp, cvc4a::Kind> to_cvc4_ops(
     { { And, cvc4a::AND },
       { Or, cvc4a::OR },
@@ -147,14 +213,15 @@ const unordered_map<PrimOp, cvc4a::Kind> to_cvc4_ops(
       { Apply_Tester, cvc4a::APPLY_TESTER },
       { Apply_Selector, cvc4a::APPLY_SELECTOR } });
 
-void get_bv_ops_subset(const UnorderedOpSet &in, UnorderedOpSet &out)
-{
-  for (const auto & o : in) {
-    if (bv_ops.find(o.prim_op) != bv_ops.end()) {
-      out.insert(o);
-    }
-  }
-}
+// TODO remove this
+// void get_bv_ops_subset(const UnorderedOpSet &in, UnorderedOpSet &out)
+// {
+//   for (const auto & o : in) {
+//     if (bv_ops.find(o.prim_op) != bv_ops.end()) {
+//       out.insert(o);
+//     }
+//   }
+// }
 
 void collect_values(const Term term, UnorderedTermSet & out)
 {
@@ -165,25 +232,41 @@ void collect_values(const Term term, UnorderedTermSet & out)
 // Helpers for CVC4 SyGuS Predicate Search
 // should eventually be moved elsewhere
 
-using OpSignatures = unordered_map<Op, unordered_set<Sort>>;
+bool cvc4_term_is_value(const cvc4a::Term & term)
+{
+  cvc4a::Kind k = term.getKind();
+  return ((k == cvc4a::CONST_BOOLEAN) || (k == cvc4a::CONST_BITVECTOR)
+          || (k == cvc4a::CONST_RATIONAL) || (k == cvc4a::CONST_FLOATINGPOINT)
+          || (k == cvc4a::CONST_ROUNDINGMODE) || (k == cvc4a::CONST_STRING)
+          || (k == cvc4a::CONST_ARRAY));
+}
 
-/** \class GrammarSeed
+using CVC4OpSignatures =
+    unordered_map<cvc4a::Op,
+                  unordered_set<cvc4a::Sort, cvc4a::SortHashFunction>,
+                  cvc4a::OpHashFunction>;
+using CVC4ValueMap =
+    unordered_map<cvc4a::Sort,
+                  unordered_set<cvc4a::Term, cvc4a::TermHashFunction>,
+                  cvc4a::SortHashFunction>;
+
+/** \class CVC4GrammarSeed
  *  \brief A class for seeding a SyGuS grammar with terms
  *
  *  Used to store ops and values used in an abstract trace
  *  More specifically, it keeps track not only of the operators,
  *  but also which sorts they're applied to
  */
-class GrammarSeed
+class CVC4GrammarSeed
 {
  public:
-  GrammarSeed(SmtSolver & solver) : solver_(solver) {}
+  CVC4GrammarSeed(cvc4a::Solver & solver) : solver_(solver), num_values_(0) {}
 
-  void scan(Term term)
+  void scan(cvc4a::Term term)
   {
-    TermVec to_visit({ term });
-    UnorderedTermSet visited;
-    Term t;
+    CVC4TermVec to_visit({ term });
+    unordered_set<cvc4a::Term, cvc4a::TermHashFunction> visited;
+    cvc4a::Term t;
     while (!to_visit.empty()) {
       t = to_visit.back();
       to_visit.pop_back();
@@ -192,22 +275,23 @@ class GrammarSeed
         continue;
       } else {
         visited.insert(t);
-        to_visit.insert(to_visit.end(), t->begin(), t->end());
+        to_visit.insert(to_visit.end(), t.begin(), t.end());
 
-        Sort sort = t->get_sort();
-        Op op;
-        if (t->is_value()) {
+        cvc4a::Sort sort = t.getSort();
+        all_sorts_.insert(sort);
+        if (cvc4_term_is_value(t)) {
           value_map_[sort].insert(t);
-        } else if (!(op = t->get_op()).is_null()) {
+          num_values_++;
+        } else if (t.hasOp()) {
+          cvc4a::Op op = t.getOp();
           // easiest way to store signature is as a function sort
-          vector<Sort> sort_vec;
+          vector<cvc4a::Sort> sort_vec;
           for (const auto & tt : t) {
-            sort_vec.push_back(tt->get_sort());
+            sort_vec.push_back(tt.getSort());
           }
-          sort_vec.push_back(sort);
 
-          Sort ufsort = solver_->make_sort(FUNCTION, sort_vec);
-          assert(!op.is_null());
+          cvc4a::Sort ufsort = solver_.mkFunctionSort(sort_vec, sort);
+          assert(!op.isNull());
           op_map_[op].insert(ufsort);
         }
       }
@@ -219,28 +303,37 @@ class GrammarSeed
    *  e.g. bvadd might have been applied to (_ BitVec 8) x (_ BitVec 8) -> (_
    * BitVec 8) and (_ BitVec 6) x (_ BitVec 6) -> (_ BitVec 6)
    */
-  const OpSignatures & get_op_map() const { return op_map_; }
+  const CVC4OpSignatures & get_op_map() const { return op_map_; }
 
   /** Getter for value map
    *  @return map from sorts to a set of values used of that sort
    */
-  const unordered_map<Sort, UnorderedTermSet> & get_value_map() const
+  const CVC4ValueMap & get_value_map() const { return value_map_; }
+
+  const unordered_set<cvc4a::Sort, cvc4a::SortHashFunction> & get_all_sorts()
+      const
   {
-    return value_map_;
+    return all_sorts_;
   }
 
+  size_t num_values() const { return num_values_; }
+
  protected:
-  SmtSolver solver_;
-  OpSignatures op_map_;
-  unordered_map<Sort, UnorderedTermSet> value_map_;
+  cvc4a::Solver & solver_;
+  CVC4OpSignatures op_map_;
+  CVC4ValueMap value_map_;
+  unordered_set<cvc4a::Sort, cvc4a::SortHashFunction> all_sorts_;
+  size_t num_values_;
 };
 
 // helper class for generating grammar for CVC4 SyGuS
 cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
                                  const CVC4TermVec & cvc4_boundvars,
-                                 const OpSignatures & ops_map,
-                                 const vector<cvc4a::Term> * values,
-                                 bool all_consts)
+                                 const CVC4GrammarSeed * gs,
+                                 // 0 - no values
+                                 // 1 - values from CVC4GrammarSeed
+                                 // 2 - all values
+                                 size_t values)
 {
   // sorts and their terminal constructors (start constructors)
   cvc4a::Sort boolean = cvc4_solver.getBooleanSort();
@@ -274,38 +367,28 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
   // construct the grammar
   cvc4a::Grammar g = cvc4_solver.mkSygusGrammar(cvc4_boundvars, starts);
 
-  // group interesting values according to sorts
-  map<cvc4a::Sort, vector<cvc4a::Term>> values_sort_map;
-  if (values) {
-    for (const auto & v : *values) {
-      cvc4a::Sort s = v.getSort();
-      auto it = values_sort_map.find(s);
-      if (it != values_sort_map.end()) {
-        it->second.push_back(v);
-      } else {
-        values_sort_map[s] = {v};
-      }
-    }
-  }
+  if (gs) {
+    const CVC4OpSignatures & ops_map = gs->get_op_map();
+    const CVC4ValueMap & values_map = gs->get_value_map();
 
-  if (!ops_map.empty()) {
     // separate operators
-    unordered_map<SortKind, unordered_set<PrimOp>> reg_ops;
-    unordered_map<SortKind, unordered_set<PrimOp>> rel_ops;
-    unordered_map<SortKind, unordered_set<Op>> ms_ops;
+    unordered_map<SortKind, unordered_set<cvc4a::Kind>> reg_ops;
+    unordered_map<SortKind, unordered_set<cvc4a::Kind>> rel_ops;
+    unordered_map<SortKind, unordered_set<cvc4a::Op, cvc4a::OpHashFunction>>
+        ms_ops;
 
     for (const auto & opelem : ops_map) {
-      Op op = opelem.first;
-      PrimOp po = op.prim_op;
+      cvc4a::Op op = opelem.first;
+      cvc4a::Kind po = op.getKind();
       // for now, just bv or arithmetic (using REAL for both real and integer)
       SortKind sk = bv_ops.find(po) == bv_ops.end() ? REAL : BV;
       if (multisort_ops.find(po) != multisort_ops.end()) {
         ms_ops[sk].insert(op);
       } else if (relational_ops.find(po) != relational_ops.end()) {
-        assert(!op.num_idx);
+        assert(!op.isIndexed());
         rel_ops[sk].insert(po);
       } else {
-        assert(!op.num_idx);
+        assert(!op.isIndexed());
         reg_ops[sk].insert(po);
       }
     }
@@ -340,29 +423,24 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
 
       // regular
       for (const auto & po : reg_ops.at(sk)) {
-        size_t arity_min = get_arity(po).first;
-        if (arity_min == 1) {
-          logger.log(1, "UNARY: {}", po);
-          constructs[s].push_back(cvc4_solver.mkTerm(to_cvc4_ops.at(po), s));
-        } else if (arity_min == 2) {
+        if (unary_ops.find(po) == unary_ops.end()) {
           logger.log(1, "BINARY: {}", po);
-          constructs[s].push_back(cvc4_solver.mkTerm(to_cvc4_ops.at(po), s, s));
+          constructs[s].push_back(cvc4_solver.mkTerm(po, s, s));
         } else {
-          cout << "Unhandled Op: " << po << endl;
-          assert(false);
+          logger.log(1, "UNARY: {}", po);
+          constructs[s].push_back(cvc4_solver.mkTerm(po, s));
         }
       }
 
       // relational
       for (const auto & po : rel_ops.at(sk)) {
-        constructs[start_bool].push_back(
-            cvc4_solver.mkTerm(to_cvc4_ops.at(po), s, s));
+        constructs[start_bool].push_back(cvc4_solver.mkTerm(po, s, s));
       }
 
       // add values
-      if (!all_consts) {
-        auto it = values_sort_map.find(s.getSort());
-        if (it != values_sort_map.end()) {
+      if (values < 2) {
+        auto it = values_map.find(s.getSort());
+        if (it != values_map.end()) {
           for (const auto & val : it->second) {
             constructs[s].push_back(val);
           }
@@ -375,41 +453,19 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
     vector<SortKind> sortkinds;
     for (SortKind sk : sortkinds) {
       for (const auto & op : ms_ops[sk]) {
-        // look up signature and get corresponding start terms
-        vector<cvc4a::Sort> signature;
-        for (const auto & sort : ops_map.at(op)) {
-          // TODO fix this needs to be translated to cvc4 solver as well
-          // need access to to_cvc4 which we don't have
-          cvc4a::Sort cvc4_sort =
-              static_pointer_cast<CVC4Sort>(sort)->get_cvc4_sort();
-          signature.push_back(cvc4_sort);
-        }
+        for (const auto & signature : ops_map.at(op)) {
+          assert(signature.isFunction());
+          vector<cvc4a::Term> args;
+          for (const auto & sort : signature.getFunctionDomainSorts()) {
+            // TODO might not have start terms for all sorts
+            //      need to create a start term for each sort in the problem
+            args.push_back(sort2start.at(sort));
+          }
 
-        cvc4a::Sort return_sort = signature.back();
-        signature.pop_back();
-
-        vector<cvc4a::Term> args;
-        args.reserve(signature.size());
-        // TODO might not have start terms for all sorts
-        // need to collect all relevant sorts in GrammarSeed
-        for (const auto & sort : signature) {
-          args.push_back(sort2start.at(sort));
+          cvc4a::Term return_start_term =
+              sort2start.at(signature.getFunctionCodomainSort());
+          constructs[return_start_term].push_back(cvc4_solver.mkTerm(op, args));
         }
-
-        PrimOp po = op.prim_op;
-        cvc4a::Term return_start_term = sort2start.at(return_sort);
-        cvc4a::Op cvc4_op;
-        cvc4a::Kind kind = to_cvc4_ops.at(po);
-        if (op.num_idx == 0) {
-          cvc4_op = cvc4_solver.mkOp(kind);
-        } else if (op.num_idx == 1) {
-          cvc4_op = cvc4_solver.mkOp(kind, op.idx0);
-        } else {
-          assert(op.num_idx == 2);
-          cvc4_op = cvc4_solver.mkOp(kind, op.idx0, op.idx1);
-        }
-        constructs[return_start_term].push_back(
-            cvc4_solver.mkTerm(cvc4_op, args));
       }
     }
 
@@ -420,7 +476,7 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
       // add rules for this nonterminal start term
       g.addRules(start_term, rules);
 
-      if (all_consts) {
+      if (values == 2) {
         g.addAnyConstant(start_term);
       }
     }
@@ -451,11 +507,15 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
       }
       vector<cvc4a::Term> constructs = {bvadd, bvmul,
                                         bvand, bvor, bvnot, bvneg };
-      if (!all_consts) {
+      if (values == 0) {
+        // no constants in this case
+        ;
+      } else if (values == 1) {
         constructs.push_back(zero);
         constructs.push_back(one);
         constructs.push_back(min_signed);
       } else {
+        assert(values == 2);
         g.addAnyConstant(s);
       }
       constructs.insert(
@@ -1155,33 +1215,23 @@ bool IC3IA::cvc4_synthesize_preds(
     cvc4_boundvars.push_back(cvc4_bv);
   }
 
-  GrammarSeed gs(solver_);
-  gs.scan(abs_trace);
+  CVC4GrammarSeed gs(cvc4_solver);
+  Term transferred_trace = to_cvc4_.transfer_term(abs_trace, BOOL);
+  gs.scan(static_pointer_cast<CVC4Term>(transferred_trace)->get_cvc4_term());
 
-  vector<cvc4a::Term> abs_trace_values_cvc4;
-  for (const auto & valelem : gs.get_value_map()) {
-    for (const auto & v : valelem.second) {
-      cvc4a::Term cvc4_val =
-          static_pointer_cast<CVC4Term>(to_cvc4_.transfer_term(v))
-              ->get_cvc4_term();
-      abs_trace_values_cvc4.push_back(cvc4_val);
-    }
-  }
-
-  logger.log(1, "Number of Values : {}", abs_trace_values_cvc4.size());
+  logger.log(1, "Number of Values : {}", gs.num_values());
 
   // Grammar construction
-  cvc4a::Grammar g = cvc4_make_grammar(cvc4_solver,
-                                       cvc4_boundvars,
-                                       gs.get_op_map(),
-                                       NULL,
-                                       options_.ic3ia_cvc4_pred_all_consts_);
+  cvc4a::Grammar g =
+      cvc4_make_grammar(cvc4_solver,
+                        cvc4_boundvars,
+                        &gs,
+                        options_.ic3ia_cvc4_pred_all_consts_ ? 2 : 0);
   cvc4a::Grammar g_with_values =
       cvc4_make_grammar(cvc4_solver,
                         cvc4_boundvars,
-                        gs.get_op_map(),
-                        &abs_trace_values_cvc4,
-                        options_.ic3ia_cvc4_pred_all_consts_);
+                        &gs,
+                        options_.ic3ia_cvc4_pred_all_consts_ ? 2 : 1);
 
   vector<cvc4a::Term> pred_vec;
   for (size_t n = 0; n < num_preds; ++n) {

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -117,7 +117,7 @@ const unordered_set<cvc4a::Kind> unary_ops({ cvc4a::BITVECTOR_NEG,
                                              cvc4a::UMINUS });
 
 const unordered_set<cvc4a::Kind> bool_ops(
-    { cvc4a::AND, cvc4a::OR, cvc4a::XOR, cvc4a::NOT, cvc4a::IMPLIES });
+    { cvc4a::AND, cvc4a::OR, cvc4a::XOR, cvc4a::NOT, cvc4a::IMPLIES, cvc4a::ITE });
 
 // Helpers for CVC4 SyGuS Predicate Search
 // should eventually be moved elsewhere

--- a/engines/ic3ia.cpp
+++ b/engines/ic3ia.cpp
@@ -247,19 +247,23 @@ cvc4a::Grammar cvc4_make_grammar(cvc4a::Solver & cvc4_solver,
   cvc4a::Term start_bool = cvc4_solver.mkVar(boolean, "Start");
   vector<cvc4a::Term> start_terms;
 
-  CVC4SortSet grammar_sorts;
-  // collect all required sorts
-  for (auto cvc4_boundvar : cvc4_boundvars) {
-    cvc4a::Sort s = cvc4_boundvar.getSort();
-    if (s.isBitVector()) {
-      grammar_sorts.insert(s);
+  unordered_map<cvc4a::Sort, cvc4a::Term, cvc4a::SortHashFunction> sort2start;
+  for (const auto & cvc4_bv : cvc4_boundvars)
+  {
+    cvc4a::Sort sort = cvc4_bv.getSort();
+    // TODO: remove this limitation
+    if (!sort.isBitVector())
+    {
+      cout << "Skipping unsupported sort " << sort << endl;
+      continue;
     }
-  }
 
-  // for each sort, introduce a new constructor for the grammar
-  for (auto s : grammar_sorts) {
-    cvc4a::Term start_term = cvc4_solver.mkVar(s, s.toString() + "_start");
-    start_terms.push_back(start_term);
+    if (sort2start.find(sort) == sort2start.end())
+    {
+      cvc4a::Term start_term = cvc4_solver.mkVar(sort, sort.toString() + "_start");
+      sort2start[sort] = start_term;
+      start_terms.push_back(start_term);
+    }
   }
 
   // merge the Boolean start and the BV start

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -59,6 +59,7 @@ enum optionIndex
   IC3IA_CVC4_PRED,
   IC3IA_CVC4_PRED_SIZE,
   IC3IA_CVC4_PRED_ALL_CONSTS,
+  IC3IA_CVC4_PRED_ALL_SORTS,
   PSEUDO_INIT_PROP,
   ASSUME_PROP,
   CEGP_ABS_VALS,
@@ -309,13 +310,20 @@ const option::Descriptor usage[] = {
     "",
     "ic3ia-cvc4-pred-size",
     Arg::Numeric,
-    "  --ic3ia-cvc4-pred-size \tlimit size of each predicate."},
-{ IC3IA_CVC4_PRED_ALL_CONSTS,
+    "  --ic3ia-cvc4-pred-size \tlimit size of each predicate." },
+  { IC3IA_CVC4_PRED_ALL_CONSTS,
     0,
     "",
     "ic3ia-cvc4-pred-all-consts",
     Arg::None,
-    "  --ic3ia-cvc4-pred-all-consts \tuse all constants in the grammar."},
+    "  --ic3ia-cvc4-pred-all-consts \tuse all constants in the grammar." },
+  { IC3IA_CVC4_PRED_ALL_SORTS,
+    0,
+    "",
+    "ic3ia-cvc4-pred-all-sorts",
+    Arg::None,
+    "  --ic3ia-cvc4-pred-all-sorts \tuse all sorts from query in the grammar."
+    " (otherwise just sorts of the variables)" },
   { PSEUDO_INIT_PROP,
     0,
     "",
@@ -357,7 +365,8 @@ const option::Descriptor usage[] = {
     "",
     "ceg-bv-arith-min-bw",
     Arg::Numeric,
-    "  --ceg-bv-arith-min-bw \tminimum bitwidth of operators to abstract - must be positive (default: 16) " },
+    "  --ceg-bv-arith-min-bw \tminimum bitwidth of operators to abstract - "
+    "must be positive (default: 16) " },
   { PROMOTE_INPUTVARS,
     0,
     "",
@@ -512,6 +521,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
         case IC3IA_CVC4_PRED: ic3ia_cvc4_pred_ = true; break;
         case IC3IA_CVC4_PRED_SIZE: ic3ia_cvc4_pred_size_ = atoi(opt.arg); break;
         case IC3IA_CVC4_PRED_ALL_CONSTS: ic3ia_cvc4_pred_all_consts_ = true; break;
+        case IC3IA_CVC4_PRED_ALL_SORTS:
+          ic3ia_cvc4_pred_all_sorts_ = true;
+          break;
         case PSEUDO_INIT_PROP: pseudo_init_prop_ = true; break;
         case ASSUME_PROP: assume_prop_ = true; break;
         case CEGP_ABS_VALS: cegp_abs_vals_ = true; break;

--- a/options/options.h
+++ b/options/options.h
@@ -183,6 +183,7 @@ class PonoOptions
   bool ic3ia_cvc4_pred_;
   unsigned int ic3ia_cvc4_pred_size_;
   bool ic3ia_cvc4_pred_all_consts_;
+  bool ic3ia_cvc4_pred_all_sorts_;
 
  private:
   // Default options
@@ -213,6 +214,7 @@ class PonoOptions
   static const std::string default_profiling_log_filename_;
   static const bool default_ic3ia_cvc4_pred_ = false;
   static const bool default_ic3ia_cvc4_pred_all_consts_ = false;
+  static const bool default_ic3ia_cvc4_pred_all_sorts_ = false;
   static const unsigned int default_ic3ia_cvc4_pred_size_ = 2;
   static const bool default_pseudo_init_prop_ = false;
   static const bool default_assume_prop_ = false;

--- a/tests/test_ic3ia.cpp
+++ b/tests/test_ic3ia.cpp
@@ -102,12 +102,6 @@ TEST_P(IC3IAUnitTests, CounterSystemUnsafe)
 
 TEST_P(IC3IAUnitTests, InductiveIntSafe)
 {
-  if (opts.ic3ia_cvc4_pred_) {
-    // Temporarily not supporting arithmetic
-    cout << "Skipping unsupported INT theory" << endl;
-    return;
-  }
-
   FunctionalTransitionSystem fts(s);
   Term max_val = fts.make_term(10, intsort);
 
@@ -127,12 +121,6 @@ TEST_P(IC3IAUnitTests, InductiveIntSafe)
 
 TEST_P(IC3IAUnitTests, SimpleIntSafe)
 {
-  if (opts.ic3ia_cvc4_pred_) {
-    // Temporarily not supporting arithmetic
-    cout << "Skipping unsupported INT theory" << endl;
-    return;
-  }
-
   RelationalTransitionSystem rts(s);
   Term x = rts.make_statevar("x", intsort);
   Term y = rts.make_statevar("y", intsort);


### PR DESCRIPTION
Note: this does not always improve performance. Adding multi-sort operators (e.g. Extract / Concat) requires adding more sorts to the grammar (before it was just the sorts of variables). This ended up losing us some benchmarks. There's an option for whether to add sorts or not which is off by default. Furthermore, even without adding all sorts, you could still add multi-sort operators that only use sorts in the grammar already and this seems to hurt performance slightly. Solving ~42 hwmcc20_bv benchmarks (with multi-sort operators manually disabled) and 841 kind benchmarks.