### PR TITLE
BMC options for improved bug hunting

### DIFF
--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -132,7 +132,12 @@ bool Bmc::step(int i)
     logger.log(2, "DEBUG saving reached_k_ = {}", reached_k_);
     int reached_k_saved = reached_k_;
     int cex_upper_bound = bmc_interval_get_cex_ub(reached_k_ + 1, i);
-    solver_->push();
+    //FIX for corner case of length-1 interval: some solvers don't
+    //allow 'push' before 'get-value' even when no terms are asserted
+    //before 'get-value'. Hence don't 'push' if we don't add any terms
+    //in function 'bmc_interval_block_cex_ub'.
+    if (cex_upper_bound + 1 <= i)
+      solver_->push();
     bmc_interval_block_cex_ub(cex_upper_bound + 1, i);
     // find shortest cex within tested interval given by bad state clause
 //    bmc_interval_find_shortest_cex(cex_upper_bound);

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -157,7 +157,8 @@ bool Bmc::step(int i)
       if (!success) {
 	reached_k_ = reached_k_saved;
 	//clear constraints added during upper bound computation and binary search
-	solver_->pop();
+	if (cex_upper_bound + 1 <= i)
+	  solver_->pop();
 	while(bin_search_frames_-- > 0)
 	  solver_->pop();
 	bmc_interval_find_shortest_cex_linear_search(cex_upper_bound);

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -232,7 +232,8 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
     } else {
       logger.log(2, "DEBUG binary search, unsat result: {}", r);
       logger.log(2, "DEBUG binary search, no cex in [low,mid] = [{},{}]", low, mid);
-      assert(low < high);
+      if (low >= high)
+	throw PonoException("BMC FAILURE (corner case): formula overconstrained");
       logger.log(2, "DEBUG binary search, unblocking [mid+1,high] = [{},{}]", mid + 1, high);
       //remove previoulsy added blocking literals for [mid+1,high]
       logger.log(3, "DEBUG binary search, solver->pop()");

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -64,7 +64,7 @@ ProverResult Bmc::check_until(int k)
   //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
 //  }
   
-  for (int i = start_bound; i <= k; i+=step_bound /* i = i == 0 ? 1 : i << 1*/) {
+  for (int i = start_bound; i <= k; i += step_bound /* i = i == 0 ? 1 : i << 1 */) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -183,7 +183,7 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
   while (low <= high) {
     //Term clause = solver_->make_term(false);
     int mid = low + (high - low) / 2;
-    logger.log(2, "DEBUG binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
+    logger.log(2, "\nDEBUG binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
 
     logger.log(3, "DEBUG binary search, solver->push()");
     //solver_->pop();
@@ -238,7 +238,13 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
       low = mid + 1;
     }
   }
-  logger.log(1, "DEBUG binary search, finding shortest cex---found at bound low == {}", low);
+
+  //must find cex inside sat-branch of if-then-else above
+  assert(low <= high);
+  //reached_k_ has been correctly updated to low - 1, i.e., cex bound - 1
+  assert(reached_k_ + 1 == low);
+  logger.log(1, "DEBUG binary search, shortest cex at bound low == {},"\
+	     " reached_k = {}", low, reached_k_);
 }
   
 void Bmc::bmc_interval_find_shortest_cex(const int upper_bound)

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -50,17 +50,21 @@ ProverResult Bmc::check_until(int k)
 {
   initialize();
 
-  int start_bound = 0;
-  if (start_bound > 0)
-    reached_k_ = start_bound - 1;
+  const int step_bound = 1;
+  const int start_bound = 0;
+
+  // reached_k == -1 initially
   
-  for (int j = 1; j < start_bound; ++j)
-  {
-    std::cout << "adding trans for j-1 == " << j - 1 << std::endl;
-    solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
-  }
+  //  if (start_bound > 0)
+  //  reached_k_ = start_bound - 1;
   
-  for (int i = start_bound; i <= k; i+=1/*i = i == 0 ? 1 : i << 1*/) {
+//  for (int j = 1; j < start_bound; ++j)
+  // {
+  //   std::cout << "DEBUG (check-until) adding trans for j-1 == " << j - 1 << std::endl;
+  //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
+//  }
+  
+  for (int i = start_bound; i <= k; i+=step_bound /*i = i == 0 ? 1 : i << 1*/) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -79,9 +83,9 @@ bool Bmc::step(int i)
   if (i > 0) {
 //
     std::cout << "DEBUG reached k " << reached_k_ << ", i " << i << std::endl;
-    for (int j = reached_k_ + 1; j <= i; j++)
+    for (int j = reached_k_ == -1 ? 1 : reached_k_ + 1; j <= i; j++)
     {
-      std::cout << "adding trans for j-1 == " << j - 1 << std::endl;
+      std::cout << "DEBUG adding trans for j-1 == " << j - 1 << std::endl;
       solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
     }
     //OLD

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -50,7 +50,17 @@ ProverResult Bmc::check_until(int k)
 {
   initialize();
 
-  for (int i = reached_k_ + 1; i <= k; ++i) {
+  int start_bound = 0;
+  if (start_bound > 0)
+    reached_k_ = start_bound - 1;
+  
+  for (int j = 1; j < start_bound; ++j)
+  {
+    std::cout << "adding trans for j-1 == " << j - 1 << std::endl;
+    solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
+  }
+  
+  for (int i = start_bound; i <= k; i+=1/*i = i == 0 ? 1 : i << 1*/) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -67,7 +77,15 @@ bool Bmc::step(int i)
 
   bool res = true;
   if (i > 0) {
-    solver_->assert_formula(unroller_.at_time(ts_.trans(), i - 1));
+//
+    std::cout << "DEBUG reached k " << reached_k_ << ", i " << i << std::endl;
+    for (int j = reached_k_ + 1; j <= i; j++)
+    {
+      std::cout << "adding trans for j-1 == " << j - 1 << std::endl;
+      solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
+    }
+    //OLD
+//    solver_->assert_formula(unroller_.at_time(ts_.trans(), i - 1));
   }
 
   solver_->push();
@@ -78,7 +96,7 @@ bool Bmc::step(int i)
     res = false;
   } else {
     solver_->pop();
-    ++reached_k_;
+    reached_k_ = i;
   }
 
   return res;

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -64,7 +64,7 @@ ProverResult Bmc::check_until(int k)
   //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
 //  }
   
-  for (int i = start_bound; i <= k; i+=step_bound /*i = i == 0 ? 1 : i << 1*/) {
+  for (int i = start_bound; i <= k; i+=step_bound /* i = i == 0 ? 1 : i << 1*/) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -121,7 +121,8 @@ bool Bmc::step(int i)
   if (r.is_sat()) {
     res = false;
     // find shortest cex within tested interval given by bad state clause
-    bmc_interval_find_shortest_cex(i);
+//    bmc_interval_find_shortest_cex(i);
+    bmc_interval_find_shortest_cex_binary_search(i);
   } else {
     solver_->pop();
     reached_k_ = i;
@@ -130,6 +131,50 @@ bool Bmc::step(int i)
   return res;
 }
 
+void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
+{
+  assert (reached_k_ < upper_bound);
+  std::cout << "DEBUG binary search, cex in interval found: lower bound = reached k = "
+	    << reached_k_ << " upper bound = " << upper_bound << std::endl;
+
+  if (upper_bound - reached_k_ == 1) {
+    std::cout << "DEBUG interval has length 1, skipping search for shortest cex" << std::endl;
+    return;
+  }
+
+  int low = reached_k_ + 1;
+  int high = upper_bound;
+  while (low <= high) {
+    Term clause = solver_->make_term(false);
+    int mid = low + (high - low) / 2;
+    std::cout << "DEBUG binary search, (low, mid, high) = (" << low << ", " << mid << ", "<< high << ")" << std::endl;
+    solver_->pop();
+    solver_->push();
+    int j;
+    for (j = low; j <= mid; j++) {
+      std::cout << "DEBUG binary search, finding shortest cex---adding bad state literal for j == " << j << std::endl;
+      clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
+    }
+    solver_->assert_formula(clause);
+    Result r = solver_->check_sat();
+    assert(r.is_sat() || r.is_unsat());
+    if (r.is_sat()) {
+      std::cout << "DEBUG binary search, sat result: " << r << std::endl;
+      // if low == mid in current iteration, then we have tested a single
+      // bad state literal; can exit loop in case of satisfiability
+      if (low == mid)
+	break;
+      else
+	high = mid;
+    } else {
+      std::cout << "DEBUG binary search, unsat result: " << r << std::endl;
+      assert(low < high);
+      low = mid + 1;
+    }
+  }
+  std::cout << "DEBUG binary search, finding shortest cex---found at bound low == " << low << std::endl;
+}
+  
 void Bmc::bmc_interval_find_shortest_cex(const int upper_bound)
 {
   assert (reached_k_ < upper_bound);

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -212,6 +212,9 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
   
 void Bmc::bmc_interval_find_shortest_cex(const int upper_bound)
 {
+  //FUNCTION TEMPORARILY DEPRECATED
+  abort();
+  
   assert (reached_k_ < upper_bound);
   logger.log(2, "DEBUG cex in interval found: lower bound = reached k = {}"\
 	     " upper bound = {}", reached_k_, upper_bound);

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -152,8 +152,9 @@ bool Bmc::step(int i)
 	solver_->push();
       bmc_interval_block_cex_ub(cex_upper_bound + 1, i);
       // find shortest cex within tested interval given by bad state clause
-//    bmc_interval_find_shortest_cex(cex_upper_bound);
-      bool success = bmc_interval_find_shortest_cex_binary_search(cex_upper_bound);
+      // 'success' will be false if binary search fails or linear search is enabled
+      bool success = options_.bmc_min_cex_linear_search_ ? false :
+	bmc_interval_find_shortest_cex_binary_search(cex_upper_bound);
       if (!success) {
 	reached_k_ = reached_k_saved;
 	//clear constraints added during upper bound computation and binary search

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -73,8 +73,10 @@ ProverResult Bmc::check_until(int k)
   //   std::cout << "DEBUG (check-until) adding trans for j-1 == " << j - 1 << std::endl;
   //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
 //  }
-  
-  for (int i = bound_start_; i <= k; i += bound_step_ /* i = i == 0 ? 1 : i << 1 */) {
+
+  const bool exp_step = options_.bmc_exponential_step_;
+
+  for (int i = bound_start_; i <= k; i = exp_step ? (i == 0 ? 1 : i << 1) : (i + bound_step_)) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -106,6 +106,7 @@ bool Bmc::step(int i)
       clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
     }
   } else {
+    std::cout << "DEBUG adding bad state literal for i == " << i << std::endl;
     clause = unroller_.at_time(bad_, i);
   }
   

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -154,8 +154,12 @@ bool Bmc::step(int i)
       // find shortest cex within tested interval given by bad state clause
       // 'success' will be false if binary search fails or linear search is enabled
       bool success = options_.bmc_min_cex_linear_search_ ? false :
-	find_shortest_cex_binary_search(cex_upper_bound);
+	( !options_.bmc_min_cex_less_inc_bin_search_ ?
+	  find_shortest_cex_binary_search(cex_upper_bound) :
+	  find_shortest_cex_binary_search_less_inc(cex_upper_bound)
+	);
       if (!success) {
+	assert(!options_.bmc_min_cex_less_inc_bin_search_);
 	reached_k_ = reached_k_saved;
 	//clear constraints added during upper bound computation and binary search
 	if (cex_upper_bound + 1 <= i)
@@ -333,10 +337,10 @@ bool Bmc::find_shortest_cex_binary_search(const int upper_bound)
    frame in each solver call to search for shortest
    counterexample. This has the effect that we potentially benefit less
    from incremental solving. */
-bool Bmc::find_shortest_cex_binary_search_non_inc(const int upper_bound)
+bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
 {
   assert (reached_k_ < upper_bound);
-  logger.log(2, "DEBUG binary search, cex found in interval "\
+  logger.log(2, "DEBUG less incremental binary search, cex found in interval "\
 	     "[reached_k+1,upper_bound] = [{},{}]", reached_k_ + 1, upper_bound);
 
   if (upper_bound - reached_k_ == 1) {

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -46,7 +46,7 @@ void Bmc::initialize()
   // the solver or it could just be polluted with redundant assertions in the
   // future we can use solver_->reset_assertions(), but it is not currently
   // supported in boolector
-  logger.log(2, "DEBUG adding init constraint for step 0");
+  logger.log(2, "BMC: adding init constraint for step 0");
   solver_->assert_formula(unroller_.at_time(ts_.init(), 0));
 }
 
@@ -54,29 +54,19 @@ ProverResult Bmc::check_until(int k)
 {
   initialize();
 
-  //NOTE/TODO: there is a corner case where an instance is trivially
+  //NOTE: there is a corner case where an instance is trivially
   //unsatisfiable, i.e., safe, when the conjunction of initial state
   //predicate and transition (+ any constraints) is already unsat. We
   //could also check this using unsat core functionality of solver (if
   //supported), and check if bad state predicate is in core
 
-  logger.log(1, "DEBUG BMC bound_start_ {} ", bound_start_);  
-  logger.log(1, "DEBUG BMC bound_step_ {} ", bound_step_);  
-  
-  // reached_k == -1 initially
-  
-  //  if (start_bound > 0)
-  //  reached_k_ = start_bound - 1;
-  
-//  for (int j = 1; j < start_bound; ++j)
-  // {
-  //   std::cout << "DEBUG (check-until) adding trans for j-1 == " << j - 1 << std::endl;
-  //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
-//  }
+  logger.log(1, "BMC: bound_start_ {} ", bound_start_);
+  logger.log(1, "BMC: bound_step_ {} ", bound_step_);
 
   const bool exp_step = options_.bmc_exponential_step_;
 
-  for (int i = bound_start_; i <= k; i = exp_step ? (i == 0 ? 1 : i << 1) : (i + bound_step_)) {
+  for (int i = bound_start_; i <= k;
+       i = exp_step ? (i == 0 ? 1 : i << 1) : (i + bound_step_)) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -87,28 +77,24 @@ ProverResult Bmc::check_until(int k)
 
 bool Bmc::step(int i)
 {
-  logger.log(1, "Checking bmc at bound: {}", i);
+  logger.log(1, "BMC: checking at bound: {}", i);
   
   if (i <= reached_k_) {
     return true;
   }
 
   bool res = true;
-//CHECK code simplification: if-statement needed? seems not needed
   if (i > 0) {
-//
-    logger.log(2, "DEBUG reached k {}, i {} ", reached_k_, i);
+    logger.log(2, "BMC: reached k {}, i {} ", reached_k_, i);
     for (int j = reached_k_ == -1 ? 1 : reached_k_ + 1; j <= i; j++) {
-      logger.log(2, "DEBUG adding trans for j-1 == {}", j - 1);
+      logger.log(2, "BMC: adding trans for j-1 == {}", j - 1);
       solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
       if (options_.bmc_neg_init_step_) {
-	logger.log(2, "DEBUG adding negated init constraint for step {}", j);
+	logger.log(2, "BMC: adding negated init constraint for step {}", j);
 	Term not_init = solver_->make_term(PrimOp::Not, unroller_.at_time(ts_.init(), j));
 	solver_->assert_formula(not_init);
       }
     }
-    //OLD
-//    solver_->assert_formula(unroller_.at_time(ts_.trans(), i - 1));
   }
 
   solver_->push();
@@ -117,37 +103,32 @@ bool Bmc::step(int i)
 
   Term clause;
   if (cex_guarantee) {
-    // make sure we cover *all* states
-  // TODO (not critical): can make 'solver_->make_term(false)' a constant in the object
+    // make sure we cover *all* states by adding disjunctive bad state predicate
     clause = solver_->make_term(false);
     for (int j = reached_k_ + 1; j <= i; j++) {
-      logger.log(2, "DEBUG adding bad state constraint for j == {}", j);
+      logger.log(2, "BMC: adding bad state constraint for j == {}", j);
       clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
     }
   } else {
-    logger.log(2, "DEBUG adding bad state constraint for i == {}", i);
+    // add a single bad state predicate (bugs might be missed)
+    logger.log(2, "BMC: adding bad state constraint for i == {}", i);
     clause = unroller_.at_time(bad_, i);
   }
   
-  solver_->assert_formula(clause);
-  
-  //TODO: add bad state clause here
-    // OLD
-    // solver_->assert_formula(unroller_.at_time(bad_, i));
-
-
+  solver_->assert_formula(clause); 
+ 
   Result r = solver_->check_sat();
   if (r.is_sat()) {
-    logger.log(1, "  bmc check at bound {} satisfiable", i);
+    logger.log(1, "  BMC: check at bound {} satisfiable", i);
     res = false;
     if (cex_guarantee) {
-      logger.log(2, "DEBUG saving reached_k_ = {}", reached_k_);
+      logger.log(2, "BMC: saving reached_k_ = {}", reached_k_);
       int reached_k_saved = reached_k_;
       int cex_upper_bound = bmc_interval_get_cex_ub(reached_k_ + 1, i);
-      //FIX for corner case of length-1 interval: some solvers don't
-      //allow 'push' before 'get-value' even when no terms are asserted
-      //before 'get-value'. Hence don't 'push' if we don't add any terms
-      //in function 'bmc_interval_block_cex_ub'.
+      // FIX for corner case of length-1 interval: some solvers don't
+      // allow 'push' before 'get-value' even when no terms are asserted
+      // before 'get-value'. Hence don't 'push' if we don't add any terms
+      // in function 'bmc_interval_block_cex_ub'.
       if (cex_upper_bound + 1 <= i)
 	solver_->push();
       bmc_interval_block_cex_ub(cex_upper_bound + 1, i);
@@ -176,18 +157,19 @@ bool Bmc::step(int i)
       reached_k_ = i - 1;
     }
   } else {
-    logger.log(1, "  bmc check at bound {} unsatisfiable", i);
+    logger.log(1, "  BMC: check at bound {} unsatisfiable", i);
     solver_->pop();
+    // optional: add negated bad state predicates to bounds where no cex was found
     if (options_.bmc_neg_bad_step_ || options_.bmc_neg_bad_step_all_) {
       Term not_bad;
       if (options_.bmc_neg_bad_step_all_) {
 	for (int j = reached_k_ + 1; j <= i; j++) {
-	  logger.log(2, "DEBUG adding negated bad state constraint for j == {}", j);
+	  logger.log(2, "BMC: adding negated bad state constraint for j == {}", j);
 	  not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));
 	  solver_->assert_formula(not_bad);
 	}
       } else {
-	logger.log(2, "DEBUG adding negated bad state constraint for i == {}", i);
+	logger.log(2, "BMC: adding negated bad state constraint for i == {}", i);
 	not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, i));
 	solver_->assert_formula(not_bad);
       }
@@ -203,15 +185,14 @@ int Bmc::bmc_interval_get_cex_ub(const int lb, const int ub)
   const Term true_term = solver_->make_term(true);
   assert(lb <= ub);
   
-  logger.log(2, "DEBUG get cex upper bound: lower bound = {}, upper bound = {} ", lb, ub);
+  logger.log(2, "BMC: get cex upper bound: lower bound = {}, upper bound = {} ", lb, ub);
   
   int j;
   for (j = lb; j <= ub; j++) {
     Term bad_state_at_j = unroller_.at_time(bad_, j);
-    logger.log(2, "DEBUG get cex upper bound, checking value of bad state constraint j = {}", j);
-    //TODO check: proper use of return value of "get_value"?
+    logger.log(2, "BMC: get cex upper bound, checking value of bad state constraint j = {}", j);
     if (solver_->get_value(bad_state_at_j) == true_term) {
-      logger.log(2, "DEBUG get cex upper bound, found at j = {}", j);
+      logger.log(2, "BMC: get cex upper bound, found at j = {}", j);
       break;
     }
   }
@@ -222,12 +203,10 @@ int Bmc::bmc_interval_get_cex_ub(const int lb, const int ub)
 
 int Bmc::bmc_interval_block_cex_ub(const int start, const int end)
 {
-  //TODO CHECK that witness printing still works, i.e., we don't add new constraints after a sat-call
-  //for search of shortest cex: block bad state constraints in interval [start,end]
-  logger.log(2, "DEBUG get cex upper bound, permanently blocking [start,end] = [{},{}]", start, end); 
+  logger.log(2, "BMC: get cex upper bound, permanently blocking [start,end] = [{},{}]", start, end); 
   for (int k = start; k <= end; k++) {
     Term not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, k));
-    logger.log(3, "DEBUG get cex upper bound, "	\
+    logger.log(3, "BMC: get cex upper bound, "	\
 	       "adding permanent blocking bad state constraint for k == {}", k);
     solver_->assert_formula(not_bad);
   }
@@ -237,52 +216,43 @@ bool Bmc::find_shortest_cex_binary_search(const int upper_bound)
 {
   assert (bin_search_frames_ == 0);
   assert (reached_k_ < upper_bound);
-  logger.log(2, "DEBUG binary search, cex found in interval "\
+  logger.log(2, "BMC: binary search, cex found in interval "\
 	     "[reached_k+1,upper_bound] = [{},{}]", reached_k_ + 1, upper_bound);
 
   if (upper_bound - reached_k_ == 1) {
-    logger.log(2, "DEBUG interval has length 1, skipping search for shortest cex");
+    logger.log(2, "BMC: interval has length 1, skipping search for shortest cex");
     return true;
   }
 
   int low = reached_k_ + 1;
   int high = upper_bound;
   while (low <= high) {
-    //Term clause = solver_->make_term(false);
     int mid = low + (high - low) / 2;
-    logger.log(2, "\nDEBUG binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
+    logger.log(2, "\nBMC: binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
 
-    logger.log(3, "DEBUG binary search, solver->push()");
-    //solver_->pop();
+    logger.log(3, "BMC: binary search, solver->push()");
     solver_->push();
     bin_search_frames_++;
 
-//TODO REMOVE
-    //  assert(solver_->check_sat().is_sat());
-
-    
     int j;
-//    for (j = low; j <= mid; j++) {
     //we search for cex in [low,mid] hence block [mid+1,high]
-    logger.log(2, "DEBUG binary search, searching for cex in [low,mid] = [{},{}]", low, mid);
-    logger.log(2, "DEBUG binary search, temporarily blocking [mid+1,high] = [{},{}]", mid + 1, high); 
+    logger.log(2, "BMC: binary search, searching for cex in [low,mid] = [{},{}]", low, mid);
+    logger.log(2, "BMC: binary search, temporarily blocking [mid+1,high] = [{},{}]", mid + 1, high); 
     for (j = mid + 1; j <= high; j++) {
-      logger.log(3, "DEBUG binary search, finding shortest cex---"\
+      logger.log(3, "BMC: binary search, finding shortest cex---"\
 		 "adding blocking bad state constraint for j == {}", j);
-      //clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
       Term not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));
       solver_->assert_formula(not_bad);
     }
-//    solver_->assert_formula(clause);
 
     Result r = solver_->check_sat();
     assert(r.is_sat() || r.is_unsat());
     if (r.is_sat()) {
-      logger.log(2, "DEBUG binary search, sat result: {}", r);
-      logger.log(2, "DEBUG binary search, cex found in [low,mid] = [{},{}]", low, mid);
-      logger.log(2, "DEBUG binary search, [mid+1,high] = [{},{}] now permanently blocked", mid + 1, high); 
+      logger.log(2, "BMC: binary search, sat result: {}", r);
+      logger.log(2, "BMC: binary search, cex found in [low,mid] = [{},{}]", low, mid);
+      logger.log(2, "BMC: binary search, [mid+1,high] = [{},{}] now permanently blocked", mid + 1, high); 
       // if low == mid in current iteration, then we have tested a single
-      // bad state constraint; can exit loop in case of satisfiability
+      // bad state constraint and found a cex; can exit loop
       if (low == mid)
 	break;
       else {
@@ -290,34 +260,31 @@ bool Bmc::find_shortest_cex_binary_search(const int upper_bound)
 	bmc_interval_block_cex_ub(high + 1, mid);
       }
     } else {
-      logger.log(2, "DEBUG binary search, unsat result: {}", r);
-      logger.log(2, "DEBUG binary search, no cex in [low,mid] = [{},{}]", low, mid);
+      logger.log(2, "BMC: binary search, unsat result: {}", r);
+      logger.log(2, "BMC: binary search, no cex in [low,mid] = [{},{}]", low, mid);
       if (low >= high) {
 	// handle rare corner case
-	logger.log(1, "BMC FAILURE: formula overconstrained,"\
+	logger.log(1, "BMC binary search failure: formula overconstrained,"\
 		      " falling back to linear search");
 	return false;
       }
-      logger.log(2, "DEBUG binary search, unblocking [mid+1,high] = [{},{}]", mid + 1, high);
+      logger.log(2, "BMC: binary search, unblocking [mid+1,high] = [{},{}]", mid + 1, high);
       //remove previoulsy added blocking constraints for [mid+1,high]
-      logger.log(3, "DEBUG binary search, solver->pop()");
+      logger.log(3, "BMC: binary search, solver->pop()");
       solver_->pop();
       assert(bin_search_frames_ > 0);
       bin_search_frames_--;
       // update reached k; we have iteratively shown that no cex exists in [0,mid]
       reached_k_ = mid;
-      logger.log(2, "DEBUG binary search, permanently blocking [low,mid] = [{},{}]", low, mid); 
+      logger.log(2, "BMC: binary search, permanently blocking [low,mid] = [{},{}]", low, mid); 
       //no cex found in [low,mid] hence block [low,mid]
       for (j = low; j <= mid; j++) {
-	logger.log(3, "DEBUG binary search, finding shortest cex---"	\
+	logger.log(3, "BMC: binary search, finding shortest cex---"	\
 		   "adding blocking bad state constraint for j == {}", j);
 	Term not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));
 	solver_->assert_formula(not_bad);
       }
 
-//TODO REMOVE
-      //  assert(solver_->check_sat().is_sat());
-      
       low = mid + 1;
     }
   }
@@ -326,7 +293,7 @@ bool Bmc::find_shortest_cex_binary_search(const int upper_bound)
   assert(low <= high);
   //reached_k_ has been correctly updated to low - 1, i.e., cex bound - 1
   assert(reached_k_ + 1 == low);
-  logger.log(1, "DEBUG binary search, shortest cex at bound low == {},"\
+  logger.log(1, "BMC: binary search, shortest cex at bound low == {},"\
 	     " reached_k = {}", low, reached_k_);
   return true;
 }
@@ -338,11 +305,11 @@ bool Bmc::find_shortest_cex_binary_search(const int upper_bound)
 bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
 {
   assert (reached_k_ < upper_bound);
-  logger.log(2, "DEBUG less incremental binary search, cex found in interval "\
+  logger.log(2, "BMC: less incremental binary search, cex found in interval "\
 	     "[reached_k+1,upper_bound] = [{},{}]", reached_k_ + 1, upper_bound);
 
   if (upper_bound - reached_k_ == 1) {
-    logger.log(2, "DEBUG interval has length 1, skipping search for shortest cex");
+    logger.log(2, "BMC: interval has length 1, skipping search for shortest cex");
     return true;
   }
 
@@ -350,20 +317,20 @@ bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
   int high = upper_bound;
   while (low <= high) {
     int mid = low + (high - low) / 2;
-    logger.log(2, "\nDEBUG binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
+    logger.log(2, "\nBMC: binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
 
-    logger.log(3, "DEBUG binary search, solver->pop()");
+    logger.log(3, "BMC: binary search, solver->pop()");
     //discard most recent bad state clause
     solver_->pop();
-    logger.log(3, "DEBUG binary search, solver->push()");
+    logger.log(3, "BMC: binary search, solver->push()");
     solver_->push();
 
     int j;
     //we search for cex in [low,mid]
-    logger.log(2, "DEBUG binary search, searching for cex in [low,mid] = [{},{}]", low, mid);
+    logger.log(2, "BMC: binary search, searching for cex in [low,mid] = [{},{}]", low, mid);
     Term clause = solver_->make_term(false);
     for (j = low; j <= mid; j++) {
-      logger.log(3, "DEBUG binary search, finding shortest cex---"\
+      logger.log(3, "BMC: binary search, finding shortest cex---"\
 		 "adding bad state constraint for j == {}", j);
       clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
     }
@@ -372,8 +339,8 @@ bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
     Result r = solver_->check_sat();
     assert(r.is_sat() || r.is_unsat());
     if (r.is_sat()) {
-      logger.log(2, "DEBUG binary search, sat result: {}", r);
-      logger.log(2, "DEBUG binary search, cex found in [low,mid] = [{},{}]", low, mid);
+      logger.log(2, "BMC: binary search, sat result: {}", r);
+      logger.log(2, "BMC: binary search, cex found in [low,mid] = [{},{}]", low, mid);
       // if low == mid in current iteration, then we have tested a single
       // bad state constraint; can exit loop in case of satisfiability
       if (low == mid)
@@ -382,8 +349,8 @@ bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
 	high = bmc_interval_get_cex_ub(low, mid);
       }
     } else {
-      logger.log(2, "DEBUG binary search, unsat result: {}", r);
-      logger.log(2, "DEBUG binary search, no cex in [low,mid] = [{},{}]", low, mid);
+      logger.log(2, "BMC: binary search, unsat result: {}", r);
+      logger.log(2, "BMC: binary search, no cex in [low,mid] = [{},{}]", low, mid);
       // update reached k; we have iteratively shown that no cex exists in [0,mid]
       reached_k_ = mid;
       low = mid + 1;
@@ -394,7 +361,7 @@ bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
   assert(low <= high);
   //reached_k_ has been correctly updated to low - 1, i.e., cex bound - 1
   assert(reached_k_ + 1 == low);
-  logger.log(1, "DEBUG binary search, shortest cex at bound low == {},"\
+  logger.log(1, "BMC: binary search, shortest cex at bound low == {},"\
 	     " reached_k = {}", low, reached_k_);
   return true;
 }
@@ -402,31 +369,20 @@ bool Bmc::find_shortest_cex_binary_search_less_inc(const int upper_bound)
 void Bmc::find_shortest_cex_linear_search(const int upper_bound)
 {  
   assert (reached_k_ < upper_bound);
-  logger.log(2, "DEBUG linear search, cex found in interval: lower bound = reached k = {},"\
+  logger.log(2, "BMC: linear search, cex found in interval: lower bound = reached k = {},"\
 	     " upper bound = {}", reached_k_, upper_bound);
 
-//TODO: immediately return for length-1 intervals
-
   if (upper_bound - reached_k_ == 1) {
-    logger.log(2, "DEBUG interval has length 1, skipping search for shortest cex");
+    logger.log(2, "BMC: interval has length 1, skipping search for shortest cex");
     return;
   }
   
-
-//TODO: below loop searches iteratively; could do exponential
-//steps also, like in "check_until"; BMC with exponential steps could
-//be useful if there is a very deep bug at a large bound and the costs
-//of the SAT calls does not increase very much with the increased
-//bound, but still the cumulative time for the SAT calls at all bounds
-//is higher
-  
-//  return;
   int j;
   for (j = reached_k_ + 1; j <= upper_bound; j++) {
     //pop: remove the latest bad state clause
     solver_->pop();
     solver_->push();
-    logger.log(2, "DEBUG finding shortest cex---adding bad state constraint for j == {}", j);
+    logger.log(2, "BMC: finding shortest cex---adding bad state constraint for j == {}", j);
     solver_->assert_formula(unroller_.at_time(bad_, j));
     if (solver_->check_sat().is_sat()) {
       break;
@@ -436,10 +392,10 @@ void Bmc::find_shortest_cex_linear_search(const int upper_bound)
   }
   // must have found cex in the interval
   if (j > upper_bound)
-    throw PonoException("BMC FAILURE in linear search: formula overconstrained");
+    throw PonoException("Unexpected BMC failure in linear search: formula overconstrained");
 
   assert(reached_k_ + 1 == j);
-  logger.log(1, "DEBUG linear search found shortest cex at bound j == {}, reached_k {}", j, reached_k_);
+  logger.log(1, "BMC: linear search found shortest cex at bound j == {}, reached_k {}", j, reached_k_);
 }
   
 }  // namespace pono

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -157,6 +157,7 @@ int Bmc::bmc_interval_get_cex_ub(const int lb, const int ub)
 
   //TODO CHECK that witness printing still works, i.e., we don't add new constraints after a sat-call
   //for search of shortest cex: block bad state literals in interval [j+1,ub]
+  logger.log(2, "DEBUG get cex upper bound, permanently blocking [j+1,ub] = [{},{}]", j + 1, ub); 
   for (int k = j + 1; k <= ub; k++) {
     Term not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, k));
     logger.log(3, "DEBUG get cex upper bound, "	\

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -38,7 +38,7 @@ void Bmc::initialize()
 
   super::initialize();
 
-  // NOTE: There's an implicit assumption that this solver is only used for
+  // NOTE: for any engine; There's an implicit assumption that this solver is only used for
   // model checking once Otherwise there could be conflicting assertions to
   // the solver or it could just be polluted with redundant assertions in the
   // future we can use solver_->reset_assertions(), but it is not currently
@@ -50,6 +50,12 @@ ProverResult Bmc::check_until(int k)
 {
   initialize();
 
+  //NOTE/TODO: there is a corner case where an instance is trivially
+  //unsatisfiable, i.e., safe, when the conjunction of initial state
+  //predicate and transition (+ any constraints) is already unsat. We
+  //could also check this using unsat core functionality of solver (if
+  //supported), and check if bad state predicate is in core
+  
   const int step_bound = 1;
   const int start_bound = 0;
 

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -120,7 +120,7 @@ bool Bmc::step(int i)
   Result r = solver_->check_sat();
   if (r.is_sat()) {
     res = false;
-    int cex_upper_bound = bmc_interval_get_cex_ub(i, clause);
+    int cex_upper_bound = bmc_interval_get_cex_ub(reached_k_ + 1, i, clause);
     // find shortest cex within tested interval given by bad state clause
 //    bmc_interval_find_shortest_cex(cex_upper_bound);
     bmc_interval_find_shortest_cex_binary_search(cex_upper_bound);
@@ -132,27 +132,21 @@ bool Bmc::step(int i)
   return res;
 }
   
-int Bmc::bmc_interval_get_cex_ub(const int cur_ub, const Term bad_state_cl)
+int Bmc::bmc_interval_get_cex_ub(const int lb, const int ub, const Term bad_cl)
 {
   const Term true_term = solver_->make_term(true);
-  assert(reached_k_ < cur_ub);
-  assert(solver_->get_value(bad_state_cl) == true_term);
+  assert(lb <= ub);
+  assert(solver_->get_value(bad_cl) == true_term);
   
-  std::cout << "DEBUG get cex upper bound, cex in interval found: lower bound = reached k = "
-	    << reached_k_ << " current upper bound = " << cur_ub << std::endl;
+  std::cout << "DEBUG get cex upper bound: lower bound = "
+	    << lb << " upper bound = " << ub << std::endl;
 
 //NOTE: could call (modified version of) this function inside binary
 //search to potentially set 'high' to lower value than 'mid' of
 //sat-call on lower half is satisfiable
   
-  //TODO: for brevity, could omit that check; loop below for length-1-interval will terminate in first iteration
-  if (cur_ub - reached_k_ == 1) {
-    std::cout << "DEBUG get cex upper bound, interval has length 1, trivial upper bound = " << cur_ub << std::endl;
-    return cur_ub;
-  }
-
   int j;
-  for (j = reached_k_ + 1; j <= cur_ub; j++) {
+  for (j = lb; j <= ub; j++) {
     Term bad_state_at_j = unroller_.at_time(bad_, j);
     std::cout << "DEBUG get cex upper bound, checking value of bad state literal j = " << j << std::endl;
     if (solver_->get_value(bad_state_at_j) == true_term) {
@@ -160,7 +154,7 @@ int Bmc::bmc_interval_get_cex_ub(const int cur_ub, const Term bad_state_cl)
       break;
     }
   }
-  assert(j <= cur_ub);
+  assert(j <= ub);
 
   return j;
 }
@@ -199,7 +193,8 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
       if (low == mid)
 	break;
       else
-	high = mid;
+	high = bmc_interval_get_cex_ub(low, mid, clause);
+//OLD: do not exploit model to get upper bound;   high = mid;
     } else {
       std::cout << "DEBUG binary search, unsat result: " << r << std::endl;
       assert(low < high);

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -178,11 +178,9 @@ bool Bmc::step(int i)
   } else {
     logger.log(1, "  bmc check at bound {} unsatisfiable", i);
     solver_->pop();
-    // TODO: could add expert option to add *all* since last reached_k,
-    // whether being tested above or not
     if (options_.bmc_neg_bad_step_) {
       Term not_bad;
-      if (cex_guarantee) {
+      if (options_.bmc_neg_bad_step_all_ || cex_guarantee) {
 	for (int j = reached_k_ + 1; j <= i; j++) {
 	  logger.log(2, "DEBUG adding negated bad state constraint for j == {}", j);
 	  not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -176,8 +176,10 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
     Term clause = solver_->make_term(false);
     int mid = low + (high - low) / 2;
     logger.log(2, "DEBUG binary search, (low, mid, high) = ({}, {}, {})", low, mid, high);
+
     solver_->pop();
     solver_->push();
+
     int j;
     for (j = low; j <= mid; j++) {
       logger.log(2, "DEBUG binary search, finding shortest cex---"\
@@ -185,6 +187,7 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
       clause = solver_->make_term(PrimOp::Or, clause, unroller_.at_time(bad_, j));
     }
     solver_->assert_formula(clause);
+
     Result r = solver_->check_sat();
     assert(r.is_sat() || r.is_unsat());
     if (r.is_sat()) {
@@ -199,6 +202,8 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
     } else {
       logger.log(2, "DEBUG binary search, unsat result: {}", r);
       assert(low < high);
+      // update reached k; we have shown that no cex exists for bounds 0,...,mid
+      reached_k_ = mid;
       low = mid + 1;
     }
   }

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -178,9 +178,9 @@ bool Bmc::step(int i)
   } else {
     logger.log(1, "  bmc check at bound {} unsatisfiable", i);
     solver_->pop();
-    if (options_.bmc_neg_bad_step_) {
+    if (options_.bmc_neg_bad_step_ || options_.bmc_neg_bad_step_all_) {
       Term not_bad;
-      if (options_.bmc_neg_bad_step_all_ || cex_guarantee) {
+      if (options_.bmc_neg_bad_step_all_) {
 	for (int j = reached_k_ + 1; j <= i; j++) {
 	  logger.log(2, "DEBUG adding negated bad state constraint for j == {}", j);
 	  not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));

--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -26,6 +26,8 @@ Bmc::Bmc(const Property & p, const TransitionSystem & ts,
   : super(p, ts, solver, opt)
 {
   engine_ = Engine::BMC;
+  bound_step_ = opt.bmc_bound_step_;
+  bound_start_ = opt.bmc_bound_start_;
 }
 
 Bmc::~Bmc() {}
@@ -55,10 +57,10 @@ ProverResult Bmc::check_until(int k)
   //predicate and transition (+ any constraints) is already unsat. We
   //could also check this using unsat core functionality of solver (if
   //supported), and check if bad state predicate is in core
-  
-  const int step_bound = 1;
-  const int start_bound = 0;
 
+  logger.log(1, "DEBUG BMC bound_start_ {} ", bound_start_);  
+  logger.log(1, "DEBUG BMC bound_step_ {} ", bound_step_);  
+  
   // reached_k == -1 initially
   
   //  if (start_bound > 0)
@@ -70,7 +72,7 @@ ProverResult Bmc::check_until(int k)
   //   solver_->assert_formula(unroller_.at_time(ts_.trans(), j - 1));
 //  }
   
-  for (int i = start_bound; i <= k; i += step_bound /* i = i == 0 ? 1 : i << 1 */) {
+  for (int i = bound_start_; i <= k; i += bound_step_ /* i = i == 0 ? 1 : i << 1 */) {
     if (!step(i)) {
       compute_witness();
       return ProverResult::FALSE;
@@ -196,6 +198,10 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
     //solver_->pop();
     solver_->push();
 
+//TODO REMOVE
+    //  assert(solver_->check_sat().is_sat());
+
+    
     int j;
 //    for (j = low; j <= mid; j++) {
     //we search for cex in [low,mid] hence block [mid+1,high]
@@ -241,7 +247,10 @@ void Bmc::bmc_interval_find_shortest_cex_binary_search(const int upper_bound)
 	Term not_bad = solver_->make_term(PrimOp::Not, unroller_.at_time(bad_, j));
 	solver_->assert_formula(not_bad);
       }
-	
+
+//TODO REMOVE
+      //  assert(solver_->check_sat().is_sat());
+      
       low = mid + 1;
     }
   }

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -2,9 +2,9 @@
 /*! \file
  ** \verbatim
  ** Top contributors (to current version):
- **   Ahmed Irfan, Makai Mann
+ **   Ahmed Irfan, Makai Mann, Florian Lonsing
  ** This file is part of the pono project.
- ** Copyright (c) 2019 by the authors listed in the file AUTHORS
+ ** Copyright (c) 2019, 2021, 2022 by the authors listed in the file AUTHORS
  ** in the top-level source directory) and their institutional affiliations.
  ** All rights reserved.  See the file LICENSE in the top-level source
  ** directory for licensing information.\endverbatim
@@ -39,13 +39,24 @@ public:
   bool step(int i);
 
  private:
+  // BMC bound to start with (default: 0)
   unsigned int bound_start_;
+  // Value by which to increase BMC bound (default: 1)
   unsigned int bound_step_;
+  // Used in binary search for cex: number of times we called 'solver->push()'
   unsigned int bin_search_frames_;
+  // Get an upper bound on the cex, which is located in interval '[lb,ub]'
   int bmc_interval_get_cex_ub(const int lb, const int ub);
+  // Add negated bad state predicate for all bounds in interval '[start,end]'.
+  // This way, we restrict the search space of the solver to disregard these
+  // bounds when searching for a cex.
   int bmc_interval_block_cex_ub(const int start, const int end);
+  // Run linear search for cex within interval '[reached_k_ + 1, upper_bound]'
   void find_shortest_cex_linear_search(const int upper_bound);
+  // Run binary search for cex within interval '[reached_k_ + 1, upper_bound]'.
   bool find_shortest_cex_binary_search(const int upper_bound);
+  // Run binary search for cex within interval '[reached_k_ + 1, upper_bound]'
+  // with less incremental solver use.
   bool find_shortest_cex_binary_search_less_inc(const int upper_bound);
 };  // class Bmc
 

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -46,7 +46,7 @@ public:
   int bmc_interval_block_cex_ub(const int start, const int end);
   void find_shortest_cex_linear_search(const int upper_bound);
   bool find_shortest_cex_binary_search(const int upper_bound);
-  bool find_shortest_cex_binary_search_non_inc(const int upper_bound);
+  bool find_shortest_cex_binary_search_less_inc(const int upper_bound);
 };  // class Bmc
 
 }  // namespace pono

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -39,6 +39,7 @@ public:
   bool step(int i);
 
  private:
+  int bmc_interval_get_cex_ub(const int cur_ub, const smt::Term bad_state_cl);
   void bmc_interval_find_shortest_cex(const int upper_bound);
   void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -39,7 +39,8 @@ public:
   bool step(int i);
 
  private:
-  void bmc_interval_find_shortest_cex(const int upper_bound); 
+  void bmc_interval_find_shortest_cex(const int upper_bound);
+  void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc
 
 }  // namespace pono

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -41,9 +41,10 @@ public:
  private:
   unsigned int bound_start_;
   unsigned int bound_step_;
+  unsigned int bin_search_frames_;
   int bmc_interval_get_cex_ub(const int lb, const int ub);
-  void bmc_interval_find_shortest_cex(const int upper_bound);
-  void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
+  void bmc_interval_find_shortest_cex_linear_search(const int upper_bound);
+  bool bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc
 
 }  // namespace pono

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -39,7 +39,7 @@ public:
   bool step(int i);
 
  private:
-  int bmc_interval_get_cex_ub(const int cur_ub, const smt::Term bad_state_cl);
+  int bmc_interval_get_cex_ub(const int lb, const int ub, const smt::Term bad_cl);
   void bmc_interval_find_shortest_cex(const int upper_bound);
   void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -39,7 +39,7 @@ public:
   bool step(int i);
 
  private:
-  int bmc_interval_get_cex_ub(const int lb, const int ub, const smt::Term bad_cl);
+  int bmc_interval_get_cex_ub(const int lb, const int ub);
   void bmc_interval_find_shortest_cex(const int upper_bound);
   void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -43,6 +43,7 @@ public:
   unsigned int bound_step_;
   unsigned int bin_search_frames_;
   int bmc_interval_get_cex_ub(const int lb, const int ub);
+  int bmc_interval_block_cex_ub(const int start, const int end);
   void bmc_interval_find_shortest_cex_linear_search(const int upper_bound);
   bool bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
 };  // class Bmc

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -44,8 +44,9 @@ public:
   unsigned int bin_search_frames_;
   int bmc_interval_get_cex_ub(const int lb, const int ub);
   int bmc_interval_block_cex_ub(const int start, const int end);
-  void bmc_interval_find_shortest_cex_linear_search(const int upper_bound);
-  bool bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 
+  void find_shortest_cex_linear_search(const int upper_bound);
+  bool find_shortest_cex_binary_search(const int upper_bound);
+  bool find_shortest_cex_binary_search_non_inc(const int upper_bound);
 };  // class Bmc
 
 }  // namespace pono

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -38,6 +38,8 @@ public:
  protected:
   bool step(int i);
 
+ private:
+  void bmc_interval_find_shortest_cex(const int upper_bound); 
 };  // class Bmc
 
 }  // namespace pono

--- a/engines/bmc.h
+++ b/engines/bmc.h
@@ -39,6 +39,8 @@ public:
   bool step(int i);
 
  private:
+  unsigned int bound_start_;
+  unsigned int bound_step_;
   int bmc_interval_get_cex_ub(const int lb, const int ub);
   void bmc_interval_find_shortest_cex(const int upper_bound);
   void bmc_interval_find_shortest_cex_binary_search(const int upper_bound); 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -72,7 +72,9 @@ enum optionIndex
   SYGUS_TERM_MODE,
   IC3SA_INITIAL_TERMS_LVL,
   IC3SA_INTERP,
-  PRINT_WALL_TIME
+  PRINT_WALL_TIME,
+  BMC_BOUND_START,
+  BMC_BOUND_STEP
 };
 
 struct Arg : public option::Arg
@@ -418,6 +420,23 @@ const option::Descriptor usage[] = {
     "print-wall-time",
     Arg::None,
     "  --print-wall-time \tPrint wall clock time of entire execution" },
+    { BMC_BOUND_START,
+    0,
+    "",
+    "bmc-bound-start",
+    Arg::Numeric,
+    "  --bmc-bound-start \tBound (unrolling depth) to start "
+    "cex search in BMC (default: 0)"
+    },
+    { BMC_BOUND_STEP,
+    0,
+    "",
+    "bmc-bound-step",
+    Arg::Numeric,
+    "  --bmc-bound-step \tAmount by which bound (unrolling depth) for cex search "
+    "is increased in BMC (default: 1). For values greater than 1, BMC searches "
+      "for cex in intervals of size '--bmc-bound-step'."
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -572,6 +591,11 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         }
         case IC3SA_INTERP: ic3sa_interp_ = true; break;
         case PRINT_WALL_TIME: print_wall_time_ = true; break;
+        case BMC_BOUND_START: bmc_bound_start_ = atoi(opt.arg); break;  
+        case BMC_BOUND_STEP: bmc_bound_step_ = atoi(opt.arg);
+	  if (bmc_bound_step_ == 0)
+	    throw PonoException("--bmc-bound-step must be greater than 0");
+	  break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -79,7 +79,8 @@ enum optionIndex
   BMC_EXPONENTIAL_STEP,
   BMC_SINGLE_BAD_STATE,
   BMC_NEG_BAD_STEP,
-  BMC_MIN_CEX_LIN_SEARCH
+  BMC_MIN_CEX_LIN_SEARCH,
+  BMC_MIN_CEX_LESS_INC_BIN_SEARCH
 };
 
 struct Arg : public option::Arg
@@ -484,7 +485,16 @@ const option::Descriptor usage[] = {
     "  --bmc-min-cex-linear-search \tApply linear instead of binary search for "
                         "minimal cex after a cex was found in current interval"
     },
+  { BMC_MIN_CEX_LESS_INC_BIN_SEARCH,
+    0,
+    "",
+    "bmc-min-cex-less-inc-bin-search",
+    Arg::None,
+    "  --bmc-min-cex-less-inc-bin-search \tApply less incremental variant of binary search for "
+                        "minimal cex after a cex was found in current interval"
+    },
 
+  
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -649,6 +659,8 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
         case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true; break;
         case BMC_MIN_CEX_LIN_SEARCH: bmc_min_cex_linear_search_ = true; break;
+        case BMC_MIN_CEX_LESS_INC_BIN_SEARCH:
+	  bmc_min_cex_less_inc_bin_search_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -668,8 +668,16 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_NEG_INIT_STEP: bmc_neg_init_step_ = true; break;
         case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
 	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
-        case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true; break;
-        case BMC_NEG_BAD_STEP_ALL: bmc_neg_bad_step_all_ = true; break;
+        case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true;
+	  if (bmc_neg_bad_step_all_)
+	    throw PonoException("--bmc-neg-bad-step-all cannot be combined "\
+				"with '--bmc-neg-bad-step'");
+	  break;
+        case BMC_NEG_BAD_STEP_ALL: bmc_neg_bad_step_all_ = true;
+	  if (bmc_neg_bad_step_)
+	    throw PonoException("--bmc-neg-bad-step cannot be combined " \
+				"with '--bmc-neg-bad-step-all'");
+	  break;
         case BMC_MIN_CEX_LIN_SEARCH: bmc_min_cex_linear_search_ = true; break;
         case BMC_MIN_CEX_LESS_INC_BIN_SEARCH:
 	  bmc_min_cex_less_inc_bin_search_ = true; break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -77,7 +77,8 @@ enum optionIndex
   BMC_BOUND_STEP,
   BMC_NEG_INIT_STEP,
   BMC_EXPONENTIAL_STEP,
-  BMC_SINGLE_BAD_STATE
+  BMC_SINGLE_BAD_STATE,
+  BMC_NEG_BAD_STEP
 };
 
 struct Arg : public option::Arg
@@ -466,7 +467,14 @@ const option::Descriptor usage[] = {
     " for current bound k rather than a disjunctive term covering the checked"
     " interval; counterexamples may be missed. (default: false)."
     },
-
+  { BMC_NEG_BAD_STEP,
+    0,
+    "",
+    "bmc-neg-bad-step",
+    Arg::None,
+    "  --bmc-neg-bad-step \tAdd negated bad state constraint in " 
+                            "BMC steps k > 0 (default: false)."
+    },
 
   { 0, 0, 0, 0, 0, 0 }
 };
@@ -630,6 +638,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_NEG_INIT_STEP: bmc_neg_init_step_ = true; break;
         case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
 	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
+        case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -78,7 +78,8 @@ enum optionIndex
   BMC_NEG_INIT_STEP,
   BMC_EXPONENTIAL_STEP,
   BMC_SINGLE_BAD_STATE,
-  BMC_NEG_BAD_STEP
+  BMC_NEG_BAD_STEP,
+  BMC_MIN_CEX_LIN_SEARCH
 };
 
 struct Arg : public option::Arg
@@ -475,6 +476,14 @@ const option::Descriptor usage[] = {
     "  --bmc-neg-bad-step \tAdd negated bad state constraint in " 
                             "BMC steps k > 0 (default: false)."
     },
+  { BMC_MIN_CEX_LIN_SEARCH,
+    0,
+    "",
+    "bmc-min-cex-linear-search",
+    Arg::None,
+    "  --bmc-min-cex-linear-search \tApply linear instead of binary search for "
+                        "minimal cex after a cex was found in current interval"
+    },
 
   { 0, 0, 0, 0, 0, 0 }
 };
@@ -639,6 +648,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
 	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
         case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true; break;
+        case BMC_MIN_CEX_LIN_SEARCH: bmc_min_cex_linear_search_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -80,7 +80,8 @@ enum optionIndex
   BMC_SINGLE_BAD_STATE,
   BMC_NEG_BAD_STEP,
   BMC_MIN_CEX_LIN_SEARCH,
-  BMC_MIN_CEX_LESS_INC_BIN_SEARCH
+  BMC_MIN_CEX_LESS_INC_BIN_SEARCH,
+  BMC_NEG_BAD_STEP_ALL
 };
 
 struct Arg : public option::Arg
@@ -477,6 +478,16 @@ const option::Descriptor usage[] = {
     "  --bmc-neg-bad-step \tAdd negated bad state constraint in " 
                             "BMC steps k > 0 (default: false)."
     },
+  { BMC_NEG_BAD_STEP_ALL,
+    0,
+    "",
+    "bmc-neg-bad-step-all",
+    Arg::None,
+    "  --bmc-neg-bad-step-all \tEXPERT OPTION: like '--bmc-neg-bad-step' but add"
+    " negated bad state constraint in ALL BMC steps k > 0 (default: false). When"
+    " combined with --bmc-single-bad-state, this option may cause overconstraining"
+    " the problem in certain corner cases."
+  },
   { BMC_MIN_CEX_LIN_SEARCH,
     0,
     "",
@@ -658,6 +669,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
 	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
         case BMC_NEG_BAD_STEP: bmc_neg_bad_step_ = true; break;
+        case BMC_NEG_BAD_STEP_ALL: bmc_neg_bad_step_all_ = true; break;
         case BMC_MIN_CEX_LIN_SEARCH: bmc_min_cex_linear_search_ = true; break;
         case BMC_MIN_CEX_LESS_INC_BIN_SEARCH:
 	  bmc_min_cex_less_inc_bin_search_ = true; break;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -76,7 +76,8 @@ enum optionIndex
   BMC_BOUND_START,
   BMC_BOUND_STEP,
   BMC_NEG_INIT_STEP,
-  BMC_EXPONENTIAL_STEP
+  BMC_EXPONENTIAL_STEP,
+  BMC_SINGLE_BAD_STATE
 };
 
 struct Arg : public option::Arg
@@ -455,6 +456,18 @@ const option::Descriptor usage[] = {
     "  --bmc-exponential-step \tDouble BMC bound in each step starting "
          "at 'bmc-bound-start' (default: false, explores bounds 0, 1, 2, 4,...)."
     },
+
+  { BMC_SINGLE_BAD_STATE,
+    0,
+    "",
+    "bmc-single-bad-state",
+    Arg::None,
+    "  --bmc-single-bad-state \tEXPERT OPTION: add a single bad state literal"
+    " for current bound k rather than a disjunctive term covering the checked"
+    " interval; counterexamples may be missed. (default: false)."
+    },
+
+
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -616,6 +629,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  break;
         case BMC_NEG_INIT_STEP: bmc_neg_init_step_ = true; break;
         case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
+	case BMC_SINGLE_BAD_STATE: bmc_single_bad_state_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -74,7 +74,8 @@ enum optionIndex
   IC3SA_INTERP,
   PRINT_WALL_TIME,
   BMC_BOUND_START,
-  BMC_BOUND_STEP
+  BMC_BOUND_STEP,
+  BMC_NEG_INIT_STEP
 };
 
 struct Arg : public option::Arg
@@ -437,6 +438,13 @@ const option::Descriptor usage[] = {
     "is increased in BMC (default: 1). For values greater than 1, BMC searches "
       "for cex in intervals of size '--bmc-bound-step'."
     },
+  { BMC_NEG_INIT_STEP,
+    0,
+    "",
+    "bmc-neg-init-step",
+    Arg::None,
+    "  --bmc-neg-init-step \tAdd negated initial state constraint in BMC steps k > 0."
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -596,6 +604,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  if (bmc_bound_step_ == 0)
 	    throw PonoException("--bmc-bound-step must be greater than 0");
 	  break;
+        case BMC_NEG_INIT_STEP: bmc_neg_init_step_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -75,7 +75,8 @@ enum optionIndex
   PRINT_WALL_TIME,
   BMC_BOUND_START,
   BMC_BOUND_STEP,
-  BMC_NEG_INIT_STEP
+  BMC_NEG_INIT_STEP,
+  BMC_EXPONENTIAL_STEP
 };
 
 struct Arg : public option::Arg
@@ -443,7 +444,16 @@ const option::Descriptor usage[] = {
     "",
     "bmc-neg-init-step",
     Arg::None,
-    "  --bmc-neg-init-step \tAdd negated initial state constraint in BMC steps k > 0."
+    "  --bmc-neg-init-step \tAdd negated initial state constraint in " 
+                            "BMC steps k > 0 (default: false)."
+    },
+  { BMC_EXPONENTIAL_STEP,
+    0,
+    "",
+    "bmc-exponential-step",
+    Arg::None,
+    "  --bmc-exponential-step \tDouble BMC bound in each step starting "
+         "at 'bmc-bound-start' (default: false, explores bounds 0, 1, 2, 4,...)."
     },
   { 0, 0, 0, 0, 0, 0 }
 };
@@ -605,6 +615,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	    throw PonoException("--bmc-bound-step must be greater than 0");
 	  break;
         case BMC_NEG_INIT_STEP: bmc_neg_init_step_ = true; break;
+        case BMC_EXPONENTIAL_STEP: bmc_exponential_step_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -138,6 +138,7 @@ class PonoOptions
         bmc_exponential_step_(default_bmc_exponential_step_),
         bmc_single_bad_state_(default_bmc_single_bad_state_),
         bmc_neg_bad_step_(default_bmc_neg_bad_step_),
+        bmc_neg_bad_step_all_(default_bmc_neg_bad_step_all_),
         bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_),
         bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_)
   {
@@ -246,6 +247,9 @@ class PonoOptions
   bool bmc_single_bad_state_;
   // BMC: add negated bad state predicate depending on reached_k_ (default: false)
   bool bmc_neg_bad_step_;
+  // BMC: like 'bmc_neg_bad_step_' but adds negated bad state predicate for all
+  // seen bounds (default: false)
+  bool bmc_neg_bad_step_all_;
   // Apply linear instead of binary search for minimal counterexample
   // after a counterexample was found within an interval
   bool bmc_min_cex_linear_search_;
@@ -307,6 +311,7 @@ private:
   static const bool default_bmc_exponential_step_ = false;
   static const bool default_bmc_single_bad_state_ = false;
   static const bool default_bmc_neg_bad_step_ = false;
+  static const bool default_bmc_neg_bad_step_all_ = false;
   static const bool default_bmc_min_cex_linear_search_ = false;
   static const bool default_bmc_min_cex_less_inc_bin_search_ = false;
 };

--- a/options/options.h
+++ b/options/options.h
@@ -136,7 +136,8 @@ class PonoOptions
         bmc_bound_step_(default_bmc_bound_step_),
         bmc_neg_init_step_(default_bmc_neg_init_step_),
         bmc_exponential_step_(default_bmc_exponential_step_),
-        bmc_single_bad_state_(default_bmc_single_bad_state_)
+        bmc_single_bad_state_(default_bmc_single_bad_state_),
+        bmc_neg_bad_step_(default_bmc_neg_bad_step_)
   {
   }
 
@@ -241,7 +242,9 @@ class PonoOptions
   // BMC EXPERT OPTION: do not add a disjunctive bad state property
   // representing an interval, but a single bad state literal at bound k;
   bool bmc_single_bad_state_;
-
+  // BMC: add negated bad state predicate depending on reached_k_ (default: false)
+  bool bmc_neg_bad_step_;
+  
 private:
   // Default options
   static const Engine default_engine_ = BMC;
@@ -296,6 +299,7 @@ private:
   static const bool default_bmc_neg_init_step_ = false;
   static const bool default_bmc_exponential_step_ = false;
   static const bool default_bmc_single_bad_state_ = false;
+  static const bool default_bmc_neg_bad_step_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -135,7 +135,8 @@ class PonoOptions
         bmc_bound_start_(default_bmc_bound_start_),
         bmc_bound_step_(default_bmc_bound_step_),
         bmc_neg_init_step_(default_bmc_neg_init_step_),
-        bmc_exponential_step_(default_bmc_exponential_step_)
+        bmc_exponential_step_(default_bmc_exponential_step_),
+        bmc_single_bad_state_(default_bmc_single_bad_state_)
   {
   }
 
@@ -237,6 +238,9 @@ class PonoOptions
   // 'bmc_bound_start_'; if bmc_bound_start_ == 0, this results in
   // exploration of bounds 0,1,2,4,8,...
   bool bmc_exponential_step_;
+  // BMC EXPERT OPTION: do not add a disjunctive bad state property
+  // representing an interval, but a single bad state literal at bound k;
+  bool bmc_single_bad_state_;
 
 private:
   // Default options
@@ -291,6 +295,7 @@ private:
   static const unsigned default_bmc_bound_step_ = 1;
   static const bool default_bmc_neg_init_step_ = false;
   static const bool default_bmc_exponential_step_ = false;
+  static const bool default_bmc_single_bad_state_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -226,7 +226,8 @@ class PonoOptions
   // print wall clock time spent in entire execution
   bool print_wall_time_;
 
-  // BMC interval options
+  // BMC interval options (these options are modifiers of the 'BMC' engine;
+  //   they do not apply to engine 'BMC-SP')
   // Default bmc_bound_start_ == 0, which starts search for cex at
   // unrolling depth 0 like traditional BMC.
   unsigned bmc_bound_start_;

--- a/options/options.h
+++ b/options/options.h
@@ -131,7 +131,9 @@ class PonoOptions
             default_sygus_use_operator_abstraction_),
         ic3sa_initial_terms_lvl_(default_ic3sa_initial_terms_lvl_),
         ic3sa_interp_(default_ic3sa_interp_),
-        print_wall_time_(default_print_wall_time_)
+        print_wall_time_(default_print_wall_time_),
+        bmc_bound_start_(default_bmc_bound_start_),
+        bmc_bound_step_(default_bmc_bound_step_)
   {
   }
 
@@ -217,7 +219,18 @@ class PonoOptions
   // print wall clock time spent in entire execution
   bool print_wall_time_;
 
- private:
+  // BMC interval options
+  // Default bmc_bound_start_ == 0, which starts search for cex at
+  // unrolling depth 0 like traditional BMC.
+  unsigned bmc_bound_start_;
+  // Default: bmc_bound_step_ == 1, which results in traditional BMC
+  // where every bound is checked one by one. bmc_bound_step_ is the
+  // value by which the current unrolling depth is increased. For
+  // bmc_bound_step_ > 1, BMC searches for cex in intervals of size
+  // bmc_bound_step_.
+  unsigned bmc_bound_step_;
+
+private:
   // Default options
   static const Engine default_engine_ = BMC;
   static const unsigned int default_prop_idx_ = 0;
@@ -266,6 +279,8 @@ class PonoOptions
   static const size_t default_ic3sa_initial_terms_lvl_ = 4;
   static const bool default_ic3sa_interp_ = false;
   static const bool default_print_wall_time_ = false;
+  static const unsigned default_bmc_bound_start_ = 0;
+  static const unsigned default_bmc_bound_step_ = 1;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -134,7 +134,8 @@ class PonoOptions
         print_wall_time_(default_print_wall_time_),
         bmc_bound_start_(default_bmc_bound_start_),
         bmc_bound_step_(default_bmc_bound_step_),
-        bmc_neg_init_step_(default_bmc_neg_init_step_)
+        bmc_neg_init_step_(default_bmc_neg_init_step_),
+        bmc_exponential_step_(default_bmc_exponential_step_)
   {
   }
 
@@ -232,6 +233,10 @@ class PonoOptions
   unsigned bmc_bound_step_;
   // BMC: add negated initial state predicate in steps k > 0 (default: false)
   bool bmc_neg_init_step_;
+  // BMC: double the bound in each step starting from
+  // 'bmc_bound_start_'; if bmc_bound_start_ == 0, this results in
+  // exploration of bounds 0,1,2,4,8,...
+  bool bmc_exponential_step_;
 
 private:
   // Default options
@@ -285,6 +290,7 @@ private:
   static const unsigned default_bmc_bound_start_ = 0;
   static const unsigned default_bmc_bound_step_ = 1;
   static const bool default_bmc_neg_init_step_ = false;
+  static const bool default_bmc_exponential_step_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -137,7 +137,8 @@ class PonoOptions
         bmc_neg_init_step_(default_bmc_neg_init_step_),
         bmc_exponential_step_(default_bmc_exponential_step_),
         bmc_single_bad_state_(default_bmc_single_bad_state_),
-        bmc_neg_bad_step_(default_bmc_neg_bad_step_)
+        bmc_neg_bad_step_(default_bmc_neg_bad_step_),
+        bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_)
   {
   }
 
@@ -244,6 +245,9 @@ class PonoOptions
   bool bmc_single_bad_state_;
   // BMC: add negated bad state predicate depending on reached_k_ (default: false)
   bool bmc_neg_bad_step_;
+  // Apply linear instead of binary search for minimal counterexample
+  // after a counterexample was found within an interval
+  bool bmc_min_cex_linear_search_;
   
 private:
   // Default options
@@ -300,6 +304,7 @@ private:
   static const bool default_bmc_exponential_step_ = false;
   static const bool default_bmc_single_bad_state_ = false;
   static const bool default_bmc_neg_bad_step_ = false;
+  static const bool default_bmc_min_cex_linear_search_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -133,7 +133,8 @@ class PonoOptions
         ic3sa_interp_(default_ic3sa_interp_),
         print_wall_time_(default_print_wall_time_),
         bmc_bound_start_(default_bmc_bound_start_),
-        bmc_bound_step_(default_bmc_bound_step_)
+        bmc_bound_step_(default_bmc_bound_step_),
+        bmc_neg_init_step_(default_bmc_neg_init_step_)
   {
   }
 
@@ -229,6 +230,8 @@ class PonoOptions
   // bmc_bound_step_ > 1, BMC searches for cex in intervals of size
   // bmc_bound_step_.
   unsigned bmc_bound_step_;
+  // BMC: add negated initial state predicate in steps k > 0 (default: false)
+  bool bmc_neg_init_step_;
 
 private:
   // Default options
@@ -281,6 +284,7 @@ private:
   static const bool default_print_wall_time_ = false;
   static const unsigned default_bmc_bound_start_ = 0;
   static const unsigned default_bmc_bound_step_ = 1;
+  static const bool default_bmc_neg_init_step_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -138,7 +138,8 @@ class PonoOptions
         bmc_exponential_step_(default_bmc_exponential_step_),
         bmc_single_bad_state_(default_bmc_single_bad_state_),
         bmc_neg_bad_step_(default_bmc_neg_bad_step_),
-        bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_)
+        bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_),
+        bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_)
   {
   }
 
@@ -248,6 +249,8 @@ class PonoOptions
   // Apply linear instead of binary search for minimal counterexample
   // after a counterexample was found within an interval
   bool bmc_min_cex_linear_search_;
+  // BMC: apply less incremental binary search
+  bool bmc_min_cex_less_inc_bin_search_;
   
 private:
   // Default options
@@ -305,6 +308,7 @@ private:
   static const bool default_bmc_single_bad_state_ = false;
   static const bool default_bmc_neg_bad_step_ = false;
   static const bool default_bmc_min_cex_linear_search_ = false;
+  static const bool default_bmc_min_cex_less_inc_bin_search_ = false;
 };
 
 // Useful functions for printing etc...

--- a/samples/bmc-interval-search/count2-large-interval-bin-search-overconstrained.btor2
+++ b/samples/bmc-interval-search/count2-large-interval-bin-search-overconstrained.btor2
@@ -4,7 +4,7 @@
 ; Command line: ./pono -v 2 -e bmc -k 1000000000 --bmc-bound-start 20 --bmc-bound-step 10
 ;
 ; With the above configuration, fully incremental binary search (default) will encounter
-; an overconstrained problem caused by blocking terms added to dived the interval into subintervals.
+; an overconstrained problem caused by blocking terms added to divide the interval into subintervals.
 ; We will fall back into linear search in that case
 ;
 ; This is not an issue with flags '--bmc-min-cex-less-inc-bin-search' (less incremental binary search) or linear search. 

--- a/samples/bmc-interval-search/count2-large-interval-bin-search-overconstrained.btor2
+++ b/samples/bmc-interval-search/count2-large-interval-bin-search-overconstrained.btor2
@@ -1,0 +1,20 @@
+; 2-bit counter with state 1 as bad state, wrap around after state 3
+; I.e., bad states due to cycle length of 4: 1, 5, 9, 13, ... 
+;
+; Command line: ./pono -v 2 -e bmc -k 1000000000 --bmc-bound-start 20 --bmc-bound-step 10
+;
+; With the above configuration, fully incremental binary search (default) will encounter
+; an overconstrained problem caused by blocking terms added to dived the interval into subintervals.
+; We will fall back into linear search in that case
+;
+; This is not an issue with flags '--bmc-min-cex-less-inc-bin-search' (less incremental binary search) or linear search. 
+1 sort bitvec 2
+2 zero 1
+3 state 1
+4 init 1 3 2
+5 one 1
+6 add 1 3 5
+7 next 1 3 6
+9 sort bitvec 1
+10 eq 9 3 5
+11 bad 10

--- a/samples/bmc-interval-search/count2-single-bad-state-neg-all-miss-cex.btor2
+++ b/samples/bmc-interval-search/count2-single-bad-state-neg-all-miss-cex.btor2
@@ -1,0 +1,20 @@
+; 2-bit counter with state 1 as bad state, wrap around after state 3
+; I.e., bad states due to cycle length of 4: 1, 5, 9, 13, ... 
+; When using single bad state approach with an interval length of 3
+; (flags '--bmc-bound-step 3 --bmc-single-bad-state') then we will
+; miss the counterexample at states 1 and 5, but will find it at state 9.
+;
+; Command line: ./pono -v 3 -e bmc -k 1000 --bmc-bound-step 3 --bmc-single-bad-state --bmc-neg-bad-step --bmc-neg-bad-step-all
+;
+; With the above configuration, the counterexample will be missed because the problem is overconstrained.
+; When omitting the flag '--bmc-neg-bad-step-all', the counterexample is found
+1 sort bitvec 2
+2 zero 1
+3 state 1
+4 init 1 3 2
+5 one 1
+6 add 1 3 5
+7 next 1 3 6
+9 sort bitvec 1
+10 eq 9 3 5
+11 bad 10

--- a/samples/bmc-interval-search/count2-stall-bad-state.btor2
+++ b/samples/bmc-interval-search/count2-stall-bad-state.btor2
@@ -1,0 +1,12 @@
+1 sort bitvec 2
+2 zero 1
+3 state 1
+4 init 1 3 2
+5 one 1
+6 add 1 3 5
+8 ones 1
+9 sort bitvec 1
+10 eq 9 3 8
+11 bad 10
+12 ite 1 10 3 6
+13 next 1 3 12

--- a/samples/bmc-interval-search/count2-stall-bad-state.btor2
+++ b/samples/bmc-interval-search/count2-stall-bad-state.btor2
@@ -1,3 +1,6 @@
+; counter with bad state defined as the max. counter value
+; once the bad state is reached after incrementing the counter,
+; the system stays in the bad state, i.e., there is no wrap-around
 1 sort bitvec 2
 2 zero 1
 3 state 1

--- a/samples/k-induction/adder-cfg-safe.btor2
+++ b/samples/k-induction/adder-cfg-safe.btor2
@@ -1,0 +1,47 @@
+; instance is safe: hard for k-induction with increasing bit-widths
+; - easy for IC3
+; - cfg is constant 0 during unrolling
+;
+10 sort bitvec 3
+20 sort bitvec 1
+30 zero 10
+40 one 10
+45 ones 10
+50 input 10 a
+60 input 10 b
+70 state 10 out
+80 state 10 buf_a
+90 state 10 buf_b
+95 state 10 cfg
+; init out := 0
+110 init 10 70 30
+; init buf_a := 0
+120 init 10 80 30
+; init buf_b := 0
+130 init 10 90 30
+; init cfg := 0
+150 init 10 95 30
+;
+; a + b
+151 add 10 50 60
+; a - b
+155 sub 10 50 50
+; cfg == 0 ? a + b : a - b
+156 eq 20 95 30
+160 ite 10 156 151 155
+;
+; cfg == 0 ? a + b : a - b
+205 next 10 70 160
+; buf_a := a
+210 next 10 80 50
+; buf_b := b
+220 next 10 90 60
+; cfg := cfg
+221 next 10 95 95
+;
+; SPEC
+; buf_a + buf_b
+230 add 10 80 90
+;;;;;
+240 neq 20 70 230
+250 bad 240

--- a/samples/k-induction/cnt-3bits-wrap-safe-kind-bound0.btor2
+++ b/samples/k-induction/cnt-3bits-wrap-safe-kind-bound0.btor2
@@ -1,0 +1,16 @@
+10 sort bitvec 3
+11 sort bitvec 1
+21 zero 10
+25 one 10
+30 state 10 cnt
+40 init 10 30 21
+45 constd 10 3
+50 eq 11 30 45
+55 add 10 30 25
+; cnt == 3 ? 0 : cnt + 1 
+60 ite 10 50 21 55
+70 next 10 30 60
+; bad state property
+80 constd 10 4
+90 eq 11 30 80
+100 bad 90

--- a/samples/k-induction/cnt-3bits-wrap-safe-kind-bound1.btor2
+++ b/samples/k-induction/cnt-3bits-wrap-safe-kind-bound1.btor2
@@ -1,0 +1,16 @@
+10 sort bitvec 3
+11 sort bitvec 1
+21 zero 10
+25 one 10
+30 state 10 cnt
+40 init 10 30 21
+45 constd 10 3
+50 eq 11 30 45
+55 add 10 30 25
+; cnt == 3 ? 0 : cnt + 1 
+60 ite 10 50 21 55
+70 next 10 30 60
+; bad state property
+80 constd 10 4
+90 ugt 11 30 80
+100 bad 90


### PR DESCRIPTION
This PR adds several options to modify the behavior of BMC. By default, the transition system is unrolled step by step to explore all possible bounds to find a counterexample, starting from zero. This leads to as many solver calls as there are bounds to be checked.

To reduce the number of solver calls and (optionally) skip over certain bounds, the options added in this PR allow to configure BMC to explore intervals of bounds. If a counterexample is found within a given interval, then either binary search or linear search is applied to the interval to find the precise bound of the counterexample.

Optionally, completeness of BMC to find counterexamples can be switched off to potentially speed up a BMC run by never checking certain bounds.