### PR TITLE
Add VMT frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(SOURCES
   "${PROJECT_SOURCE_DIR}/frontends/btor2_encoder.cpp"
   "${PROJECT_SOURCE_DIR}/frontends/smv_encoder.cpp"
   "${PROJECT_SOURCE_DIR}/frontends/smv_node.cpp"
+  "${PROJECT_SOURCE_DIR}/frontends/vmt_encoder.cpp"
   "${PROJECT_SOURCE_DIR}/modifiers/array_abstractor.cpp"
   "${PROJECT_SOURCE_DIR}/modifiers/control_signals.cpp"
   "${PROJECT_SOURCE_DIR}/modifiers/implicit_predicate_abstractor.cpp"

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -11,17 +11,17 @@ if [ -d "$DEPS/bison" ]; then
     exit 1
 fi
 
-curl http://ftp.gnu.org/gnu/bison/bison-3.5.tar.gz --output $DEPS/bison-3.5.tar.gz
+curl http://ftp.gnu.org/gnu/bison/bison-3.7.tar.gz --output $DEPS/bison-3.7.tar.gz
 
-if [ ! -f "$DEPS/bison-3.5.tar.gz" ]; then
-    echo "It seems like downloading bison to $DEPS/bison-3.5.tar.gz failed"
+if [ ! -f "$DEPS/bison-3.7.tar.gz" ]; then
+    echo "It seems like downloading bison to $DEPS/bison-3.7.tar.gz failed"
     exit 1
 fi
 
 cd $DEPS
-tar -xzf bison-3.5.tar.gz
-rm bison-3.5.tar.gz
-mv ./bison-3.5 ./bison
+tar -xzf bison-3.7.tar.gz
+rm bison-3.7.tar.gz
+mv ./bison-3.7 ./bison
 cd bison
 mkdir bison-install
 ./configure --prefix $DEPS/bison/bison-install --exec-prefix $DEPS/bison/bison-install

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -74,8 +74,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     ./contrib/setup-bison.sh
     ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
     cd build
-    # make -j$(nproc)
-    make -j2
+    make -j$(nproc)
     # TODO put this back
     # temporarily disable due to test-disjointset issue
     # make test

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -74,7 +74,8 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     ./contrib/setup-bison.sh
     ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
     cd build
-    make -j$(nproc)
+    # make -j$(nproc)
+    make -j2
     # TODO put this back
     # temporarily disable due to test-disjointset issue
     # make test

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -69,7 +69,8 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
-    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=./deps/bison/bison-install --flex-dir=./deps/flex/flex-install
+    # pass bison/flex directories from smt-switch perspective
+    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=../bison/bison-install --flex-dir=../flex/flex-install
     cd build
     make -j$(nproc)
     # TODO put this back

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,8 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-# hash of branch
-SMT_SWITCH_VERSION=90bf1b75b1b150e2d7e14ed8b3ccbc7a7392d709
+SMT_SWITCH_VERSION=cb19886f9cb042bf87dd37b2f634a8d8ed636f0d
 
 usage () {
     cat <<EOF
@@ -60,7 +59,7 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone -b smt-lib-attributes https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
     git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
@@ -70,9 +69,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
-    ./contrib/setup-flex.sh
-    ./contrib/setup-bison.sh
-    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
+    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=./deps/bison/bison-install --flex-dir=./deps/flex/flex-install
     cd build
     make -j$(nproc)
     # TODO put this back

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=cb19886f9cb042bf87dd37b2f634a8d8ed636f0d
+SMT_SWITCH_VERSION=0574042d56ad98d2373a1eba81493ca0c075a649
 
 usage () {
     cat <<EOF

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -59,9 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    git clone -b smt-lib-attributes https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
+    # git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh
@@ -69,6 +69,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
+    ./contrib/setup-bison.sh
     ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
     cd build
     make -j$(nproc)

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,8 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=ed05b58d109642f440e6311c632131cdeb20991a
+# hash of branch
+SMT_SWITCH_VERSION=90bf1b75b1b150e2d7e14ed8b3ccbc7a7392d709
 
 usage () {
     cat <<EOF
@@ -61,7 +62,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
     git clone -b smt-lib-attributes https://github.com/makaimann/smt-switch
     cd smt-switch
-    # git checkout -f $SMT_SWITCH_VERSION
+    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc4_home = default ]; then
         ./contrib/setup-cvc4.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -69,6 +69,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
+    ./contrib/setup-flex.sh
     ./contrib/setup-bison.sh
     ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
     cd build

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -69,7 +69,7 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
-    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static
+    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader
     cd build
     make -j$(nproc)
     # TODO put this back

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -359,6 +359,8 @@ void TransitionSystem::add_statevar(const Term & cv, const Term & nv)
         "Cannot use an existing state variable as a next state var");
   }
 
+  // if using an input variable, remove from set
+  // will be a state variable now
   if (inputvars_.find(cv) != inputvars_.end()) {
     bool success = inputvars_.erase(cv);
     assert(success);

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -359,10 +359,14 @@ void TransitionSystem::add_statevar(const Term & cv, const Term & nv)
         "Cannot use an existing state variable as a next state var");
   }
 
-  if (inputvars_.find(cv) != inputvars_.end()
-      || inputvars_.find(nv) != inputvars_.end()) {
-    throw PonoException(
-        "Cannot re-use an input variable as a current or next state var");
+  if (inputvars_.find(cv) != inputvars_.end()) {
+    bool success = inputvars_.erase(cv);
+    assert(success);
+  }
+
+  if (inputvars_.find(nv) != inputvars_.end()) {
+    bool success = inputvars_.erase(nv);
+    assert(success);
   }
 
   statevars_.insert(cv);

--- a/core/ts.h
+++ b/core/ts.h
@@ -225,8 +225,10 @@ class TransitionSystem
   void add_inputvar(const smt::Term & v);
 
   // getters
+  /* Returns const reference to solver */
   const smt::SmtSolver & solver() const { return solver_; };
 
+  /* Gets a non-const reference to the solver */
   smt::SmtSolver & get_solver() { return solver_; };
 
   const smt::UnorderedTermSet & statevars() const { return statevars_; };

--- a/core/ts.h
+++ b/core/ts.h
@@ -227,6 +227,8 @@ class TransitionSystem
   // getters
   const smt::SmtSolver & solver() const { return solver_; };
 
+  smt::SmtSolver & get_solver() { return solver_; };
+
   const smt::UnorderedTermSet & statevars() const { return statevars_; };
 
   const smt::UnorderedTermSet & inputvars() const { return inputvars_; };

--- a/frontends/vmt_encoder.cpp
+++ b/frontends/vmt_encoder.cpp
@@ -22,9 +22,11 @@ using namespace std;
 namespace pono {
 
 VMTEncoder::VMTEncoder(std::string filename, RelationalTransitionSystem & rts)
-    : super(solver_), filename_(filename), rts_(rts)
+    : super(rts.get_solver()), filename_(filename), rts_(rts)
 {
-  solver_ = rts_.solver();
+  set_logic_all();
+  int res = parse(filename_);
+  assert(!res);  // 0 means success
 }
 
 void VMTEncoder::term_attribute(const Term & term,

--- a/frontends/vmt_encoder.cpp
+++ b/frontends/vmt_encoder.cpp
@@ -45,6 +45,13 @@ void VMTEncoder::term_attribute(const Term & term,
 {
   if (keyword == "next") {
     Term next_var = lookup_symbol(value);
+    if (!next_var) {
+      // undeclared next var
+      // make a new one
+      Sort sort = term->get_sort();
+      new_symbol(value, sort);
+      next_var = lookup_symbol(value);
+    }
     assert(next_var);
     rts_.add_statevar(term, next_var);
   } else if (keyword == "init") {

--- a/frontends/vmt_encoder.cpp
+++ b/frontends/vmt_encoder.cpp
@@ -10,6 +10,7 @@
 ** directory for licensing information.\endverbatim
 **
 ** \brief Frontend for the Verification Modulo Theories (VMT) format.
+**        See https://vmt-lib.fbk.eu/ for more information.
 **
 **
 **/

--- a/frontends/vmt_encoder.cpp
+++ b/frontends/vmt_encoder.cpp
@@ -29,6 +29,15 @@ VMTEncoder::VMTEncoder(std::string filename, RelationalTransitionSystem & rts)
   assert(!res);  // 0 means success
 }
 
+void VMTEncoder::new_symbol(const std::string & name, const smt::Sort & sort)
+{
+  super::new_symbol(name, sort);
+  if (sort->get_sort_kind() != FUNCTION) {
+    // treat as an input variable until given :next
+    rts_.add_inputvar(lookup_symbol(name));
+  }
+}
+
 void VMTEncoder::term_attribute(const Term & term,
                                 const string & keyword,
                                 const string & value)

--- a/frontends/vmt_encoder.cpp
+++ b/frontends/vmt_encoder.cpp
@@ -1,0 +1,49 @@
+/*********************                                                        */
+/*! \file vmt_encoder.cpp
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Frontend for the Verification Modulo Theories (VMT) format.
+**
+**
+**/
+
+#include "frontends/vmt_encoder.h"
+
+using namespace smt;
+using namespace std;
+
+namespace pono {
+
+VMTEncoder::VMTEncoder(std::string filename, RelationalTransitionSystem & rts)
+    : super(solver_), filename_(filename), rts_(rts)
+{
+  solver_ = rts_.solver();
+}
+
+void VMTEncoder::term_attribute(const Term & term,
+                                const string & keyword,
+                                const string & value)
+{
+  if (keyword == "next") {
+    Term next_var = lookup_symbol(value);
+    assert(next_var);
+    rts_.add_statevar(term, next_var);
+  } else if (keyword == "init") {
+    rts_.constrain_init(term);
+  } else if (keyword == "trans") {
+    rts_.constrain_trans(term);
+  } else if (keyword == "invar-property") {
+    propvec_.push_back(term);
+  } else {
+    throw PonoException("Unhandled VMT attribute -- :" + keyword + " " + value);
+  }
+}
+
+}  // namespace pono

--- a/frontends/vmt_encoder.h
+++ b/frontends/vmt_encoder.h
@@ -43,8 +43,6 @@ class VMTEncoder : public smt::SmtLibReader
 
   RelationalTransitionSystem & rts_;
 
-  smt::SmtSolver solver_;
-
   smt::TermVec propvec_;
 };
 

--- a/frontends/vmt_encoder.h
+++ b/frontends/vmt_encoder.h
@@ -1,0 +1,51 @@
+/*********************                                                        */
+/*! \file vmt_encoder.h
+** \verbatim
+** Top contributors (to current version):
+**   Makai Mann
+** This file is part of the pono project.
+** Copyright (c) 2019 by the authors listed in the file AUTHORS
+** in the top-level source directory) and their institutional affiliations.
+** All rights reserved.  See the file LICENSE in the top-level source
+** directory for licensing information.\endverbatim
+**
+** \brief Frontend for the Verification Modulo Theories (VMT) format.
+**
+**
+**/
+
+#pragma once
+
+#include <iostream>
+
+#include "assert.h"
+#include "core/rts.h"
+#include "smt-switch/smt.h"
+#include "smt-switch/smtlib_reader.h"
+#include "utils/exceptions.h"
+
+namespace pono {
+class VMTEncoder : public smt::SmtLibReader
+{
+ public:
+  VMTEncoder(std::string filename, RelationalTransitionSystem & rts);
+
+  typedef SmtLibReader super;
+
+  void term_attribute(const smt::Term & term,
+                      const std::string & keyword,
+                      const std::string & value) override;
+
+  const smt::TermVec & propvec() const { return propvec_; }
+
+ protected:
+  std::string filename_;
+
+  RelationalTransitionSystem & rts_;
+
+  smt::SmtSolver solver_;
+
+  smt::TermVec propvec_;
+};
+
+}  // namespace pono

--- a/frontends/vmt_encoder.h
+++ b/frontends/vmt_encoder.h
@@ -10,6 +10,7 @@
 ** directory for licensing information.\endverbatim
 **
 ** \brief Frontend for the Verification Modulo Theories (VMT) format.
+**        See https://vmt-lib.fbk.eu/ for more information.
 **
 **
 **/

--- a/frontends/vmt_encoder.h
+++ b/frontends/vmt_encoder.h
@@ -32,6 +32,8 @@ class VMTEncoder : public smt::SmtLibReader
 
   typedef SmtLibReader super;
 
+  void new_symbol(const std::string & name, const smt::Sort & sort) override;
+
   void term_attribute(const smt::Term & term,
                       const std::string & keyword,
                       const std::string & value) override;

--- a/pono.cpp
+++ b/pono.cpp
@@ -327,7 +327,7 @@ int main(int argc, char ** argv)
         cout << "b" << pono_options.prop_idx_ << endl;
       }
 
-    } else if (file_ext == "smv" || file_ext == "vmt") {
+    } else if (file_ext == "smv" || file_ext == "vmt" || file_ext == "smt2") {
       logger.log(2, "Parsing SMV file: {}", pono_options.filename_);
       RelationalTransitionSystem rts(s);
       TermVec propvec;
@@ -335,7 +335,7 @@ int main(int argc, char ** argv)
         SMVEncoder smv_enc(pono_options.filename_, rts);
         propvec = smv_enc.propvec();
       } else {
-        assert(file_ext == "vmt");
+        assert(file_ext == "vmt" || file_ext == "smt2");
         VMTEncoder vmt_enc(pono_options.filename_, rts);
         propvec = vmt_enc.propvec();
       }

--- a/pono.cpp
+++ b/pono.cpp
@@ -30,6 +30,7 @@
 #include "core/fts.h"
 #include "frontends/btor2_encoder.h"
 #include "frontends/smv_encoder.h"
+#include "frontends/vmt_encoder.h"
 #include "modifiers/control_signals.h"
 #include "modifiers/mod_ts_prop.h"
 #include "modifiers/prop_monitor.h"
@@ -326,11 +327,18 @@ int main(int argc, char ** argv)
         cout << "b" << pono_options.prop_idx_ << endl;
       }
 
-    } else if (file_ext == "smv") {
+    } else if (file_ext == "smv" || file_ext == "vmt") {
       logger.log(2, "Parsing SMV file: {}", pono_options.filename_);
       RelationalTransitionSystem rts(s);
-      SMVEncoder smv_enc(pono_options.filename_, rts);
-      const TermVec & propvec = smv_enc.propvec();
+      TermVec propvec;
+      if (file_ext == "smv") {
+        SMVEncoder smv_enc(pono_options.filename_, rts);
+        propvec = smv_enc.propvec();
+      } else {
+        assert(file_ext == "vmt");
+        VMTEncoder vmt_enc(pono_options.filename_, rts);
+        propvec = vmt_enc.propvec();
+      }
       unsigned int num_props = propvec.size();
       if (pono_options.prop_idx_ >= num_props) {
         throw PonoException(

--- a/pono.cpp
+++ b/pono.cpp
@@ -328,7 +328,7 @@ int main(int argc, char ** argv)
       }
 
     } else if (file_ext == "smv" || file_ext == "vmt" || file_ext == "smt2") {
-      logger.log(2, "Parsing SMV file: {}", pono_options.filename_);
+      logger.log(2, "Parsing SMV/VMT file: {}", pono_options.filename_);
       RelationalTransitionSystem rts(s);
       TermVec propvec;
       if (file_ext == "smv") {

--- a/python/pono_imp.pxd
+++ b/python/pono_imp.pxd
@@ -179,6 +179,18 @@ cdef extern from "frontends/btor2_encoder.h" namespace "pono":
         const c_TermVec & propvec() except +
 
 
+cdef extern from "frontends/smv_encoder.h" namespace "pono":
+    cdef cppclass SMVEncoder:
+        SMVEncoder(string filename, RelationalTransitionSystem & ts) except +
+        const c_TermVec & propvec() except +
+
+
+cdef extern from "frontends/vmt_encoder.h" namespace "pono":
+    cdef cppclass VMTEncoder:
+        VMTEncoder(string filename, RelationalTransitionSystem & ts) except +
+        const c_TermVec & propvec() except +
+
+
 # WITH_COREIR is set in python/CMakeLists.txt via the --compile-time-env flag of Cython
 IF WITH_COREIR == "ON":
     cdef extern from "coreir.h" namespace "CoreIR":

--- a/python/pono_imp.pxi
+++ b/python/pono_imp.pxi
@@ -29,6 +29,8 @@ from pono_imp cimport ModelBasedIC3 as c_ModelBasedIC3
 IF WITH_MSAT_IC3IA == "ON":
     from pono_imp cimport MsatIC3IA as c_MsatIC3IA
 from pono_imp cimport BTOR2Encoder as c_BTOR2Encoder
+from pono_imp cimport SMVEncoder as c_SMVEncoder
+from pono_imp cimport VMTEncoder as c_VMTEncoder
 IF WITH_COREIR == "ON":
     from pono_imp cimport Module as c_Module
     from pono_imp cimport CoreIREncoder as c_CoreIREncoder
@@ -643,6 +645,48 @@ cdef class BTOR2Encoder:
         cdef vector[c_Term] props = dref(self.cbe).propvec()
         for p in props:
             term = Term(self._ts._solver)
+            term.ct = p
+            res.append(term)
+        return res
+
+
+cdef class SMVEncoder:
+    cdef c_SMVEncoder * cbe
+    cdef RelationalTransitionSystem _rts
+    def __cinit__(self, str filename, RelationalTransitionSystem rts):
+        self.cbe = new c_SMVEncoder(filename.encode(), \
+                                    dref(<c_RelationalTransitionSystem * ?> rts.cts))
+        self._rts = rts
+
+    def __dealloc__(self):
+        del self.cbe
+
+    def propvec(self):
+        res = []
+        cdef vector[c_Term] props = dref(self.cbe).propvec()
+        for p in props:
+            term = Term(self._rts._solver)
+            term.ct = p
+            res.append(term)
+        return res
+
+
+cdef class VMTEncoder:
+    cdef c_VMTEncoder * cbe
+    cdef RelationalTransitionSystem _rts
+    def __cinit__(self, str filename, RelationalTransitionSystem rts):
+        self.cbe = new c_VMTEncoder(filename.encode(), \
+                                    dref(<c_RelationalTransitionSystem * ?> rts.cts))
+        self._rts = rts
+
+    def __dealloc__(self):
+        del self.cbe
+
+    def propvec(self):
+        res = []
+        cdef vector[c_Term] props = dref(self.cbe).propvec()
+        for p in props:
+            term = Term(self._rts._solver)
             term.ct = p
             res.append(term)
         return res


### PR DESCRIPTION
This PR adds support for a Verification Modulo Theories (VMT) frontend. This format uses valid, annotated SMT-LIB to describe a transition system. Please see https://vmt-lib.fbk.eu/ for more information on the format. Because this is valid SMT-LIB, we can support VMT by a very simple extension of the `SmtLibReader` class provided by `smt-switch` for parsing SMT-LIB.