### PR TITLE
BMC option: allow non-minimal cex

### DIFF
--- a/engines/bmc.cpp
+++ b/engines/bmc.cpp
@@ -125,6 +125,15 @@ bool Bmc::step(int i)
   if (r.is_sat()) {
     logger.log(1, "  BMC: check at bound {} satisfiable", i);
     res = false;
+    if (options_.bmc_allow_non_minimal_cex_) {
+      // Terminate immediately; the reported bound 'reached_k' of the
+      // cex is an upper bound of the actual cex within the interval
+      // that was tested most recently. Option
+      // 'options_.bmc_allow_non_minimal_cex' makes sense only if
+      // 'options.bmc_bound_step > 1'.
+      reached_k_ = i - 1;
+      return res;
+    }
     if (cex_guarantee) {
       logger.log(2, "BMC: saving reached_k_ = {}", reached_k_);
       int reached_k_saved = reached_k_;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -81,7 +81,8 @@ enum optionIndex
   BMC_NEG_BAD_STEP,
   BMC_MIN_CEX_LIN_SEARCH,
   BMC_MIN_CEX_LESS_INC_BIN_SEARCH,
-  BMC_NEG_BAD_STEP_ALL
+  BMC_NEG_BAD_STEP_ALL,
+  BMC_ALLOW_NON_MINIMAL_CEX
 };
 
 struct Arg : public option::Arg
@@ -504,7 +505,14 @@ const option::Descriptor usage[] = {
     "  --bmc-min-cex-less-inc-bin-search \tApply less incremental variant of binary search for "
                         "minimal cex after a cex was found in current interval"
     },
-
+  { BMC_ALLOW_NON_MINIMAL_CEX,
+    0,
+    "",
+    "bmc-allow-non-minimal-cex",
+    Arg::None,
+    "  --bmc-allow-non-minimal-cex \tDo not search for minimal cex within an interval;"
+    "instead, terminate immediately (reported bound of cex is an upper bound of actual cex)"
+    },
   
   { 0, 0, 0, 0, 0, 0 }
 };
@@ -681,6 +689,8 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_MIN_CEX_LIN_SEARCH: bmc_min_cex_linear_search_ = true; break;
         case BMC_MIN_CEX_LESS_INC_BIN_SEARCH:
 	  bmc_min_cex_less_inc_bin_search_ = true; break;
+        case BMC_ALLOW_NON_MINIMAL_CEX:
+	  bmc_allow_non_minimal_cex_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -140,7 +140,8 @@ class PonoOptions
         bmc_neg_bad_step_(default_bmc_neg_bad_step_),
         bmc_neg_bad_step_all_(default_bmc_neg_bad_step_all_),
         bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_),
-        bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_)
+        bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_),
+        bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_)
   {
   }
 
@@ -256,6 +257,11 @@ class PonoOptions
   bool bmc_min_cex_linear_search_;
   // BMC: apply less incremental binary search
   bool bmc_min_cex_less_inc_bin_search_;
+  // BMC: when using disjunctive bad state property, skip the
+  // minimization phase after an interval containing a cex was found,
+  // i.e., skip binary or linear search for shortest cex in that
+  // interval
+  bool bmc_allow_non_minimal_cex_;
   
 private:
   // Default options
@@ -315,6 +321,7 @@ private:
   static const bool default_bmc_neg_bad_step_all_ = false;
   static const bool default_bmc_min_cex_linear_search_ = false;
   static const bool default_bmc_min_cex_less_inc_bin_search_ = false;
+  static const bool default_bmc_allow_non_minimal_cex_ = false;
 };
 
 // Useful functions for printing etc...


### PR DESCRIPTION
Add option `--bmc-allow-non-minimal-cex` to BMC to skip the search for the minimal counterexample within an interval. This is relevant only when option `--bmc-single-bad-state` is not given and when combined with option `--bmc-bound step n` where `n` is greater than 1, i.e., searching for a cex in intervals of `n` steps. By default, BMC runs with `n == 1`.

Witnesses (traces) for the counterexamples that are found by running BMC with `--bmc-allow-non-minimal-cex` are not necessarily minimal in length. However, unlike option `--bmc-single-bad-state`, option `--bmc-allow-non-minimal-cex` still guarantees that a (non-minimal) counterexample is found if one exists and sufficient computational resources are provided.

The rationale for not returning a minimal-length counterexample is that it might be faster to find such counterexample because fewer solver calls are required. 
