### PR TITLE
Throw exception if attempting to use cvc4 with a multi-solver engine

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -368,6 +368,16 @@ const option::Descriptor usage[] = {
 
 namespace pono {
 
+const std::unordered_set<Engine> ic3_variants_set({ IC3_BOOL,
+                                                    IC3_BITS,
+                                                    MBIC3,
+                                                    IC3IA_ENGINE,
+                                                    MSAT_IC3IA,
+                                                    IC3SA_ENGINE,
+                                                    SYGUS_PDR });
+
+const std::unordered_set<Engine> & ic3_variants() { return ic3_variants_set; }
+
 const std::string PonoOptions::default_profiling_log_filename_ = "";
 
 Engine PonoOptions::to_engine(std::string s)
@@ -508,6 +518,13 @@ ProverResult PonoOptions::parse_and_set_options(int argc, char ** argv)
     if (ceg_prophecy_arrays_ && smt_solver_ != smt::MSAT) {
       throw PonoException(
           "Counterexample-guided prophecy only supported with MathSAT so far");
+    }
+
+    if (smt_solver_ == smt::CVC4
+        && ic3_variants().find(engine_) != ic3_variants().end()) {
+      throw PonoException(
+          "CVC4 cannot handle multiple solver instances, and thus does not "
+          "currently support IC3 variants.");
     }
   }
   catch (PonoException & ce) {

--- a/options/options.h
+++ b/options/options.h
@@ -40,7 +40,7 @@ enum Engine
   IC3SA_ENGINE,
   SYGUS_PDR
   // NOTE: if adding an IC3 variant,
-  // make sure to update ic3_variants in smt/available_solvers.cpp
+  // make sure to update ic3_variants_set in options/options.cpp
   // used for setting solver options appropriately
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -44,6 +44,15 @@ enum Engine
   // used for setting solver options appropriately
 };
 
+// NOTE keep this up to date so that setting
+//      solver options based on the engine works
+//      as expected.
+//      IC3 uses the solver differently than other
+//      techniques and thus different options are
+//      appropriate
+/** Returns the set of all IC3 variant engines */
+const std::unordered_set<Engine> & ic3_variants();
+
 const std::unordered_map<std::string, Engine> str2engine(
     { { "bmc", BMC },
       { "bmc-sp", BMC_SP },

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -58,12 +58,6 @@ const std::vector<SolverEnum> solver_enums({
 #endif
 });
 
-// keep this up-to-date for setting solver options
-// IC3 uses the solver in a different way, so different
-// options are appropriate than for other engines
-std::unordered_set<Engine> ic3_variants(
-  { IC3_BOOL, IC3_BITS, MBIC3, IC3IA_ENGINE, MSAT_IC3IA, IC3SA_ENGINE, SYGUS_PDR });
-
 // internal method for creating a particular solver
 // doesn't set any options
 SmtSolver create_solver_base(SolverEnum se, bool logging)
@@ -117,7 +111,7 @@ SmtSolver create_solver_for(SolverEnum se,
                             bool full_model)
 {
   SmtSolver s;
-  bool ic3_engine = ic3_variants.find(e) != ic3_variants.end();
+  bool ic3_engine = ic3_variants().find(e) != ic3_variants().end();
   if (e == IC3SA_ENGINE) {
     // IC3SA requires a full model
     full_model = true;
@@ -208,7 +202,7 @@ SmtSolver create_interpolating_solver(SolverEnum se)
 
 SmtSolver create_interpolating_solver_for(SolverEnum se, Engine e)
 {
-  if (ic3_variants.find(e) == ic3_variants.end()) {
+  if (ic3_variants().find(e) == ic3_variants().end()) {
     return create_interpolating_solver(se);
   }
 


### PR DESCRIPTION
This PR would throw an exception if trying to use CVC4 with an engine that uses multiple instances of the solver. This is only temporary until the multi-solver issues in CVC4 are resolved.