### PR TITLE
CEGP: Fixes for indices with next vars in them

### DIFF
--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -344,7 +344,6 @@ bool CegProphecyArrays<Prover_T>::cegar_refine()
       assert(delay > 0 || abs_ts_.only_curr(idx));
       // Prophecy Modifier will add prophecy and history variables
       // automatically here but it does NOT update the property
-      cout << "creating prophecy variable for " << idx << ":" << delay << endl;
       proph_vars.push_back(pm_.get_proph(idx, delay));
     }
 

--- a/engines/ceg_prophecy_arrays.cpp
+++ b/engines/ceg_prophecy_arrays.cpp
@@ -336,12 +336,15 @@ bool CegProphecyArrays<Prover_T>::cegar_refine()
       // number of steps before the property violation
       size_t delay =
           reached_k_ + 1 - abs_unroller_.get_curr_time(timed_idx);
-      // Prophecy Modifier will add prophecy and history variables
-      // automatically here but it does NOT update the property
-      Term idx = abs_unroller_.untime(timed_idx);
+      // Note: can't rely on Unroller::untime
+      // see documentation for ArrayAxiomEnumerator::untime_index
+      Term idx = aae_.untime_index(timed_idx);
       // can't target a non-current state variable
       // because the target will appear in the updated property
       assert(delay > 0 || abs_ts_.only_curr(idx));
+      // Prophecy Modifier will add prophecy and history variables
+      // automatically here but it does NOT update the property
+      cout << "creating prophecy variable for " << idx << ":" << delay << endl;
       proph_vars.push_back(pm_.get_proph(idx, delay));
     }
 

--- a/modifiers/history_modifier.cpp
+++ b/modifiers/history_modifier.cpp
@@ -12,9 +12,10 @@
 ** \brief Class for adding history variables to a system.
 **
 **/
-#include "assert.h"
-
 #include "modifiers/history_modifier.h"
+
+#include "assert.h"
+#include "core/rts.h"
 
 using namespace smt;
 using namespace std;
@@ -46,8 +47,22 @@ Term HistoryModifier::get_hist(const Term & target, size_t delay)
     var = ts_.make_statevar(name, sort);
 
     if (num_existing_hist_vars == 1) {
-      // hist_x_1' = x
-      ts_.assign_next(var, target);
+      if (ts_.no_next(target)) {
+        // hist_x_1' = x
+        ts_.assign_next(var, target);
+      } else {
+        // target has next variables
+        // only possible if system is relational
+        if (ts_.is_functional()) {
+          throw PonoException(
+              "Cannot create history variable for target containing next in "
+              "functional system");
+        }
+
+        Term eq = solver_->make_term(Equal, ts_.next(var), target);
+        cout << "HIT RELATIONAL CASE with " << eq << endl;
+        static_cast<RelationalTransitionSystem &>(ts_).constrain_trans(eq);
+      }
     } else {
       // hist_x_n' = hist_x_{n-1}
       assert(hist_vars_.find(target) != hist_vars_.end());

--- a/modifiers/history_modifier.cpp
+++ b/modifiers/history_modifier.cpp
@@ -60,7 +60,6 @@ Term HistoryModifier::get_hist(const Term & target, size_t delay)
         }
 
         Term eq = solver_->make_term(Equal, ts_.next(var), target);
-        cout << "HIT RELATIONAL CASE with " << eq << endl;
         static_cast<RelationalTransitionSystem &>(ts_).constrain_trans(eq);
       }
     } else {

--- a/refiners/array_axiom_enumerator.cpp
+++ b/refiners/array_axiom_enumerator.cpp
@@ -371,6 +371,7 @@ bool ArrayAxiomEnumerator::check_nonconsecutive_axioms(AxiomClass ac,
 
   UnorderedTermSet & indices = only_curr ? cur_index_set_ : index_set_;
   UnorderedTermSet unrolled_indices;
+  Term unrolled_idx;
   for (auto idx : indices) {
     if (i == bound_ && !ts_.only_curr(idx)) {
       // IMPORTANT: cannot instantiate anything containing
@@ -382,7 +383,9 @@ bool ArrayAxiomEnumerator::check_nonconsecutive_axioms(AxiomClass ac,
       // and the bound is essentially the last next unrolling
       continue;
     }
-    unrolled_indices.insert(un_.at_time(idx, i));
+    unrolled_idx = un_.at_time(idx, i);
+    unrolled_indices.insert(unrolled_idx);
+    untime_index_cache_[unrolled_idx] = idx;
   }
 
   // check these axioms

--- a/refiners/array_axiom_enumerator.h
+++ b/refiners/array_axiom_enumerator.h
@@ -97,6 +97,17 @@ class ArrayAxiomEnumerator : public AxiomEnumerator
    */
   void add_index(const smt::Term & idx);
 
+  /** Untimes an index, taking into account current and next
+   *  e.g. the Unroller::untime(x@4 + y@5) would give x + y
+   *  instead of x + y.next
+   *  @param timed_index an unrolled index
+   *  @return the untimed version
+   */
+  smt::Term untime_index(const smt::Term & timed_idx)
+  {
+    return untime_index_cache_.at(timed_idx);
+  }
+
   smt::UnorderedTermSet & get_consecutive_axioms() override
   {
     return consecutive_axioms_;
@@ -403,6 +414,8 @@ class ArrayAxiomEnumerator : public AxiomEnumerator
                                     ///< transition system variables
   AxiomVec nonconsecutive_axioms_;  ///< populated with nonconsecutive axiom
                                     ///< instantiations
+
+  smt::UnorderedTermMap untime_index_cache_;
 
   // useful terms
   smt::Term false_;


### PR DESCRIPTION
Untiming did not work correctly, just keep an explicit map for that

Could not add history equality using assign_next if the target
had a next state variable in it. Check if relational and handle,
otherwise throw an exception because not possible for functional
system.