### PR TITLE
K-induction refactoring

### DIFF
--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -28,6 +28,9 @@ BmcSimplePath::BmcSimplePath(const Property & p, const TransitionSystem & ts,
   : super(p, ts, solver, opt)
 {
   engine_ = Engine::BMC_SP;
+  // BMC with simple path checking is a special instance of
+  // k-induction; disable inductive case checking
+  options_.kind_no_ind_check_ = true;
 }
 
 BmcSimplePath::~BmcSimplePath() {}
@@ -35,41 +38,7 @@ BmcSimplePath::~BmcSimplePath() {}
 ProverResult BmcSimplePath::check_until(int k)
 {
   initialize();
-
-  for (int i = 0; i <= k; ++i) {
-    logger.log(1, "Checking Bmc at bound: {}", i);
-    if (!base_step(i)) {
-      compute_witness();
-      return ProverResult::FALSE;
-    }
-    logger.log(1, "Checking simple path at bound: {}", i);
-    if (cover_step(i)) {
-      return ProverResult::TRUE;
-    }
-  }
-  return ProverResult::UNKNOWN;
-}
-
-bool BmcSimplePath::cover_step(int i)
-{
-  if (i <= reached_k_) {
-    return false;
-  }
-
-  solver_->push();
-  solver_->assert_formula(init0_);
-  Term not_init = solver_->make_term(PrimOp::Not, ts_.init());
-  for (int j = 1; j <= i; ++j) {
-    solver_->assert_formula(unroller_.at_time(not_init, j));
-  }
-  if (ts_.statevars().size() && check_simple_path_lazy(i)) {
-    return true;
-  }
-  solver_->pop();
-
-  ++reached_k_;
-
-  return false;
+  super::check_until(k);
 }
 
 }  // namespace pono

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -28,6 +28,7 @@ BmcSimplePath::BmcSimplePath(const Property & p, const TransitionSystem & ts,
   : super(p, ts, solver, opt)
 {
   engine_ = Engine::BMC_SP;
+  kind_engine_name_ = "BMC-SP";
   // BMC with simple path checking is a special instance of
   // k-induction; disable inductive case checking
   options_.kind_no_ind_check_ = true;

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -39,7 +39,7 @@ BmcSimplePath::~BmcSimplePath() {}
 ProverResult BmcSimplePath::check_until(int k)
 {
   initialize();
-  super::check_until(k);
+  return super::check_until(k);
 }
 
 }  // namespace pono

--- a/engines/bmc_simplepath.cpp
+++ b/engines/bmc_simplepath.cpp
@@ -29,9 +29,14 @@ BmcSimplePath::BmcSimplePath(const Property & p, const TransitionSystem & ts,
 {
   engine_ = Engine::BMC_SP;
   kind_engine_name_ = "BMC-SP";
+
+  // Options that affect k-induction also have an effect on BMC-SP
+
   // BMC with simple path checking is a special instance of
-  // k-induction; disable inductive case checking
-  options_.kind_no_ind_check_ = true;
+  // k-induction; disable inductive case checking based on property;
+  // inductive case based on initial states is still checked as in
+  // previous implementation of BMC-SP
+  options_.kind_no_ind_check_property_ = true;
 }
 
 BmcSimplePath::~BmcSimplePath() {}

--- a/engines/bmc_simplepath.h
+++ b/engines/bmc_simplepath.h
@@ -33,9 +33,6 @@ class BmcSimplePath : public KInduction
 
   ProverResult check_until(int k) override;
 
- protected:
-  bool cover_step(int i);
-
 };  // BmcSimplePath
 
 }  // namespace pono

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -57,29 +57,30 @@ ProverResult KInduction::check_until(int k)
   Result res;
   for (int i = reached_k_ + 1; i <= k; ++i) {
 
-    solver_->push();
-
-    // inductive case check
-    if (!options_.kind_no_simple_path_check_)
-      solver_->assert_formula(simple_path_);
-    solver_->assert_formula(unroller_.at_time(bad_, i));
-    logger.log(1, "Checking k-induction inductive step at bound: {}", i);
-    // solver call inside 'check_simple_path_lazy/eager'
-    if (!options_.kind_eager_simple_path_check_) {
-      if (ts_.statevars().size() && check_simple_path_lazy(i)) {
-	return ProverResult::TRUE;
-      }
-    } else {
-      if (ts_.statevars().size() && check_simple_path_eager(i)) {
-	return ProverResult::TRUE;
+    // simple path check
+    if (!options_.kind_no_simple_path_check_) {
+      //OBSOLETE  solver_->assert_formula(simple_path_);
+      // solver call inside 'check_simple_path_lazy/eager'
+      if (!options_.kind_eager_simple_path_check_) {
+	if (ts_.statevars().size() && check_simple_path_lazy(i)) {
+	  return ProverResult::TRUE;
+	}
+      } else {
+	if (ts_.statevars().size() && check_simple_path_eager(i)) {
+	  return ProverResult::TRUE;
+	}
       }
     }
 
-//DELETE THIS
-//    res = solver_->check_sat();
-//    if (res.is_unsat()) {
-//      return ProverResult::TRUE;
-//    }
+    solver_->push();
+
+    // inductive case check
+    solver_->assert_formula(unroller_.at_time(bad_, i));
+    logger.log(1, "Checking k-induction inductive step at bound: {}", i);
+    res = solver_->check_sat();
+    if (res.is_unsat()) {
+      return ProverResult::TRUE;
+    }
 
     // base case check
     solver_->assert_formula(init0_);
@@ -197,8 +198,8 @@ bool KInduction::check_simple_path_eager(int i)
   for (int j = 0; (!no_simp_path_check && j < i); j++) {
     Term constraint = simple_path_constraint(j, i);
     logger.log(3, "   Adding simple path clause for pair 'j,i' = {},{}", j,i);
-    simple_path_ =
-      solver_->make_term(PrimOp::And, simple_path_, constraint);
+    //OBSOLETE simple_path_ =
+    //  solver_->make_term(PrimOp::And, simple_path_, constraint);
     solver_->assert_formula(constraint);
   }
 
@@ -248,8 +249,8 @@ bool KInduction::check_simple_path_lazy(int i)
 	logger.log(3, "    Checking constraint for pair j,l = {} , {}", j,l);
         if (solver_->get_value(constraint) == false_) {
 	  logger.log(3, "      Adding constraint for pair j,l = {} , {}", j,l);
-          simple_path_ =
-              solver_->make_term(PrimOp::And, simple_path_, constraint);
+          //OBSOLETE simple_path_ =
+          //OBSOLETE    solver_->make_term(PrimOp::And, simple_path_, constraint);
           added_to_simple_path = true;
           if (!no_multi_call) {
             solver_->assert_formula(constraint);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -77,7 +77,7 @@ ProverResult KInduction::check_until(int k)
 
     solver_->push();
 
-    if (i >= 1 && options_.kind_ind_check_init_states_ &&
+    if (i >= 1 && !options_.kind_no_ind_check_init_states_ &&
        !options_.kind_no_ind_check_) {
       // inductive case check based on initial state predicates like in
       // Sheeran et al 2003: assert that s_0 is an initial state and no
@@ -106,7 +106,7 @@ ProverResult KInduction::check_until(int k)
 
     // inductive case check
     if (!options_.kind_no_ind_check_) {
-      kind_log_msg(1, "", "checking inductive step at bound: {}", i);
+      kind_log_msg(1, "", "checking inductive step (property) at bound: {}", i);
       res = solver_->check_sat();
       if (res.is_unsat()) {
 	return ProverResult::TRUE;

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -136,56 +136,6 @@ ProverResult KInduction::check_until(int k)
   return ProverResult::UNKNOWN;
 }
 
-bool KInduction::base_step(int i)
-{
-  //TODO function deprecated
-  abort();
-
-  if (i <= reached_k_) {
-    return true;
-  }
-
-  solver_->push();
-  solver_->assert_formula(init0_);
-  solver_->assert_formula(unroller_.at_time(bad_, i));
-  Result r = solver_->check_sat();
-  if (r.is_sat()) {
-    return false;
-  }
-  solver_->pop();
-
-  const Term &prop = solver_->make_term(Not, bad_);
-  solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
-  solver_->assert_formula(unroller_.at_time(prop, i));
-
-  return true;
-}
-
-bool KInduction::inductive_step(int i)
-{
-  //TODO function deprecated
-  abort();
-
-  if (i <= reached_k_) {
-    return false;
-  }
-
-  solver_->push();
-  if (!options_.kind_no_simple_path_check_)
-    solver_->assert_formula(simple_path_);
-  solver_->assert_formula(unroller_.at_time(bad_, i + 1));
-
-  if (ts_.statevars().size() && check_simple_path_lazy(i + 1)) {
-    return true;
-  }
-
-  solver_->pop();
-
-  ++reached_k_;
-
-  return false;
-}
-
 Term KInduction::simple_path_constraint(int i, int j)
 {
   assert(!options_.kind_no_simple_path_check_);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -47,13 +47,12 @@ void KInduction::initialize()
   // supported in boolector
   init0_ = unroller_.at_time(ts_.init(), 0);
   false_ = solver_->make_term(false);
-  neg_init_terms_ = solver_->make_term(true);
 
   // selector literal to toggle initial state predicate
   Sort boolsort = solver_->make_sort(smt::BOOL);
   sel_init_ = solver_->make_symbol("sel_init", boolsort);
   not_sel_init_ = solver_->make_term(Not, sel_init_);
-  //permanently add term '(sel_init0_ OR init0_)'
+  // permanently add term '(sel_init0_ OR init0_)'
   solver_->assert_formula(solver_->make_term(PrimOp::Or, sel_init_, init0_));
 
   // add second selector literal to toggle conjunction of negated
@@ -73,7 +72,7 @@ ProverResult KInduction::check_until(int k)
     logger.log(1, "");
     kind_log_msg(1, "", "current unrolling depth/bound: {}", i);
 
-    //disable initial state predicate and its negated instances
+    // disable initial state predicate and its negated instances
     while (!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(sel_init_);
@@ -100,21 +99,15 @@ ProverResult KInduction::check_until(int k)
       // other state s_1,...,s_{i} is an initial state + simple path
       // constraints.
 
-      //enable initial state predicate and its negated instances
+      // enable initial state predicate and its negated instances
       while(!sel_assumption_.empty())
         sel_assumption_.pop_back();
       sel_assumption_.push_back(not_sel_init_);
       sel_assumption_.push_back(not_sel_neg_init_terms_);
 
-      // OBSOLETE COMMENT --- NOTE: we do this check in a new push/pop frame, which does not
-      // benefit from incrementality. At least, we should build a
-      // conjunction of initial state constraints that is added back and
-      // where we append a new conjunct for each time step.
-      // OBSOLETE ---solver_->push();
       smt::Term neg_init_at_i = unroller_.at_time(
 	solver_->make_term(Not, ts_.init()), i);
       smt::Term clause = solver_->make_term(PrimOp::Or, sel_neg_init_terms_, neg_init_at_i);
-      //OBSOLETE      neg_init_terms_ = solver_->make_term(And, neg_init_terms_, neg_init_at_i);
       //permanently add term '(sel_neg_init_terms_ OR neg_init_at_i)'
       solver_->assert_formula(clause);
       kind_log_msg(1, "", "checking inductive step (initial states) at bound: {}", i);
@@ -122,10 +115,9 @@ ProverResult KInduction::check_until(int k)
       if (res.is_unsat()) {
 	return ProverResult::TRUE;
       }
-      //OBSOLETE ---solver_->pop();
     }
 
-    //disable initial state predicate and its negated instances
+    // disable initial state predicate and its negated instances
     while (!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(sel_init_);
@@ -148,7 +140,7 @@ ProverResult KInduction::check_until(int k)
 
     // base case check
 
-    //enable initial state predicate but NOT its negated instances
+    // enable initial state predicate but NOT its negated instances
     while(!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(not_sel_init_);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -66,6 +66,10 @@ ProverResult KInduction::check_until(int k)
   initialize();
   assert(reached_k_ == -1);
 
+  assert(!options_.kind_no_ind_check_ ||
+	 (options_.kind_no_ind_check_init_states_ &&
+	  options_.kind_no_ind_check_property_));
+
   Result res;
   for (int i = reached_k_ + 1; i <= k; ++i) {
 
@@ -92,8 +96,7 @@ ProverResult KInduction::check_until(int k)
       }
     }
 
-    if (i >= 1 && !options_.kind_no_ind_check_init_states_ &&
-       !options_.kind_no_ind_check_) {
+    if (i >= 1 && !options_.kind_no_ind_check_init_states_) {
       // inductive case check based on initial state predicates like in
       // Sheeran et al 2003: assert that s_0 is an initial state and no
       // other state s_1,...,s_{i} is an initial state + simple path
@@ -130,7 +133,7 @@ ProverResult KInduction::check_until(int k)
     solver_->assert_formula(unroller_.at_time(bad_, i));
 
     // inductive case check
-    if (!options_.kind_no_ind_check_) {
+    if (!options_.kind_no_ind_check_property_) {
       kind_log_msg(1, "", "checking inductive step (property) at bound: {}", i);
       res = solver_->check_sat_assuming(sel_assumption_);
       if (res.is_unsat()) {

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -47,7 +47,6 @@ void KInduction::initialize()
   // supported in boolector
   init0_ = unroller_.at_time(ts_.init(), 0);
   false_ = solver_->make_term(false);
-  simple_path_ = solver_->make_term(true);
   neg_init_terms_ = solver_->make_term(true);
 }
 
@@ -64,7 +63,6 @@ ProverResult KInduction::check_until(int k)
 
     // simple path check
     if (!options_.kind_no_simple_path_check_) {
-      //OBSOLETE  solver_->assert_formula(simple_path_);
       // solver call inside 'check_simple_path_lazy/eager'
       if (!options_.kind_eager_simple_path_check_) {
 	if (ts_.statevars().size() && check_simple_path_lazy(i)) {
@@ -166,8 +164,6 @@ bool KInduction::check_simple_path_eager(int i)
   for (int j = 0; (!no_simp_path_check && j < i); j++) {
     Term constraint = simple_path_constraint(j, i);
     kind_log_msg(3, "   ", "adding simple path clause for pair 'j,i' = {},{}", j,i);
-    //OBSOLETE simple_path_ =
-    //  solver_->make_term(PrimOp::And, simple_path_, constraint);
     solver_->assert_formula(constraint);
   }
 
@@ -217,8 +213,6 @@ bool KInduction::check_simple_path_lazy(int i)
 	kind_log_msg(3, "    ", "checking constraint for pair j,l = {} , {}", j,l);
         if (solver_->get_value(constraint) == false_) {
 	  kind_log_msg(3, "      ", "adding constraint for pair j,l = {} , {}", j,l);
-          //OBSOLETE simple_path_ =
-          //OBSOLETE    solver_->make_term(PrimOp::And, simple_path_, constraint);
           added_to_simple_path = true;
           if (!no_multi_call) {
             solver_->assert_formula(constraint);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -125,6 +125,10 @@ ProverResult KInduction::check_until(int k)
     solver_->pop();
 
     // add transition and negated bad state property
+    // it is sound to add the negated bad state property for use in
+    // next base case checks and inductive case checks (initial
+    // states) because we proved in base check that it is implied when
+    // assuming initial state predicate
     solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
     solver_->assert_formula(unroller_.at_time(solver_->make_term(Not, bad_), i));
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -52,8 +52,41 @@ void KInduction::initialize()
 ProverResult KInduction::check_until(int k)
 {
   initialize();
+  assert(reached_k_ == -1);
 
+  Result res;
   for (int i = reached_k_ + 1; i <= k; ++i) {
+
+    solver_->push();
+
+    // inductive case check
+    //TBA ADD SIMPLE PATH CHECK
+    solver_->assert_formula(unroller_.at_time(bad_, i));
+    logger.log(1, "Checking k-induction inductive step at bound: {}", i);
+    res = solver_->check_sat();
+    if (res.is_unsat()) {
+      return ProverResult::TRUE;
+    }
+
+    // base case check
+    solver_->assert_formula(init0_);
+    logger.log(1, "Checking k-induction base case at bound: {}", i);
+    res = solver_->check_sat();
+    if (res.is_sat()) {
+      compute_witness();
+      return ProverResult::FALSE;
+    }
+
+    solver_->pop();
+
+    // add transition and negated bad state property
+    solver_->assert_formula(unroller_.at_time(ts_.trans(), i));
+    solver_->assert_formula(unroller_.at_time(solver_->make_term(Not, bad_), i));
+
+    reached_k_++;
+    
+#if 0    
+    ///////////////////////////////////
     logger.log(1, "Checking k-induction base case at bound: {}", i);
     if (!base_step(i)) {
       compute_witness();
@@ -63,12 +96,19 @@ ProverResult KInduction::check_until(int k)
     if (inductive_step(i)) {
       return ProverResult::TRUE;
     }
-  }
+    /////////////////////////////////// 
+ #endif
+    
+  } //end: for all bounds
+  
   return ProverResult::UNKNOWN;
 }
 
 bool KInduction::base_step(int i)
 {
+  //TODO function deprecated
+  abort();
+
   if (i <= reached_k_) {
     return true;
   }
@@ -91,6 +131,9 @@ bool KInduction::base_step(int i)
 
 bool KInduction::inductive_step(int i)
 {
+  //TODO function deprecated
+  abort();
+
   if (i <= reached_k_) {
     return false;
   }

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -96,7 +96,8 @@ bool KInduction::inductive_step(int i)
   }
 
   solver_->push();
-  solver_->assert_formula(simple_path_);
+  if (!options_.kind_no_simple_path_check_)
+    solver_->assert_formula(simple_path_);
   solver_->assert_formula(unroller_.at_time(bad_, i + 1));
 
   if (ts_.statevars().size() && check_simple_path_lazy(i + 1)) {
@@ -112,6 +113,7 @@ bool KInduction::inductive_step(int i)
 
 Term KInduction::simple_path_constraint(int i, int j)
 {
+  assert(!options_.kind_no_simple_path_check_);
   assert(ts_.statevars().size());
 
   Term disj = false_;
@@ -135,6 +137,12 @@ bool KInduction::check_simple_path_lazy(int i)
     if (r.is_unsat()) {
       return true;
     }
+
+    // We need the above check_sat call if simple path checks are
+    // disabled because it is part of the inductive step check. Hence
+    // we return immediately here and skip simple path checking.
+    if (options_.kind_no_simple_path_check_)
+      return false;
 
     added_to_simple_path = false;
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -75,7 +75,8 @@ ProverResult KInduction::check_until(int k)
 
     solver_->push();
 
-    if (i >= 1 && options_.kind_ind_check_init_states_) {
+    if (i >= 1 && options_.kind_ind_check_init_states_ &&
+       !options_.kind_no_ind_check_) {
       // inductive case check based on initial state predicates like in
       // Sheeran et al 2003: assert that s_0 is an initial state and no
       // other state s_1,...,s_{i} is an initial state + simple path
@@ -98,12 +99,16 @@ ProverResult KInduction::check_until(int k)
       solver_->pop();
     }
 
-    // inductive case check
+    // for inductive case and base case: add bad state predicate
     solver_->assert_formula(unroller_.at_time(bad_, i));
-    logger.log(1, "Checking k-induction inductive step at bound: {}", i);
-    res = solver_->check_sat();
-    if (res.is_unsat()) {
-      return ProverResult::TRUE;
+
+    // inductive case check
+    if (!options_.kind_no_ind_check_) {
+      logger.log(1, "Checking k-induction inductive step at bound: {}", i);
+      res = solver_->check_sat();
+      if (res.is_unsat()) {
+	return ProverResult::TRUE;
+      }
     }
 
     // base case check

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -180,11 +180,15 @@ Term KInduction::simple_path_constraint(int i, int j)
 
 bool KInduction::check_simple_path_lazy(int i)
 {
+
+  logger.log(2, "  Checking k-induction simple path at bound: {}", i);
   bool added_to_simple_path = false;
 
   do {
+    logger.log(2, "    Calling solver for simple path check");
     Result r = solver_->check_sat();
     if (r.is_unsat()) {
+      logger.log(2, "      Simple path check UNSAT");
       return true;
     }
 
@@ -199,8 +203,9 @@ bool KInduction::check_simple_path_lazy(int i)
     for (int j = 0; j < i && !added_to_simple_path; ++j) {
       for (int l = j + 1; l <= i; ++l) {
         Term constraint = simple_path_constraint(j, l);
+	logger.log(3, "    Checking constraint for pair j,l = {} , {}", j,l);
         if (solver_->get_value(constraint) == false_) {
-	  logger.log(2, "Adding Simple Path Clause");
+	  logger.log(3, "      Adding constraint for pair j,l = {} , {}", j,l);
           simple_path_ =
               solver_->make_term(PrimOp::And, simple_path_, constraint);
           solver_->assert_formula(constraint);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -60,13 +60,20 @@ ProverResult KInduction::check_until(int k)
     solver_->push();
 
     // inductive case check
-    //TBA ADD SIMPLE PATH CHECK
+    if (!options_.kind_no_simple_path_check_)
+      solver_->assert_formula(simple_path_);
     solver_->assert_formula(unroller_.at_time(bad_, i));
     logger.log(1, "Checking k-induction inductive step at bound: {}", i);
-    res = solver_->check_sat();
-    if (res.is_unsat()) {
+    // solver call inside 'check_simple_path_lazy'
+    if (ts_.statevars().size() && check_simple_path_lazy(i)) {
       return ProverResult::TRUE;
     }
+
+//DELETE THIS
+//    res = solver_->check_sat();
+//    if (res.is_unsat()) {
+//      return ProverResult::TRUE;
+//    }
 
     // base case check
     solver_->assert_formula(init0_);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -193,15 +193,19 @@ bool KInduction::check_simple_path_eager(int i)
 
   const bool no_simp_path_check = options_.kind_no_simple_path_check_;
 
-  //Here we assume that all pairs for values smaller than 'i' have been added
-  //If simple path checking is disabled then we still need the final
-  //solver call below for inductive case check
+  // Here we assume that all pairs for values smaller than 'i' have been added
+  // If simple path checking is disabled then we still need the final
+  // solver call below for inductive case check
   for (int j = 0; (!no_simp_path_check && j < i); j++) {
     Term constraint = simple_path_constraint(j, i);
     kind_log_msg(3, "   ", "adding simple path clause for pair 'j,i' = {},{}", j,i);
     solver_->assert_formula(constraint);
   }
 
+  // Note: the solver call here is actually not necessary since we add
+  // all possible constraints, and we add them permanently to the
+  // formula. For the lazy approach, we need to call the solver to be
+  // able to add constraints based on models produced by the solver.
   kind_log_msg(2, "    ", "calling solver for simple path check");
   Result r = solver_->check_sat_assuming(sel_assumption_);
   if (r.is_unsat()) {

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -48,12 +48,18 @@ void KInduction::initialize()
   init0_ = unroller_.at_time(ts_.init(), 0);
   false_ = solver_->make_term(false);
   neg_init_terms_ = solver_->make_term(true);
+
   // selector literal to toggle initial state predicate
   Sort boolsort = solver_->make_sort(smt::BOOL);
   sel_init_ = solver_->make_symbol("sel_init", boolsort);
   not_sel_init_ = solver_->make_term(Not, sel_init_);
   //permanently add term '(sel_init0_ OR init0_)'
   solver_->assert_formula(solver_->make_term(PrimOp::Or, sel_init_, init0_));
+
+  // add second selector literal to toggle conjunction of negated
+  // initial state terms
+  sel_neg_init_terms_ = solver_->make_symbol("sel_neg_init_terms_", boolsort);
+  not_sel_neg_init_terms_ = solver_->make_term(Not, sel_neg_init_terms_);
 }
 
 ProverResult KInduction::check_until(int k)
@@ -67,10 +73,11 @@ ProverResult KInduction::check_until(int k)
     logger.log(1, "");
     kind_log_msg(1, "", "current unrolling depth/bound: {}", i);
 
-    //disable initial state predicate
+    //disable initial state predicate and its negated instances
     while (!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(sel_init_);
+    sel_assumption_.push_back(sel_neg_init_terms_);
 
     // simple path check
     if (!options_.kind_no_simple_path_check_) {
@@ -93,32 +100,36 @@ ProverResult KInduction::check_until(int k)
       // other state s_1,...,s_{i} is an initial state + simple path
       // constraints.
 
-      //enable initial state predicate
+      //enable initial state predicate and its negated instances
       while(!sel_assumption_.empty())
         sel_assumption_.pop_back();
       sel_assumption_.push_back(not_sel_init_);
+      sel_assumption_.push_back(not_sel_neg_init_terms_);
 
-      // NOTE: we do this check in a new push/pop frame, which does not
+      // OBSOLETE COMMENT --- NOTE: we do this check in a new push/pop frame, which does not
       // benefit from incrementality. At least, we should build a
       // conjunction of initial state constraints that is added back and
       // where we append a new conjunct for each time step.
-      solver_->push();
+      // OBSOLETE ---solver_->push();
       smt::Term neg_init_at_i = unroller_.at_time(
 	solver_->make_term(Not, ts_.init()), i);
-      neg_init_terms_ = solver_->make_term(And, neg_init_terms_, neg_init_at_i);
-      solver_->assert_formula(neg_init_terms_);
+      smt::Term clause = solver_->make_term(PrimOp::Or, sel_neg_init_terms_, neg_init_at_i);
+      //OBSOLETE      neg_init_terms_ = solver_->make_term(And, neg_init_terms_, neg_init_at_i);
+      //permanently add term '(sel_neg_init_terms_ OR neg_init_at_i)'
+      solver_->assert_formula(clause);
       kind_log_msg(1, "", "checking inductive step (initial states) at bound: {}", i);
       res = solver_->check_sat_assuming(sel_assumption_);
       if (res.is_unsat()) {
 	return ProverResult::TRUE;
       }
-      solver_->pop();
+      //OBSOLETE ---solver_->pop();
     }
 
-    //disable initial state predicate
+    //disable initial state predicate and its negated instances
     while (!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(sel_init_);
+    sel_assumption_.push_back(sel_neg_init_terms_);
 
     // open new frame; this is to be able to remove bad state predicate added next
     solver_->push();
@@ -137,10 +148,11 @@ ProverResult KInduction::check_until(int k)
 
     // base case check
 
-    //enable initial state predicate
+    //enable initial state predicate but NOT its negated instances
     while(!sel_assumption_.empty())
       sel_assumption_.pop_back();
     sel_assumption_.push_back(not_sel_init_);
+    sel_assumption_.push_back(sel_neg_init_terms_);
 
     kind_log_msg(1, "", "checking base case at bound: {}", i);
     res = solver_->check_sat_assuming(sel_assumption_);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -188,7 +188,7 @@ Term KInduction::simple_path_constraint(int i, int j)
 bool KInduction::check_simple_path_eager(int i)
 {
   assert(options_.kind_eager_simple_path_check_);
-  logger.log(2, "  Eagerly checking k-induction simple path at bound: {}", i);
+  logger.log(1, "Eagerly checking k-induction simple path at bound: {}", i);
 
   const bool no_simp_path_check = options_.kind_no_simple_path_check_;
 
@@ -215,7 +215,7 @@ bool KInduction::check_simple_path_eager(int i)
 
 bool KInduction::check_simple_path_lazy(int i)
 {
-  logger.log(2, "  Lazily checking k-induction simple path at bound: {}", i);
+  logger.log(1, "Lazily checking k-induction simple path at bound: {}", i);
   bool added_to_simple_path = false;
 
   // If no_multi_call == true, then we add as many simple path

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -46,6 +46,7 @@ class KInduction : public Prover
   smt::Term init0_;
   smt::Term false_;
   smt::Term simple_path_;
+  smt::Term neg_init_terms_;
 
 };  // class KInduction
 

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -41,6 +41,7 @@ class KInduction : public Prover
 
   smt::Term simple_path_constraint(int i, int j);
   bool check_simple_path_lazy(int i);
+  bool check_simple_path_eager(int i);
 
   smt::Term init0_;
   smt::Term false_;

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -44,12 +44,15 @@ class KInduction : public Prover
   smt::Term false_;
   smt::Term neg_init_terms_;
 
-  // selector variable used to toggle addition of
+  // selector term used to toggle addition of
   // initial state predicate 'init0_'. We add a term '(sel_init_ OR init0_)'
   // and then assert either 'sel_init_' to effectively disable 'init0_' or
   // its negation 'not_sel_init_' to enable it.
   smt::Term sel_init_;
   smt::Term not_sel_init_;
+  // another selector term to toggle 'neg_init_terms_'
+  smt::Term sel_neg_init_terms_;
+  smt::Term not_sel_neg_init_terms_;
   // 'sel_assumption_' is passed to solver's 'check_sat_assuming(...)' function
   smt::TermVec sel_assumption_;
 

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -48,6 +48,16 @@ class KInduction : public Prover
   smt::Term simple_path_;
   smt::Term neg_init_terms_;
 
+  // Engine name used to print progress information used when running
+  // k-induction and BMC + simple paths (a subclass of KInduction)
+  std::string kind_engine_name_;
+  // Wrapper function for logging feature. It takes the same
+  // parameters as "logger.log(...)" except for string 'indent', which
+  // is a string of space characters. The function calls
+  // "logger.log(...)" and prepends the engine name to the output.
+  template <typename... Args>
+    void kind_log_msg(size_t level, const std::string & indent,
+		      const std::string & format, const Args &... args);
 };  // class KInduction
 
 }  // namespace pono

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -42,7 +42,6 @@ class KInduction : public Prover
 
   smt::Term init0_;
   smt::Term false_;
-  smt::Term neg_init_terms_;
 
   // selector term used to toggle addition of
   // initial state predicate 'init0_'. We add a term '(sel_init_ OR init0_)'
@@ -50,7 +49,7 @@ class KInduction : public Prover
   // its negation 'not_sel_init_' to enable it.
   smt::Term sel_init_;
   smt::Term not_sel_init_;
-  // another selector term to toggle 'neg_init_terms_'
+  // another selector term to toggle negated initial state terms
   smt::Term sel_neg_init_terms_;
   smt::Term not_sel_neg_init_terms_;
   // 'sel_assumption_' is passed to solver's 'check_sat_assuming(...)' function

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -44,6 +44,15 @@ class KInduction : public Prover
   smt::Term false_;
   smt::Term neg_init_terms_;
 
+  // selector variable used to toggle addition of
+  // initial state predicate 'init0_'. We add a term '(sel_init_ OR init0_)'
+  // and then assert either 'sel_init_' to effectively disable 'init0_' or
+  // its negation 'not_sel_init_' to enable it.
+  smt::Term sel_init_;
+  smt::Term not_sel_init_;
+  // 'sel_assumption_' is passed to solver's 'check_sat_assuming(...)' function
+  smt::TermVec sel_assumption_;
+
   // Engine name used to print progress information used when running
   // k-induction and BMC + simple paths (a subclass of KInduction)
   std::string kind_engine_name_;

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -36,9 +36,6 @@ class KInduction : public Prover
   ProverResult check_until(int k) override;
 
  protected:
-  bool base_step(int i);
-  bool inductive_step(int i);
-
   smt::Term simple_path_constraint(int i, int j);
   bool check_simple_path_lazy(int i);
   bool check_simple_path_eager(int i);

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -42,7 +42,6 @@ class KInduction : public Prover
 
   smt::Term init0_;
   smt::Term false_;
-  smt::Term simple_path_;
   smt::Term neg_init_terms_;
 
   // Engine name used to print progress information used when running

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -524,7 +524,7 @@ const option::Descriptor usage[] = {
     "kind-no-simple-path-check",
     Arg::None,
     "  --kind-no-simple-path-check \tSkip simple path check in k-induction "
-    "  (WARNING: might cause incompleteness)"
+    "(WARNING: might cause incompleteness)"
     },
   { KIND_EAGER_SIMPLE_PATH_CHECK,
     0,
@@ -532,7 +532,7 @@ const option::Descriptor usage[] = {
     "kind-eager-simple-path-check",
     Arg::None,
     "  --kind-eager-simple-path-check \tEager simple path check in k-induction "
-    "  (default: lazy check)"
+    "(default: lazy check)"
     },
   { KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
     0,
@@ -540,23 +540,23 @@ const option::Descriptor usage[] = {
     "kind-no-multi-call-simple-path-check",
     Arg::None,
     "  --kind-no-multi-call-simple-path-check \tTry to avoid multiple solver calls "
-    "    in lazy simple path check in k-induction"
+    "in lazy simple path check in k-induction"
     },
   { KIND_IND_CHECK_INIT_STATES,
     0,
     "",
     "kind-ind-check-init-states",
     Arg::None,
-    "  --kind-ind-check-init-states \tK-induction: check inductive case based"
-    "    on initial states in addition to property check"
+    "  --kind-ind-check-init-states \tK-induction: check inductive case based "
+    "on initial states in addition to property check"
     },
   { KIND_NO_IND_CHECK,
     0,
     "",
     "kind-no-ind-check",
     Arg::None,
-    "  --kind-no-ind-check \tK-induction: skip inductive case check"
-    " (WARNING: will cause incompleteness on most problem instances)"
+    "  --kind-no-ind-check \tK-induction: skip inductive case check "
+    "(WARNING: will cause incompleteness on most problem instances)"
     },
   { 0, 0, 0, 0, 0, 0 }
 };

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -82,7 +82,8 @@ enum optionIndex
   BMC_MIN_CEX_LIN_SEARCH,
   BMC_MIN_CEX_LESS_INC_BIN_SEARCH,
   BMC_NEG_BAD_STEP_ALL,
-  BMC_ALLOW_NON_MINIMAL_CEX
+  BMC_ALLOW_NON_MINIMAL_CEX,
+  KIND_NO_SIMPLE_PATH_CHECK
 };
 
 struct Arg : public option::Arg
@@ -513,7 +514,14 @@ const option::Descriptor usage[] = {
     "  --bmc-allow-non-minimal-cex \tDo not search for minimal cex within an interval;"
     "instead, terminate immediately (reported bound of cex is an upper bound of actual cex)"
     },
-  
+  { KIND_NO_SIMPLE_PATH_CHECK,
+    0,
+    "",
+    "kind-no-simple-path-check",
+    Arg::None,
+    "  --kind-no-simple-path-check \tSkip simple path check in k-induction "
+    "  (WARNING: might cause incompleteness)"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -691,6 +699,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  bmc_min_cex_less_inc_bin_search_ = true; break;
         case BMC_ALLOW_NON_MINIMAL_CEX:
 	  bmc_allow_non_minimal_cex_ = true; break;
+        case KIND_NO_SIMPLE_PATH_CHECK: kind_no_simple_path_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -83,7 +83,8 @@ enum optionIndex
   BMC_MIN_CEX_LESS_INC_BIN_SEARCH,
   BMC_NEG_BAD_STEP_ALL,
   BMC_ALLOW_NON_MINIMAL_CEX,
-  KIND_NO_SIMPLE_PATH_CHECK
+  KIND_NO_SIMPLE_PATH_CHECK,
+  KIND_EAGER_SIMPLE_PATH_CHECK
 };
 
 struct Arg : public option::Arg
@@ -522,6 +523,14 @@ const option::Descriptor usage[] = {
     "  --kind-no-simple-path-check \tSkip simple path check in k-induction "
     "  (WARNING: might cause incompleteness)"
     },
+  { KIND_EAGER_SIMPLE_PATH_CHECK,
+    0,
+    "",
+    "kind-eager-simple-path-check",
+    Arg::None,
+    "  --kind-eager-simple-path-check \tEager simple path check in k-induction "
+    "  (default: lazy check)"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -700,6 +709,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case BMC_ALLOW_NON_MINIMAL_CEX:
 	  bmc_allow_non_minimal_cex_ = true; break;
         case KIND_NO_SIMPLE_PATH_CHECK: kind_no_simple_path_check_ = true; break;
+        case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -86,7 +86,7 @@ enum optionIndex
   KIND_NO_SIMPLE_PATH_CHECK,
   KIND_EAGER_SIMPLE_PATH_CHECK,
   KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
-  KIND_IND_CHECK_INIT_STATES,
+  KIND_NO_IND_CHECK_INIT_STATES,
   KIND_NO_IND_CHECK
 };
 
@@ -542,13 +542,13 @@ const option::Descriptor usage[] = {
     "  --kind-no-multi-call-simple-path-check \tTry to avoid multiple solver calls "
     "in lazy simple path check in k-induction"
     },
-  { KIND_IND_CHECK_INIT_STATES,
+  { KIND_NO_IND_CHECK_INIT_STATES,
     0,
     "",
-    "kind-ind-check-init-states",
+    "kind-no-ind-check-init-states",
     Arg::None,
-    "  --kind-ind-check-init-states \tK-induction: check inductive case based "
-    "on initial states in addition to property check"
+    "  --kind-no-ind-check-init-states \tK-induction: skip checking inductive case based "
+    "on initial states"
     },
   { KIND_NO_IND_CHECK,
     0,
@@ -738,7 +738,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_NO_SIMPLE_PATH_CHECK: kind_no_simple_path_check_ = true; break;
         case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
         case KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK: kind_no_multi_call_simple_path_check_ = true; break;
-        case KIND_IND_CHECK_INIT_STATES: kind_ind_check_init_states_ = true; break;
+        case KIND_NO_IND_CHECK_INIT_STATES: kind_no_ind_check_init_states_ = true; break;
         case KIND_NO_IND_CHECK: kind_no_ind_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -85,7 +85,8 @@ enum optionIndex
   BMC_ALLOW_NON_MINIMAL_CEX,
   KIND_NO_SIMPLE_PATH_CHECK,
   KIND_EAGER_SIMPLE_PATH_CHECK,
-  KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK
+  KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
+  KIND_IND_CHECK_INIT_STATES
 };
 
 struct Arg : public option::Arg
@@ -540,6 +541,14 @@ const option::Descriptor usage[] = {
     "  --kind-no-multi-call-simple-path-check \tTry to avoid multiple solver calls "
     "    in lazy simple path check in k-induction"
     },
+  { KIND_IND_CHECK_INIT_STATES,
+    0,
+    "",
+    "kind-ind-check-init-states",
+    Arg::None,
+    "  --kind-ind-check-init-states \tK-induction: check inductive case based"
+    "    on initial states in addition to property check"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -720,6 +729,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_NO_SIMPLE_PATH_CHECK: kind_no_simple_path_check_ = true; break;
         case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
         case KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK: kind_no_multi_call_simple_path_check_ = true; break;
+        case KIND_IND_CHECK_INIT_STATES: kind_ind_check_init_states_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -86,7 +86,8 @@ enum optionIndex
   KIND_NO_SIMPLE_PATH_CHECK,
   KIND_EAGER_SIMPLE_PATH_CHECK,
   KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
-  KIND_IND_CHECK_INIT_STATES
+  KIND_IND_CHECK_INIT_STATES,
+  KIND_NO_IND_CHECK
 };
 
 struct Arg : public option::Arg
@@ -549,6 +550,14 @@ const option::Descriptor usage[] = {
     "  --kind-ind-check-init-states \tK-induction: check inductive case based"
     "    on initial states in addition to property check"
     },
+  { KIND_NO_IND_CHECK,
+    0,
+    "",
+    "kind-no-ind-check",
+    Arg::None,
+    "  --kind-no-ind-check \tK-induction: skip inductive case check"
+    " (WARNING: will cause incompleteness on most problem instances)"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -730,6 +739,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
         case KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK: kind_no_multi_call_simple_path_check_ = true; break;
         case KIND_IND_CHECK_INIT_STATES: kind_ind_check_init_states_ = true; break;
+        case KIND_NO_IND_CHECK: kind_no_ind_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -87,7 +87,8 @@ enum optionIndex
   KIND_EAGER_SIMPLE_PATH_CHECK,
   KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
   KIND_NO_IND_CHECK_INIT_STATES,
-  KIND_NO_IND_CHECK
+  KIND_NO_IND_CHECK,
+  KIND_NO_IND_CHECK_PROPERTY
 };
 
 struct Arg : public option::Arg
@@ -555,8 +556,17 @@ const option::Descriptor usage[] = {
     "",
     "kind-no-ind-check",
     Arg::None,
-    "  --kind-no-ind-check \tK-induction: skip inductive case check "
+    "  --kind-no-ind-check \tK-induction: skip inductive case checks; "
+    "implies '--kind-no-ind-check-init-states' and '--kind-no-ind-check-property' "
     "(WARNING: will cause incompleteness on most problem instances)"
+    },
+  { KIND_NO_IND_CHECK_PROPERTY,
+    0,
+    "",
+    "kind-no-ind-check-property",
+    Arg::None,
+    "  --kind-no-ind-check-property \tK-induction: skip checking inductive case based "
+    "on property (WARNING: will cause incompleteness on most problem instances)"
     },
   { 0, 0, 0, 0, 0, 0 }
 };
@@ -739,7 +749,9 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
         case KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK: kind_no_multi_call_simple_path_check_ = true; break;
         case KIND_NO_IND_CHECK_INIT_STATES: kind_no_ind_check_init_states_ = true; break;
-        case KIND_NO_IND_CHECK: kind_no_ind_check_ = true; break;
+        case KIND_NO_IND_CHECK: kind_no_ind_check_ = true;
+	  kind_no_ind_check_init_states_ = true; kind_no_ind_check_property_ = true; break;
+        case KIND_NO_IND_CHECK_PROPERTY: kind_no_ind_check_property_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -84,7 +84,8 @@ enum optionIndex
   BMC_NEG_BAD_STEP_ALL,
   BMC_ALLOW_NON_MINIMAL_CEX,
   KIND_NO_SIMPLE_PATH_CHECK,
-  KIND_EAGER_SIMPLE_PATH_CHECK
+  KIND_EAGER_SIMPLE_PATH_CHECK,
+  KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK
 };
 
 struct Arg : public option::Arg
@@ -531,6 +532,14 @@ const option::Descriptor usage[] = {
     "  --kind-eager-simple-path-check \tEager simple path check in k-induction "
     "  (default: lazy check)"
     },
+  { KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
+    0,
+    "",
+    "kind-no-multi-call-simple-path-check",
+    Arg::None,
+    "  --kind-no-multi-call-simple-path-check \tTry to avoid multiple solver calls "
+    "    in lazy simple path check in k-induction"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -710,6 +719,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  bmc_allow_non_minimal_cex_ = true; break;
         case KIND_NO_SIMPLE_PATH_CHECK: kind_no_simple_path_check_ = true; break;
         case KIND_EAGER_SIMPLE_PATH_CHECK: kind_eager_simple_path_check_ = true; break;
+        case KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK: kind_no_multi_call_simple_path_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -146,7 +146,8 @@ class PonoOptions
         kind_eager_simple_path_check_(default_kind_eager_simple_path_check_),
         kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_),
         kind_no_ind_check_init_states_(default_kind_no_ind_check_init_states_),
-        kind_no_ind_check_(default_kind_no_ind_check_)
+        kind_no_ind_check_(default_kind_no_ind_check_),
+        kind_no_ind_check_property_(default_kind_no_ind_check_property_)
   {
   }
 
@@ -276,8 +277,13 @@ class PonoOptions
   // K-induction: skip inductive case check based on initial states
   bool kind_no_ind_check_init_states_;
   // K-induction: skip inductive case check (EXPERT OPTION: will cause
-  // incompleteness for most problem instances)
+  // incompleteness for most problem instances); this option implies
+  // 'kind_no_ind_check_init_states_ == true' and
+  // 'kind_no_ind_check_property_ == true'
   bool kind_no_ind_check_;
+  // K-induction: skip inductive case check based on property (EXPERT
+  // OPTION: will cause incompleteness for most problem instances)
+  bool kind_no_ind_check_property_;
   
 private:
   // Default options
@@ -343,6 +349,7 @@ private:
   static const bool default_kind_no_multi_call_simple_path_check_ = false;
   static const bool default_kind_no_ind_check_init_states_ = false;
   static const bool default_kind_no_ind_check_ = false;
+  static const bool default_kind_no_ind_check_property_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -145,7 +145,7 @@ class PonoOptions
         kind_no_simple_path_check_(default_kind_no_simple_path_check_),
         kind_eager_simple_path_check_(default_kind_eager_simple_path_check_),
         kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_),
-        kind_ind_check_init_states_(default_kind_ind_check_init_states_),
+        kind_no_ind_check_init_states_(default_kind_no_ind_check_init_states_),
         kind_no_ind_check_(default_kind_no_ind_check_)
   {
   }
@@ -273,8 +273,8 @@ class PonoOptions
   bool kind_eager_simple_path_check_;
   // K-induction: no multi-call simple path check
   bool kind_no_multi_call_simple_path_check_;
-  // K-induction: check inductive case based on initial states also
-  bool kind_ind_check_init_states_;
+  // K-induction: skip inductive case check based on initial states
+  bool kind_no_ind_check_init_states_;
   // K-induction: skip inductive case check (EXPERT OPTION: will cause
   // incompleteness for most problem instances)
   bool kind_no_ind_check_;
@@ -341,7 +341,7 @@ private:
   static const bool default_kind_no_simple_path_check_ = false;
   static const bool default_kind_eager_simple_path_check_ = false;
   static const bool default_kind_no_multi_call_simple_path_check_ = false;
-  static const bool default_kind_ind_check_init_states_ = false;
+  static const bool default_kind_no_ind_check_init_states_ = false;
   static const bool default_kind_no_ind_check_ = false;
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -141,7 +141,8 @@ class PonoOptions
         bmc_neg_bad_step_all_(default_bmc_neg_bad_step_all_),
         bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_),
         bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_),
-        bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_)
+        bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_),
+        kind_no_simple_path_check_(default_kind_no_simple_path_check_)
   {
   }
 
@@ -262,6 +263,8 @@ class PonoOptions
   // i.e., skip binary or linear search for shortest cex in that
   // interval
   bool bmc_allow_non_minimal_cex_;
+  // K-induction: omit simple path check (might cause incompleteness)
+  bool kind_no_simple_path_check_;
   
 private:
   // Default options
@@ -322,6 +325,7 @@ private:
   static const bool default_bmc_min_cex_linear_search_ = false;
   static const bool default_bmc_min_cex_less_inc_bin_search_ = false;
   static const bool default_bmc_allow_non_minimal_cex_ = false;
+  static const bool default_kind_no_simple_path_check_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -144,7 +144,8 @@ class PonoOptions
         bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_),
         kind_no_simple_path_check_(default_kind_no_simple_path_check_),
         kind_eager_simple_path_check_(default_kind_eager_simple_path_check_),
-        kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_)
+        kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_),
+        kind_ind_check_init_states_(default_kind_ind_check_init_states_)
   {
   }
 
@@ -271,6 +272,8 @@ class PonoOptions
   bool kind_eager_simple_path_check_;
   // K-induction: no multi-call simple path check
   bool kind_no_multi_call_simple_path_check_;
+  // K-induction: check inductive case based on initial states also
+  bool kind_ind_check_init_states_;
   
 private:
   // Default options
@@ -334,6 +337,7 @@ private:
   static const bool default_kind_no_simple_path_check_ = false;
   static const bool default_kind_eager_simple_path_check_ = false;
   static const bool default_kind_no_multi_call_simple_path_check_ = false;
+  static const bool default_kind_ind_check_init_states_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -142,7 +142,8 @@ class PonoOptions
         bmc_min_cex_linear_search_(default_bmc_min_cex_linear_search_),
         bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_),
         bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_),
-        kind_no_simple_path_check_(default_kind_no_simple_path_check_)
+        kind_no_simple_path_check_(default_kind_no_simple_path_check_),
+        kind_eager_simple_path_check_(default_kind_eager_simple_path_check_)
   {
   }
 
@@ -265,6 +266,8 @@ class PonoOptions
   bool bmc_allow_non_minimal_cex_;
   // K-induction: omit simple path check (might cause incompleteness)
   bool kind_no_simple_path_check_;
+  // K-induction: eager simple path check (default: lazy check)
+  bool kind_eager_simple_path_check_;
   
 private:
   // Default options
@@ -326,6 +329,7 @@ private:
   static const bool default_bmc_min_cex_less_inc_bin_search_ = false;
   static const bool default_bmc_allow_non_minimal_cex_ = false;
   static const bool default_kind_no_simple_path_check_ = false;
+  static const bool default_kind_eager_simple_path_check_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -143,7 +143,8 @@ class PonoOptions
         bmc_min_cex_less_inc_bin_search_(default_bmc_min_cex_less_inc_bin_search_),
         bmc_allow_non_minimal_cex_(default_bmc_allow_non_minimal_cex_),
         kind_no_simple_path_check_(default_kind_no_simple_path_check_),
-        kind_eager_simple_path_check_(default_kind_eager_simple_path_check_)
+        kind_eager_simple_path_check_(default_kind_eager_simple_path_check_),
+        kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_)
   {
   }
 
@@ -268,6 +269,8 @@ class PonoOptions
   bool kind_no_simple_path_check_;
   // K-induction: eager simple path check (default: lazy check)
   bool kind_eager_simple_path_check_;
+  // K-induction: no multi-call simple path check
+  bool kind_no_multi_call_simple_path_check_;
   
 private:
   // Default options
@@ -330,6 +333,7 @@ private:
   static const bool default_bmc_allow_non_minimal_cex_ = false;
   static const bool default_kind_no_simple_path_check_ = false;
   static const bool default_kind_eager_simple_path_check_ = false;
+  static const bool default_kind_no_multi_call_simple_path_check_ = false;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -145,7 +145,8 @@ class PonoOptions
         kind_no_simple_path_check_(default_kind_no_simple_path_check_),
         kind_eager_simple_path_check_(default_kind_eager_simple_path_check_),
         kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_),
-        kind_ind_check_init_states_(default_kind_ind_check_init_states_)
+        kind_ind_check_init_states_(default_kind_ind_check_init_states_),
+        kind_no_ind_check_(default_kind_no_ind_check_)
   {
   }
 
@@ -274,6 +275,9 @@ class PonoOptions
   bool kind_no_multi_call_simple_path_check_;
   // K-induction: check inductive case based on initial states also
   bool kind_ind_check_init_states_;
+  // K-induction: skip inductive case check (EXPERT OPTION: will cause
+  // incompleteness for most problem instances)
+  bool kind_no_ind_check_;
   
 private:
   // Default options
@@ -338,6 +342,7 @@ private:
   static const bool default_kind_eager_simple_path_check_ = false;
   static const bool default_kind_no_multi_call_simple_path_check_ = false;
   static const bool default_kind_ind_check_init_states_ = false;
+  static const bool default_kind_no_ind_check_ = false;
 };
 
 // Useful functions for printing etc...

--- a/samples/k-induction/pono-test-case-simple-alu-no-state-init-enforce-equal.btor2
+++ b/samples/k-induction/pono-test-case-simple-alu-no-state-init-enforce-equal.btor2
@@ -1,0 +1,49 @@
+; states 'spec_res' and 'imp_res' are not initialized, which would
+; give a trivial counterexample.  To avoid this, we add an auxiliary
+; counter starting at zero; add constraint: if counter zero then
+; require that spec_res == imp_res
+10 sort bitvec 1
+20 sort bitvec 8
+21 zero 20
+22 zero 10
+25 one 20
+; state vars
+30 state 10 cfg
+40 state 20 spec_res
+50 state 20 imp_res
+; aux cnt initialized to zero
+55 state 20 cnt_aux
+56 init 20 55 21
+; input vars
+60 input 20 a
+70 input 20 b
+; logic for cfg, set to zero and keep it there
+90 init 10 30 22
+100 next 10 30 30
+; logic for results
+; init: spec_res == 0
+;;110 init 20 40 21
+; init: imp_res == 0
+;;120 init 20 50 21
+; add inputs 'a' and 'b'
+130 add 20 60 70
+; next(spec_res) = a + b
+140 next 20 40 130
+; a - b
+150 sub 20 60 70
+; cfg == 0
+160 eq 10 30 22
+170 ite 20 160 130 150
+; next(imp_res)
+180 next 20 50 170
+; property
+190 neq 10 40 50
+200 bad 190
+; aux cnt next function
+210 add 20 55 25
+220 next 20 55 210
+; constaint
+230 eq 10 40 50
+240 eq 10 55 21
+250 implies 10 240 230
+260 constraint 250

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -71,9 +71,12 @@ def test_kind(create_solver):
     prop, ts = build_simple_alu_fts(s)
 
     kind = pono.KInduction(prop, ts, s)
-    res = kind.check_until(10)
+    res = kind.check_until(1)
 
-    assert res is None, "KInduction shouldn't be able to solve this property"
+    # NOTE: k-induction uses a stronger termination criterion based on
+    # initial states by default (newly added), which allows it to prove the
+    # property with only one unrolling.
+    assert res is True, "KInduction should be able to solve this property"
 
 
 @pytest.mark.parametrize("solver_and_interpolator", available_solvers.solver_and_interpolators.values())

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -100,7 +100,7 @@ TEST_P(EngineUnitTests, KInductionTrue)
 {
   SmtSolver s = create_solver(se);
   KInduction kind(*true_p, *ts, s);
-  ProverResult r = kind.check_until(21);
+  ProverResult r = kind.check_until(20);
   ASSERT_EQ(r, ProverResult::TRUE);
 }
 
@@ -108,7 +108,7 @@ TEST_P(EngineUnitTests, KInductionFalse)
 {
   SmtSolver s = create_solver(se);
   KInduction kind(*false_p, *ts, s);
-  ProverResult r = kind.check_until(21);
+  ProverResult r = kind.check_until(20);
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
@@ -231,7 +231,7 @@ TEST_P(InterpWinTests, BmcSimplePathFail)
 TEST_P(InterpWinTests, KInductionFail)
 {
   KInduction kind(*true_p, *ts, s);
-  ProverResult r = kind.check_until(11);
+  ProverResult r = kind.check_until(10);
   ASSERT_EQ(r, ProverResult::UNKNOWN);
 }
 

--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -100,7 +100,7 @@ TEST_P(EngineUnitTests, KInductionTrue)
 {
   SmtSolver s = create_solver(se);
   KInduction kind(*true_p, *ts, s);
-  ProverResult r = kind.check_until(20);
+  ProverResult r = kind.check_until(21);
   ASSERT_EQ(r, ProverResult::TRUE);
 }
 
@@ -108,7 +108,7 @@ TEST_P(EngineUnitTests, KInductionFalse)
 {
   SmtSolver s = create_solver(se);
   KInduction kind(*false_p, *ts, s);
-  ProverResult r = kind.check_until(20);
+  ProverResult r = kind.check_until(21);
   ASSERT_EQ(r, ProverResult::FALSE);
 }
 
@@ -231,7 +231,7 @@ TEST_P(InterpWinTests, BmcSimplePathFail)
 TEST_P(InterpWinTests, KInductionFail)
 {
   KInduction kind(*true_p, *ts, s);
-  ProverResult r = kind.check_until(10);
+  ProverResult r = kind.check_until(11);
   ASSERT_EQ(r, ProverResult::UNKNOWN);
 }
 


### PR DESCRIPTION
Refactoring k-induction implementation:

- Changes inspired by "Niklas Eén, Niklas Sörensson.  Temporal induction by incremental SAT solving. 2003" and "Mary Sheeran, Satnam Singh, Gunnar Stålmarck. Checking Safety Properties Using Induction and a SAT-Solver. 2000"
- Potentially better incremental use of solver: do not use push/pop to add/remove the same constraints in multiple iterations. Instead, use selector terms of Sort Bool to toggle the addition/removal of these constraints via solving under assumptions.
-  Simple path constraints are permanently added to the formula and are effective in any checks (base case, inductive case).
- Additional termination condition for inductive case based on initial state predicate, cf. Sheeran et al., 2000.
- Options added to make implementation configurable. Current default options performed best in experiments.
- BMC+SimplePath class: avoid code duplication by calling "check_until()" from super class KInduction