### PR TITLE
tests/CMakeLists.txt.in: the default branch of google/googletest is 'main'

### DIFF
--- a/tests/CMakeLists.txt.in
+++ b/tests/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
This PR updates the GIT_TAG used for google/googletest, since the default branch name changed from `master` to `main`.