### PR TITLE
Align reached_k

### DIFF
--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -78,9 +78,8 @@ bool Bmc::step(int i)
     res = false;
   } else {
     solver_->pop();
+    ++reached_k_;
   }
-
-  ++reached_k_;
 
   return res;
 }

--- a/engines/interpolantmc.cpp
+++ b/engines/interpolantmc.cpp
@@ -167,8 +167,6 @@ bool InterpolantMC::step(int i)
       if (!r.is_sat()) {
         throw PonoException("Internal error: Expecting satisfiable result");
       }
-      // increment reached_k_ so that witness goes up to the bad state
-      ++reached_k_;
       return false;
     }
     else if (r.is_unknown())

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -78,7 +78,6 @@ bool KInduction::base_step(int i)
   solver_->assert_formula(unroller_.at_time(bad_, i));
   Result r = solver_->check_sat();
   if (r.is_sat()) {
-    ++reached_k_;
     return false;
   }
   solver_->pop();

--- a/engines/msat_ic3ia.cpp
+++ b/engines/msat_ic3ia.cpp
@@ -166,7 +166,9 @@ bool MsatIC3IA::compute_witness(msat_env env,
   assert(ic3ia_wit.size());
 
   // set reached_k_ so that it matches the counterexample length
-  reached_k_ = ic3ia_wit.size() - 1;
+  // reached_k_ was last bound without a counterexample, so
+  // it's size - 2
+  reached_k_ = ic3ia_wit.size() - 2;
 
   // set up a BMC query
   // with state variables constrained at each step

--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -206,7 +206,7 @@ bool Prover::compute_witness()
 {
   // TODO: make sure the solver state is SAT
 
-  for (int i = 0; i <= reached_k_; ++i) {
+  for (int i = 0; i <= reached_k_ + 1; ++i) {
     witness_.push_back(UnorderedTermMap());
     UnorderedTermMap & map = witness_.back();
 

--- a/engines/prover.h
+++ b/engines/prover.h
@@ -112,7 +112,7 @@ class Prover
 
   Unroller unroller_;
 
-  int reached_k_;
+  int reached_k_;  ///< the last bound reached with no counterexamples
 
   smt::Term bad_;
 

--- a/modifiers/array_abstractor.cpp
+++ b/modifiers/array_abstractor.cpp
@@ -292,7 +292,7 @@ void ArrayAbstractor::abstract_vars()
   for (auto iv : conc_ts_.inputvars()) {
     sort = iv->get_sort();
     if (sort->get_sort_kind() == ARRAY) {
-      abs_var = abs_ts_.make_statevar("abs_" + iv->to_string(),
+      abs_var = abs_ts_.make_inputvar("abs_" + iv->to_string(),
                                       abstract_array_sort(sort));
       update_term_cache(iv, abs_var);
     } else {

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -220,7 +220,9 @@ SmtSolver create_interpolating_solver_for(SolverEnum se, Engine e)
       // These will be managed by the solver object
       // don't need to destroy
       msat_config cfg =
-          get_msat_config_for_ic3(true, { { "model_generation", "false" } });
+          get_msat_config_for_ic3(true,
+                                  { { "bool_model_generation", "false" },
+                                    { "model_generation", "true" } });
       msat_env env = msat_create_env(cfg);
       return std::make_shared<MsatInterpolatingSolver>(cfg, env);
       break;


### PR DESCRIPTION
This PR updates each engine to use `reached_k` with the same meaning. This fixes a corner case bug in counterexample-guided prophecy and ensures that `reached_k` is used the same by all engines. 

The PR also enables model generation for interpolators and allows input variables, both minor tweaks in counterexample-guided prophecy.