### PR TITLE
Enable witness printing when using static COI

### DIFF
--- a/engines/prover.cpp
+++ b/engines/prover.cpp
@@ -89,12 +89,6 @@ bool Prover::witness(std::vector<UnorderedTermMap> & out)
     transfer_to_prover_as = [](const Term & t, SortKind sk) { return t; };
     transfer_to_orig_ts_as = [](const Term & t, SortKind sk) { return t; };
   } else {
-    /* TODO: double-check that transferring terms still works as
-       intended in this branch when COI is used. */
-    if (options_.static_coi_)
-      throw PonoException(
-          "Temporary restriction: cone-of-influence analysis "
-          "currently incompatible with witness generation.");
     // need to add symbols to cache
     UnorderedTermMap & cache = to_orig_ts_solver.get_cache();
     for (const auto &v : orig_ts_.statevars()) {
@@ -175,12 +169,6 @@ Term Prover::to_orig_ts(Term t, SortKind sk)
     // don't need to transfer terms if the solvers are the same
     return t;
   } else {
-    /* TODO: double-check that transferring terms still works as
-       intended in this branch when COI is used. */
-    if (options_.static_coi_)
-      throw PonoException(
-          "Temporary restriction: cone-of-influence analysis "
-          "currently incompatible with witness generation.");
     // need to add symbols to cache
     TermTranslator to_orig_ts_solver(orig_ts_.solver());
     UnorderedTermMap & cache = to_orig_ts_solver.get_cache();

--- a/pono.cpp
+++ b/pono.cpp
@@ -258,13 +258,6 @@ int main(int argc, char ** argv)
 
     // limitations with COI
     if (pono_options.static_coi_) {
-      if (pono_options.witness_) {
-        logger.log(
-            0,
-            "Warning: disabling witness production. Temporary restriction -- "
-            "Cannot produce witness with option --static-coi");
-        pono_options.witness_ = false;
-      }
       if (pono_options.pseudo_init_prop_) {
         // Issue explained here:
         // https://github.com/upscale-project/pono/pull/160 will be resolved
@@ -312,7 +305,7 @@ int main(int argc, char ** argv)
         cout << "b" << pono_options.prop_idx_ << endl;
         assert(pono_options.witness_ || !cex.size());
         if (cex.size()) {
-          print_witness_btor(btor_enc, cex);
+          print_witness_btor(btor_enc, cex, fts);
           if (!pono_options.vcd_name_.empty()) {
             VCDWitnessPrinter vcdprinter(fts, cex);
             vcdprinter.dump_trace_to_file(pono_options.vcd_name_);


### PR DESCRIPTION
This PR removes a temporary restriction that did not allow to print  witnesses in BTOR2 format when static cone-of-influence (COI) reduction was enabled.