### PR TITLE
Update smt switch version

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=c3957b2e7fec8af4fab24df089230c88e523c0e6
+SMT_SWITCH_VERSION=a2af6ea75b994d666c9c175793a70c8945208ba5
 
 usage () {
     cat <<EOF

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -412,7 +412,7 @@ void CegProphecyArrays<Prover_T>::reduce_consecutive_axioms(
   assert(res.is_unsat());
 
   UnorderedTermSet core;
-  super::solver_->get_unsat_core(core);
+  super::solver_->get_unsat_assumptions(core);
 
   for (auto l : assumps) {
     if (core.find(l) == core.end()) {

--- a/engines/cegar_ops_uf.cpp
+++ b/engines/cegar_ops_uf.cpp
@@ -49,7 +49,7 @@ CegarOpsUf<Prover_T>::CegarOpsUf(const Property & p,
       cegopsuf_ts_(cegopsuf_solver_),
       cegopsuf_un_(cegopsuf_ts_)
 {
-  cegopsuf_solver_->set_opt("produce-unsat-cores", "true");
+  cegopsuf_solver_->set_opt("produce-unsat-assumptions", "true");
 }
 
 template <class Prover_T>
@@ -194,7 +194,7 @@ bool CegarOpsUf<Prover_T>::cegar_refine()
   if (r.is_unsat()) {
     UnorderedTermSet axioms;
     UnorderedTermSet core;
-    cegopsuf_solver_->get_unsat_core(core);
+    cegopsuf_solver_->get_unsat_assumptions(core);
 
     for (size_t i = 0; i < assumps.size(); ++i) {
       if (core.find(assumps[i]) != core.end()) {

--- a/engines/cegar_values.cpp
+++ b/engines/cegar_values.cpp
@@ -179,7 +179,7 @@ CegarValues<Prover_T>::CegarValues(const Property & p,
       cegval_ts_(cegval_solver_),
       cegval_un_(cegval_ts_)
 {
-  cegval_solver_->set_opt("produce-unsat-cores", "true");
+  cegval_solver_->set_opt("produce-unsat-assumptions", "true");
 }
 
 template <class Prover_T>
@@ -348,7 +348,7 @@ bool CegarValues<Prover_T>::cegar_refine()
   if (r.is_unsat()) {
     UnorderedTermSet core;
     UnorderedTermSet axioms;
-    cegval_solver_->get_unsat_core(core);
+    cegval_solver_->get_unsat_assumptions(core);
     for (size_t i = 0; i < assumps.size(); ++i) {
       if (core.find(assumps[i]) != core.end()) {
         Term eq = equalities[i];

--- a/engines/ic3base.cpp
+++ b/engines/ic3base.cpp
@@ -99,8 +99,7 @@ IC3Base::IC3Base(const Property & p,
       solver_context_(0),
       num_check_sat_since_reset_(0),
       failed_to_reset_solver_(false),
-      approx_pregen_(false),
-      boolsort_(solver_->make_sort(BOOL))
+      approx_pregen_(false)
 {
 }
 
@@ -112,6 +111,9 @@ void IC3Base::initialize()
     return;
   }
 
+  boolsort_ = solver_->make_sort(BOOL);
+  solver_true_ = solver_->make_term(true);
+
   // abstract the transition relation if this is a CEGAR implementation
   // otherwise it is a No-Op
   abstract();
@@ -122,7 +124,6 @@ void IC3Base::initialize()
   check_ts();
 
   assert(solver_context_ == 0);  // expecting to be at base context level
-  solver_true_ = solver_->make_term(true);
 
   frames_.clear();
   frame_labels_.clear();
@@ -517,7 +518,7 @@ bool IC3Base::rel_ind_check(size_t i,
 
     // Use unsat core to get cheap generalization
     UnorderedTermSet core;
-    solver_->get_unsat_core(core);
+    solver_->get_unsat_assumptions(core);
     assert(core.size());
 
     TermVec gen;  // cheap unsat-core generalization of c

--- a/engines/ic3sa.cpp
+++ b/engines/ic3sa.cpp
@@ -416,7 +416,7 @@ RefineResult IC3SA::ic3sa_refine_functional(Term & learned_lemma)
 
   assert(r.is_unsat());  // not expecting unknown
   UnorderedTermSet core;
-  solver_->get_unsat_core(core);
+  solver_->get_unsat_assumptions(core);
   assert(core.size());
 
   TermVec reduced_constraints;
@@ -545,7 +545,7 @@ RefineResult IC3SA::ic3sa_refine_value(Term & learned_lemma)
 
   assert(r.is_unsat());  // not expecting unknown
   UnorderedTermSet core;
-  solver_->get_unsat_core(core);
+  solver_->get_unsat_assumptions(core);
   assert(core.size());
 
   pop_solver_context();

--- a/engines/mbic3.cpp
+++ b/engines/mbic3.cpp
@@ -73,7 +73,6 @@ ModelBasedIC3::ModelBasedIC3(const Property & p, const TransitionSystem & ts,
   : super(p, ts, slv, opt)
 {
   engine_ = Engine::MBIC3;
-  solver_->set_opt("produce-unsat-cores", "true");
 }
 
 IC3Formula ModelBasedIC3::get_model_ic3formula() const

--- a/engines/syguspdr.cpp
+++ b/engines/syguspdr.cpp
@@ -88,7 +88,7 @@ SygusPdr::SygusPdr(const Property & p, const TransitionSystem & ts,
     partial_model_getter(solver_),
     has_assumptions(true) // most conservative way
 {
-  solver_->set_opt("produce-unsat-cores", "true");
+  solver_->set_opt("produce-unsat-assumptions", "true");
 
   // we need to have the reset-assertion capability 
   if(solver_->get_solver_enum() == SolverEnum::BTOR)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
       CACHE STRING "Extra flags to the cython compiler." FORCE)
 endif()
 
-include_directories("${PROJECT_SOURCE_DIR}/deps/smt-switch/python")
+include_directories("${PROJECT_SOURCE_DIR}/deps/smt-switch/python/smt_switch")
 
 include(FindPythonExtensions)
 

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -554,6 +554,7 @@ cdef class BTOR2Encoder:
     cdef c_BTOR2Encoder * cbe
     def __cinit__(self, str filename, __AbstractTransitionSystem ts):
         self.cbe = new c_BTOR2Encoder(filename.encode(), dref(ts.cts))
+        self._ts = ts
 
     def __dealloc__(self):
         del self.cbe
@@ -562,6 +563,7 @@ IF WITH_COREIR == "ON":
     cdef class CoreIREncoder:
         cdef c_CoreIREncoder * cbe
         def __cinit__(self, mod, RelationalTransitionSystem ts):
+            self._ts = ts
             cdef uintptr_t adr
             if isinstance(mod, str):
                 self.cbe = new c_CoreIREncoder((<string?> (mod.encode())), dref((<c_RelationalTransitionSystem *> ts.cts)))

--- a/refiners/array_axiom_enumerator.cpp
+++ b/refiners/array_axiom_enumerator.cpp
@@ -266,7 +266,7 @@ bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
   UnorderedTermSet core_set;
   if (reduce_axioms_unsatcore_) {
     try {
-      solver_->get_unsat_core(core_set);
+      solver_->get_unsat_assumptions(core_set);
     }
     catch (SmtException & e) {
       // if core is empty, that's fine -- continue

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -158,7 +158,7 @@ SmtSolver create_solver_for(SolverEnum se,
 
   assert(s);
   if (ic3_engine) {
-    s->set_opt("produce-unsat-cores", "true");
+    s->set_opt("produce-unsat-assumptions", "true");
   }
   return s;
 }
@@ -169,7 +169,7 @@ SmtSolver create_reducer_for(SolverEnum se, Engine e, bool logging)
   if (se != MSAT) {
     s = create_solver_base(se, logging);
     s->set_opt("incremental", "true");
-    s->set_opt("produce-unsat-cores", "true");
+    s->set_opt("produce-unsat-assumptions", "true");
   }
 #ifdef WITH_MSAT
   else {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -243,6 +243,18 @@ const std::vector<SolverEnum> itp_enums({
 
 std::vector<SolverEnum> available_solver_enums() { return solver_enums; }
 
+std::vector<SolverEnum> available_solver_enums_except(
+    const std::unordered_set<SolverEnum> & exclude)
+{
+  std::vector<SolverEnum> res;
+  for (const auto & se : solver_enums) {
+    if (exclude.find(se) == exclude.end()) {
+      res.push_back(se);
+    }
+  }
+  return res;
+}
+
 std::vector<SolverEnum> available_interpolator_enums() { return itp_enums; };
 
 std::vector<SolverEnum> filter_solver_enums(

--- a/smt/available_solvers.h
+++ b/smt/available_solvers.h
@@ -62,6 +62,9 @@ smt::SmtSolver create_interpolating_solver_for(smt::SolverEnum se, Engine e);
 // collect all the available solvers
 std::vector<smt::SolverEnum> available_solver_enums();
 
+std::vector<smt::SolverEnum> available_solver_enums_except(
+    const std::unordered_set<smt::SolverEnum> & exclude);
+
 // collect all the available interpolating solvers
 std::vector<smt::SolverEnum> available_interpolator_enums();
 

--- a/tests/encoders/test_btor2_ts_copy_equal.cpp
+++ b/tests/encoders/test_btor2_ts_copy_equal.cpp
@@ -183,8 +183,14 @@ TEST_P(CopyUnitTests, CopyToDefault)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverCopyUnitTests,
     CopyUnitTests,
-    testing::Combine(testing::ValuesIn(available_solver_enums()),
-                     // from test_encoder_inputs.h
-                     testing::ValuesIn(btor2_inputs)));
+    // TEMP excluding CVC4 because these tests use two solvers
+    // (default and created one)
+    // and this causes strange behavior for CVC4 until its fixed
+    // (note: updated to cvc5 now)
+    // see https://github.com/cvc5/cvc5/issues/5893
+    testing::Combine(
+        testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })),
+        // from test_encoder_inputs.h
+        testing::ValuesIn(btor2_inputs)));
 
 }  // namespace pono_tests

--- a/tests/test_ceg_prophecy_arrays.cpp
+++ b/tests/test_ceg_prophecy_arrays.cpp
@@ -17,7 +17,7 @@ TEST(CegProphecyArraysTest, Simple)
   set_global_logger_verbosity(1);
 
   SmtSolver s = create_solver(MSAT);
-  s->set_opt("produce-unsat-cores", "true");
+  s->set_opt("produce-unsat-assumptions", "true");
   RelationalTransitionSystem rts(s);
   Sort bvsort8 = rts.make_sort(BV, 8);
   Sort bvsort32 = rts.make_sort(BV, 32);

--- a/tests/test_ic3.cpp
+++ b/tests/test_ic3.cpp
@@ -76,7 +76,12 @@ TEST_P(IC3UnitTests, SimpleSystemUnsafe)
   ASSERT_EQ(r, FALSE);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverIC3UnitTests,
-                         IC3UnitTests,
-                         testing::ValuesIn(available_solver_enums()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSolverIC3UnitTests,
+    IC3UnitTests,
+    // TEMP excluding CVC4 because IC3 variants use two solvers
+    // and this causes strange behavior for CVC4 until its fixed
+    // (note: updated to cvc5 now)
+    // see https://github.com/cvc5/cvc5/issues/5893
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
 }  // namespace pono_tests

--- a/tests/test_ic3bits.cpp
+++ b/tests/test_ic3bits.cpp
@@ -62,8 +62,13 @@ TEST_P(IC3BitsUnitTests, CounterSystemSafe)
   ASSERT_TRUE(check_invar(fts, prop_term, invar));
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverIC3BitsUnitTests,
-                         IC3BitsUnitTests,
-                         testing::ValuesIn(available_solver_enums()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSolverIC3BitsUnitTests,
+    IC3BitsUnitTests,
+    // TEMP excluding CVC4 because IC3 variants use two solvers
+    // and this causes strange behavior for CVC4 until its fixed
+    // (note: updated to cvc5 now)
+    // see https://github.com/cvc5/cvc5/issues/5893
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
 
 }  // namespace pono_tests

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -133,8 +133,13 @@ TEST_P(IC3SAUnitTests, SimpleCounterVar)
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverIC3SAUnitTests,
-                         IC3SAUnitTests,
-                         testing::ValuesIn(available_solver_enums()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSolverIC3SAUnitTests,
+    IC3SAUnitTests,
+    // TEMP excluding CVC4 because IC3 variants use two solvers
+    // and this causes strange behavior for CVC4 until its fixed
+    // (note: updated to cvc5 now)
+    // see https://github.com/cvc5/cvc5/issues/5893
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
 
 }  // namespace pono_tests

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -49,7 +49,7 @@ class IC3SAUnitTests : public ::testing::Test,
   void SetUp() override
   {
     s = create_solver(GetParam());
-    s->set_opt("produce-unsat-cores", "true");
+    s->set_opt("produce-unsat-assumptions", "true");
   }
   SmtSolver s;
 };

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -140,7 +140,7 @@ TEST_P(UtilsEngineUnitTests, MakeProver)
   }
 
   SmtSolver s = create_solver(se);
-  s->set_opt("produce-unsat-cores", "true");
+  s->set_opt("produce-unsat-assumptions", "true");
   std::shared_ptr<Prover> prover = make_prover(eng, prop, fts, s);
   ProverResult r = prover->check_until(9);
 

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -139,6 +139,14 @@ TEST_P(UtilsEngineUnitTests, MakeProver)
     return;
   }
 
+  // TEMP excluding CVC4 because IC3 variants use two solvers
+  // and this causes strange behavior for CVC4 until its fixed
+  // (note: updated to cvc5 now)
+  // see https://github.com/cvc5/cvc5/issues/5893
+  if (se == smt::CVC4) {
+    return;
+  }
+
   SmtSolver s = create_solver(se);
   s->set_opt("produce-unsat-assumptions", "true");
   std::shared_ptr<Prover> prover = make_prover(eng, prop, fts, s);

--- a/tests/test_witness.cpp
+++ b/tests/test_witness.cpp
@@ -89,8 +89,14 @@ TEST_P(WitnessUnitTests, ArraysDefaultSolver)
   ASSERT_EQ(witness[6][x], fts.make_term(10, bvsort4));
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedWitnessUnitTests,
-                         WitnessUnitTests,
-                         testing::ValuesIn(available_solver_enums()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedWitnessUnitTests,
+    WitnessUnitTests,
+    // TEMP excluding CVC4 because these tests use two solvers
+    // (default and created one)
+    // and this causes strange behavior for CVC4 until its fixed
+    // (note: updated to cvc5 now)
+    // see https://github.com/cvc5/cvc5/issues/5893
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
 
 }  // namespace pono_tests

--- a/travis-scripts/download-cvc4.sh
+++ b/travis-scripts/download-cvc4.sh
@@ -29,13 +29,13 @@ done
 if [ ! -d "$DEPS/CVC4" ]; then
     cd $DEPS
     if [[ "$OSTYPE" == linux* ]]; then
-        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux.tar.bz2
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux-smtswitch.tar.bz2
     elif [[ "$OSTYPE" == darwin* ]]; then
-        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-mac.tar.bz2
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-mac-smtswitch.tar.bz2
     elif [[ "$OSTYPE" == msys* ]]; then
         echo "Pre-compiled libraries for Windows not yet available"
     elif [[ "$OSTYPE" == cygwin* ]]; then
-        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux.tar.bz2
+        curl -o CVC4.tar.bz2 -L http://web.stanford.edu/~makaim/files/CVC4-linux-smtswitch.tar.bz2
     else
         echo "Unrecognized OSTYPE=$OSTYPE"
         exit 1
@@ -51,7 +51,7 @@ fi
 
 if [ -f $DEPS/CVC4/build/src/libcvc4.a ] ; then \
     echo "It appears CVC4 was setup successfully into $DEPS/CVC4."
-    echo "You may now install it with make ./configure.sh --msat && cd build && make"
+    echo "You may now install it with make ./configure.sh --cvc4 && cd build && make"
 else
     echo "Downloading CVC4 failed."
     exit 1

--- a/utils/sygus_ic3formula_helper.cpp
+++ b/utils/sygus_ic3formula_helper.cpp
@@ -101,7 +101,7 @@ void reduce_unsat_core_to_fixedpoint(
     assert(r.is_unsat());
 
     smt::UnorderedTermSet core_out;
-    reducer_->get_unsat_core(core_out);
+    reducer_->get_unsat_assumptions(core_out);
     if (core_inout.size() == core_out.size()) {
       break; // fixed point is reached
     }
@@ -175,7 +175,7 @@ void reduce_unsat_core_linear(
       ++ to_remove_pos;
     } else { // if unsat, we can remove
       smt::UnorderedTermSet core_set;
-      reducer_->get_unsat_core(core_set);
+      reducer_->get_unsat_assumptions(core_set);
       // below function will update assumption_list and to_remove_pos
       remove_and_move_to_next(assumption_list, to_remove_pos, core_set);
     }


### PR DESCRIPTION
This PR updates the smt-switch version used in Pono. It temporarily disables any tests that use two CVC4 instances, due to https://github.com/cvc5/cvc5/issues/5893. This limitation will be removed once that issue is resolved, and the updated version of (now) cvc5 is available through smt-switch.