### PR TITLE
Fix: CI flow on MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
           brew install \
             gmp
 
-      - name: Python Dependencies
+      # install previous version of setuptools as temporary fix
+      # see also recommendations here: https://github.com/pypa/setuptools/issues/3227
+      - name: Python Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: python3 -m pip install 'setuptools<61'
+
+      - name: Python Dependencies (all)
         run: python3 -m pip install Cython pytest toml
 
       - name: Download MathSAT


### PR DESCRIPTION
Fixing the CI flow on MacOS, where installation of Python bindings failed due to an updated version of setuptools.

As a _temporary_ fix, we install setuptools version 60.

See also the discussion here, which inspired this fix: https://github.com/pypa/setuptools/issues/3227