### PR TITLE
Fix BMC/K-Induction printing for repeated check_until calls

### DIFF
--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -50,7 +50,7 @@ ProverResult Bmc::check_until(int k)
 {
   initialize();
 
-  for (int i = 0; i <= k; ++i) {
+  for (int i = reached_k_ + 1; i <= k; ++i) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -53,7 +53,7 @@ ProverResult KInduction::check_until(int k)
 {
   initialize();
 
-  for (int i = 0; i <= k; ++i) {
+  for (int i = reached_k_ + 1; i <= k; ++i) {
     logger.log(1, "Checking k-induction base case at bound: {}", i);
     if (!base_step(i)) {
       compute_witness();


### PR DESCRIPTION
With repeated calls to `check_until`, provers are expected to start from their current state. Bmc and KInduction did this correctly, see [here](https://github.com/upscale-project/pono/blob/f228d77dc4a033ba304d94175bc1f78aa50b3d9c/engines/kinduction.cpp#L72). However, the main loop always started from 0, for example [here](https://github.com/upscale-project/pono/blob/f228d77dc4a033ba304d94175bc1f78aa50b3d9c/engines/kinduction.cpp#L56). This made the logger messages appear to be repeating work. This PR fixes that by starting the loop from the next target. `reached_k_` is the highest _already checked_ bound, so the next one to work on is `reached_k_ + 1`.