### PR TITLE
Disable support for finite domain indices in CEGP

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -214,17 +214,32 @@ void CegProphecyArrays<Prover_T>::initialize()
   super::initialize();
 
   bool contains_arrays = false;
+  Sort boolsort = super::solver_->make_sort(BOOL);
+  Sort sort;
   for (const auto &sv : conc_ts_.statevars()) {
-    if (sv->get_sort()->get_sort_kind() == ARRAY) {
+    sort = sv->get_sort();
+    if (sort->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      break;
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk != REAL && sk != INT) {
+        throw PonoException(
+            "CEGP currently only supports infinite domain indices in arrays "
+            "due to an edge case for constant arrays, but got "
+            + sort->to_string());
+      }
     }
   }
 
   for (const auto &iv : conc_ts_.inputvars()) {
     if (iv->get_sort()->get_sort_kind() == ARRAY) {
       contains_arrays = true;
-      break;
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk != REAL && sk != INT) {
+        throw PonoException(
+            "CEGP currently only supports infinite domain indices in arrays "
+            "due to an edge case for constant arrays, but got "
+            + sort->to_string());
+      }
     }
   }
 

--- a/tests/test_ceg_prophecy_arrays.cpp
+++ b/tests/test_ceg_prophecy_arrays.cpp
@@ -19,25 +19,24 @@ TEST(CegProphecyArraysTest, Simple)
   SmtSolver s = create_solver(MSAT);
   s->set_opt("produce-unsat-assumptions", "true");
   RelationalTransitionSystem rts(s);
-  Sort bvsort8 = rts.make_sort(BV, 8);
-  Sort bvsort32 = rts.make_sort(BV, 32);
-  Sort arrsort = rts.make_sort(ARRAY, bvsort8, bvsort32);
-  Term i = rts.make_statevar("i", bvsort8);
-  Term j = rts.make_statevar("j", bvsort8);
-  Term d = rts.make_statevar("d", bvsort32);
+  Sort intsort = rts.make_sort(INT);
+  Sort arrsort = rts.make_sort(ARRAY, intsort, intsort);
+  Term i = rts.make_statevar("i", intsort);
+  Term j = rts.make_statevar("j", intsort);
+  Term d = rts.make_statevar("d", intsort);
   Term a = rts.make_statevar("a", arrsort);
 
-  Term constarr0 = rts.make_term(rts.make_term(0, bvsort32), arrsort);
+  Term constarr0 = rts.make_term(rts.make_term(0, intsort), arrsort);
   rts.set_init(rts.make_term(Equal, a, constarr0));
   rts.assign_next(
       a,
       rts.make_term(Ite,
-                    rts.make_term(BVUlt, d, rts.make_term(200, bvsort32)),
+                    rts.make_term(Lt, d, rts.make_term(200, intsort)),
                     rts.make_term(Store, a, i, d),
                     a));
 
   Term prop_term = rts.make_term(
-      BVUlt, rts.make_term(Select, a, j), rts.make_term(200, bvsort32));
+      Lt, rts.make_term(Select, a, j), rts.make_term(200, intsort));
   Property prop(s, prop_term);
   std::shared_ptr<Prover> cegp = make_ceg_proph_prover(INTERP, prop, rts, s);
   ProverResult r = cegp->check_until(5);

--- a/tests/test_cegar_values.cpp
+++ b/tests/test_cegar_values.cpp
@@ -21,25 +21,24 @@ TEST(CegValues, SimpleSafe)
 
   SmtSolver s = create_solver(MSAT);
   RelationalTransitionSystem rts(s);
-  Sort bvsort8 = rts.make_sort(BV, 8);
-  Sort bvsort32 = rts.make_sort(BV, 32);
-  Sort arrsort = rts.make_sort(ARRAY, bvsort8, bvsort32);
-  Term i = rts.make_statevar("i", bvsort8);
-  Term j = rts.make_statevar("j", bvsort8);
-  Term d = rts.make_statevar("d", bvsort32);
+  Sort intsort = rts.make_sort(INT);
+  Sort arrsort = rts.make_sort(ARRAY, intsort, intsort);
+  Term i = rts.make_statevar("i", intsort);
+  Term j = rts.make_statevar("j", intsort);
+  Term d = rts.make_statevar("d", intsort);
   Term a = rts.make_statevar("a", arrsort);
 
-  Term constarr0 = rts.make_term(rts.make_term(0, bvsort32), arrsort);
+  Term constarr0 = rts.make_term(rts.make_term(0, intsort), arrsort);
   rts.set_init(rts.make_term(Equal, a, constarr0));
   rts.assign_next(
       a,
       rts.make_term(Ite,
-                    rts.make_term(BVUlt, d, rts.make_term(200, bvsort32)),
+                    rts.make_term(Lt, d, rts.make_term(200, intsort)),
                     rts.make_term(Store, a, i, d),
                     a));
 
   Term prop_term = rts.make_term(
-      BVUlt, rts.make_term(Select, a, j), rts.make_term(200, bvsort32));
+      Lt, rts.make_term(Select, a, j), rts.make_term(200, intsort));
   Property prop(s, prop_term);
 
   // TODO create a make_ command for this
@@ -56,27 +55,26 @@ TEST(CegValues, SimpleUnsafe)
 
   SmtSolver s = create_solver(MSAT);
   RelationalTransitionSystem rts(s);
-  Sort bvsort8 = rts.make_sort(BV, 8);
-  Sort bvsort32 = rts.make_sort(BV, 32);
-  Sort arrsort = rts.make_sort(ARRAY, bvsort8, bvsort32);
-  Term i = rts.make_statevar("i", bvsort8);
-  Term j = rts.make_statevar("j", bvsort8);
-  Term d = rts.make_statevar("d", bvsort32);
+  Sort intsort = rts.make_sort(INT);
+  Sort arrsort = rts.make_sort(ARRAY, intsort, intsort);
+  Term i = rts.make_statevar("i", intsort);
+  Term j = rts.make_statevar("j", intsort);
+  Term d = rts.make_statevar("d", intsort);
   Term a = rts.make_statevar("a", arrsort);
 
-  Term constarr0 = rts.make_term(rts.make_term(0, bvsort32), arrsort);
+  Term constarr0 = rts.make_term(rts.make_term(0, intsort), arrsort);
   rts.set_init(rts.make_term(Equal, a, constarr0));
   rts.assign_next(
       a,
       rts.make_term(Ite,
                     // off by one in the update
                     // e.g. using <= instead of <
-                    rts.make_term(BVUle, d, rts.make_term(200, bvsort32)),
+                    rts.make_term(Le, d, rts.make_term(200, intsort)),
                     rts.make_term(Store, a, i, d),
                     a));
 
   Term prop_term = rts.make_term(
-      BVUlt, rts.make_term(Select, a, j), rts.make_term(200, bvsort32));
+      Lt, rts.make_term(Select, a, j), rts.make_term(200, intsort));
   Property prop(s, prop_term);
 
   // TODO create a make_ command for this


### PR DESCRIPTION
There is an edge case with finite domain indices that is not properly handled in counterexample-guided prophecy. It might be possible to work around, but I'm not entirely sure. The solution we had implemented does not work in every case. Many SMT solvers have this same limitation (it has to do with array equalities and constant arrays). See http://theory.stanford.edu/~arbrad/pivc/arrays.pdf for more information. For now, just disabling support for finite domain indices.