### PR TITLE
Update to use cvc5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Python Dependencies (all)
         run: python3 -m pip install Cython pytest toml
 
+      - name: Python Dependencies (all)
+        run: python3 -m pip install scikit-build
+
       - name: Download MathSAT
         run: ./ci-scripts/setup-msat.sh --auto-yes
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,8 @@ if (NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-btor.a")
   message(FATAL_ERROR "Missing smt-switch boolector library -- try running ./contrib/setup-smt-switch.sh")
 endif()
 
-if (NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc4.a")
-  message(FATAL_ERROR "Missing smt-switch cvc4 library -- try running ./contrib/setup-smt-switch.sh --with-cvc4")
+if (NOT EXISTS "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc5.a")
+  message(FATAL_ERROR "Missing smt-switch cvc5 library -- try running ./contrib/setup-smt-switch.sh --with-cvc5")
 endif()
 
 if (WITH_MSAT)
@@ -223,7 +223,7 @@ if (BUILD_PYTHON_BINDINGS)
 endif()
 
 target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-btor.a")
-target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc4.a")
+target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-cvc5.a")
 
 if (WITH_MSAT)
   target_link_libraries(pono-lib PUBLIC "${SMT_SWITCH_DIR}/local/lib/libsmt-switch-msat.a")

--- a/configure.sh
+++ b/configure.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Syntax and structure borrowed from CVC4's configure.sh script
+# Syntax and structure borrowed from cvc5's configure.sh script
 
 CONF_FILE=Makefile.conf
 

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -59,9 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone https://github.com/makaimann/smt-switch
+    git clone -b cvc5-repack-libtool https://github.com/makaimann/smt-switch
     cd smt-switch
-    git checkout -f $SMT_SWITCH_VERSION
+    # git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc5_home = default ]; then
         ./contrib/setup-cvc5.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -66,9 +66,6 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     if [ $cvc5_home = default ]; then
         ./contrib/setup-cvc5.sh
     fi
-    if [ $WITH_PYTHON = YES ]; then
-        ./contrib/setup-skbuild.sh
-    fi
     # pass bison/flex directories from smt-switch perspective
     ./configure.sh --btor --cvc5 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=../bison/bison-install --flex-dir=../flex/flex-install
     cd build

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -59,9 +59,9 @@ mkdir -p $DEPS
 
 if [ ! -d "$DEPS/smt-switch" ]; then
     cd $DEPS
-    git clone -b cvc5-repack-libtool https://github.com/makaimann/smt-switch
+    git clone https://github.com/makaimann/smt-switch
     cd smt-switch
-    # git checkout -f $SMT_SWITCH_VERSION
+    git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
     if [ $cvc5_home = default ]; then
         ./contrib/setup-cvc5.sh

--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=e64c261faa826beb51f22ff6d5e74f581362ab47
+SMT_SWITCH_VERSION=499621b009ca0e86a65339aed59157bfaa874776
 
 usage () {
     cat <<EOF
@@ -13,7 +13,7 @@ Sets up the smt-switch API for interfacing with SMT solvers through a C++ API.
 
 -h, --help              display this message and exit
 --with-msat             include MathSAT which is under a custom non-BSD compliant license (default: off)
---cvc4-home             use an already downloaded version of CVC4
+--cvc5-home             use an already downloaded version of cvc5
 --python                build python bindings (default: off)
 EOF
     exit 0
@@ -27,7 +27,7 @@ die () {
 WITH_MSAT=default
 CONF_OPTS=""
 WITH_PYTHON=default
-cvc4_home=default
+cvc5_home=default
 
 while [ $# -gt 0 ]
 do
@@ -39,16 +39,16 @@ do
         --python)
             WITH_PYTHON=YES
             CONF_OPTS="$CONF_OPTS --python";;
-        --cvc4-home) die "missing argument to $1 (see -h)" ;;
-        --cvc4-home=*)
-            cvc4_home=${1##*=}
-            # Check if cvc4_home is an absolute path and if not, make it
+        --cvc5-home) die "missing argument to $1 (see -h)" ;;
+        --cvc5-home=*)
+            cvc5_home=${1##*=}
+            # Check if cvc5_home is an absolute path and if not, make it
             # absolute.
-            case $cvc4_home in
+            case $cvc5_home in
                 /*) ;;                            # absolute path
-                *) cvc4_home=$(pwd)/$cvc4_home ;; # make absolute path
+                *) cvc5_home=$(pwd)/$cvc5_home ;; # make absolute path
             esac
-            CONF_OPTS="$CONF_OPTS --cvc4-home=$cvc4_home"
+            CONF_OPTS="$CONF_OPTS --cvc5-home=$cvc5_home"
             ;;
         *) die "unexpected argument: $1";;
     esac
@@ -63,14 +63,14 @@ if [ ! -d "$DEPS/smt-switch" ]; then
     cd smt-switch
     git checkout -f $SMT_SWITCH_VERSION
     ./contrib/setup-btor.sh
-    if [ $cvc4_home = default ]; then
-        ./contrib/setup-cvc4.sh
+    if [ $cvc5_home = default ]; then
+        ./contrib/setup-cvc5.sh
     fi
     if [ $WITH_PYTHON = YES ]; then
         ./contrib/setup-skbuild.sh
     fi
     # pass bison/flex directories from smt-switch perspective
-    ./configure.sh --btor --cvc4 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=../bison/bison-install --flex-dir=../flex/flex-install
+    ./configure.sh --btor --cvc5 $CONF_OPTS --prefix=local --static --smtlib-reader --bison-dir=../bison/bison-install --flex-dir=../flex/flex-install
     cd build
     make -j$(nproc)
     # TODO put this back
@@ -83,7 +83,7 @@ else
 fi
 
 if [ 0 -lt $(ls $DEPS/smt-switch/local/lib/libsmt-switch* 2>/dev/null | wc -w) ]; then
-    echo "It appears smt-switch with boolector and CVC4 was successfully installed to $DEPS/smt-switch/local."
+    echo "It appears smt-switch with boolector and cvc5 was successfully installed to $DEPS/smt-switch/local."
     echo "You may now build pono with: ./configure.sh && cd build && make"
 else
     echo "Building smt-switch failed."

--- a/core/ts.h
+++ b/core/ts.h
@@ -19,9 +19,8 @@
 #include <string>
 #include <unordered_map>
 
-#include "smt-switch/cvc4_factory.h"
+#include "smt-switch/cvc5_factory.h"
 #include "smt-switch/smt.h"
-
 #include "utils/exceptions.h"
 
 namespace pono {
@@ -29,12 +28,12 @@ namespace pono {
 class TransitionSystem
 {
  public:
-  /** use CVC4 by default (doesn't require logging so pass false)
+  /** use cvc5 by default (doesn't require logging so pass false)
    *  it supports the most theories and doesn't rewrite-on-the-fly or alias
    * sorts
    *  this makes it a great candidate for representing the TransitionSystem */
   TransitionSystem()
-      : solver_(smt::CVC4SolverFactory::create(false)),
+      : solver_(smt::Cvc5SolverFactory::create(false)),
         init_(solver_->make_term(true)),
         trans_(solver_->make_term(true)),
         functional_(false),

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -174,7 +174,7 @@ const option::Descriptor usage[] = {
     "",
     "smt-solver",
     Arg::NonEmpty,
-    "  --smt-solver \tSMT Solver to use: btor, msat, or cvc4." },
+    "  --smt-solver \tSMT Solver to use: btor, msat, or cvc5." },
   { LOGGING_SMT_SOLVER,
     0,
     "",
@@ -654,7 +654,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case SMT_SOLVER: {
           if (opt.arg == std::string("btor")) {
             smt_solver_ = smt::BTOR;
-          } else if (opt.arg == std::string("cvc4")) {
+          } else if (opt.arg == std::string("cvc5")) {
             smt_solver_ = smt::CVC5;
           } else if (opt.arg == std::string("msat")) {
             smt_solver_ = smt::MSAT;

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -655,7 +655,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           if (opt.arg == std::string("btor")) {
             smt_solver_ = smt::BTOR;
           } else if (opt.arg == std::string("cvc4")) {
-            smt_solver_ = smt::CVC4;
+            smt_solver_ = smt::CVC5;
           } else if (opt.arg == std::string("msat")) {
             smt_solver_ = smt::MSAT;
           } else {
@@ -769,10 +769,10 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
           "Counterexample-guided prophecy only supported with MathSAT so far");
     }
 
-    if (smt_solver_ == smt::CVC4
+    if (smt_solver_ == smt::CVC5
         && ic3_variants().find(engine_) != ic3_variants().end()) {
       throw PonoException(
-          "CVC4 cannot handle multiple solver instances, and thus does not "
+          "cvc5 cannot handle multiple solver instances, and thus does not "
           "currently support IC3 variants.");
     }
   }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,9 +1,3 @@
-# relying on cmake files from scikit-build in smt-switch deps
-if (NOT EXISTS "${SMT_SWITCH_DIR}/deps/scikit-build/skbuild/resources/cmake")
-  message(FATAL_ERROR "Missing CMake files in smt-switch. Remember to set it up with --python")
-else()
-  list(APPEND CMAKE_MODULE_PATH ${SMT_SWITCH_DIR}/deps/scikit-build/skbuild/resources/cmake)
-endif()
 
 if(POLICY CMP0057)
   # For cmake >= 3.3 this policy changed the behavior of IN_LIST
@@ -42,6 +36,65 @@ else()
 endif()
 
 include_directories("${PROJECT_SOURCE_DIR}/deps/smt-switch/python/smt_switch")
+
+# Everything from here up to line 'include(FindPythonExtensions)' is copied
+# from smt-switch python/CMakefile:
+#   https://github.com/stanford-centaur/smt-switch/blob/499621b009ca0e86a65339aed59157bfaa874776/python/CMakeLists.txt
+# Note: using same pattern used in cvc5 for scikit-build / python module checking
+# Check if given Python module is installed and raises a FATAL_ERROR error
+# if the module cannot be found.
+function(check_python_module module)
+  execute_process(
+    COMMAND
+    ${PYTHON_EXECUTABLE} -c "import ${module}"
+    RESULT_VARIABLE
+      RET_MODULE_TEST
+    ERROR_QUIET
+  )
+  set(module_name ${ARGN})
+  if(NOT module_name)
+    set(module_name ${module})
+  endif()
+
+  if(RET_MODULE_TEST)
+    message(FATAL_ERROR
+        "Could not find module ${module_name} for Python "
+        "version ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}. "
+        "Make sure to install ${module_name} for this Python version "
+        "via \n`${PYTHON_EXECUTABLE} -m pip install ${module_name}'.\n"
+        "Note: You need to have pip installed for this Python version.")
+  endif()
+endfunction()
+
+
+# Check that scikit-build is installed
+# Provides CMake files for Python bindings
+# and used to find correct Python includes
+# and libraries
+check_python_module("skbuild" "scikit-build")
+
+# Find cmake modules distributed with scikit-build
+# They are distributed under <scikit-build directory>/resources/cmake
+execute_process(
+  COMMAND
+    ${PYTHON_EXECUTABLE} -c "from __future__ import print_function; \
+      import os; import skbuild; \
+      cmake_module_path=os.path.join(os.path.dirname(skbuild.__file__), \
+        'resources', 'cmake'); print(cmake_module_path, end='')"
+  OUTPUT_VARIABLE
+    SKBUILD_CMAKE_MODULE_PATH
+  RESULT_VARIABLE
+    RET_SKBUILD_CMAKE_MODULE_PATH
+)
+
+if (NOT EXISTS ${SKBUILD_CMAKE_MODULE_PATH})
+  message(FATAL_ERROR "Expected CMake module path from
+                       scikit-build at ${SKBUILD_CMAKE_MODULE_PATH}")
+endif()
+
+# Add scikit-build cmake files to cmake module path
+# Required for Cython target below
+list(APPEND CMAKE_MODULE_PATH ${SKBUILD_CMAKE_MODULE_PATH})
 
 include(FindPythonExtensions)
 

--- a/smt/available_solvers.cpp
+++ b/smt/available_solvers.cpp
@@ -24,7 +24,7 @@
 
 // these two always included
 #include "smt-switch/boolector_factory.h"
-#include "smt-switch/cvc4_factory.h"
+#include "smt-switch/cvc5_factory.h"
 
 #if WITH_MSAT
 #include "smt-switch/msat_factory.h"
@@ -47,7 +47,7 @@ namespace pono {
 
 // list of regular (non-interpolator) solver enums
 const std::vector<SolverEnum> solver_enums({
-  BTOR, CVC4,
+  BTOR, CVC5,
 
 #if WITH_MSAT
       MSAT,
@@ -68,8 +68,8 @@ SmtSolver create_solver_base(SolverEnum se, bool logging)
       s = BoolectorSolverFactory::create(logging);
       break;
     }
-    case CVC4: {
-      s = CVC4SolverFactory::create(logging);
+    case CVC5: {
+      s = Cvc5SolverFactory::create(logging);
       break;
     }
 #if WITH_MSAT

--- a/tests/encoders/test_btor2_ts_copy_equal.cpp
+++ b/tests/encoders/test_btor2_ts_copy_equal.cpp
@@ -183,13 +183,13 @@ TEST_P(CopyUnitTests, CopyToDefault)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverCopyUnitTests,
     CopyUnitTests,
-    // TEMP excluding CVC4 because these tests use two solvers
+    // TEMP excluding cvc5 because these tests use two solvers
     // (default and created one)
-    // and this causes strange behavior for CVC4 until its fixed
+    // and this causes strange behavior for cvc5 until its fixed
     // (note: updated to cvc5 now)
     // see https://github.com/cvc5/cvc5/issues/5893
     testing::Combine(
-        testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })),
+        testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })),
         // from test_encoder_inputs.h
         testing::ValuesIn(btor2_inputs)));
 

--- a/tests/encoders/test_btor2_ts_copy_equal.cpp
+++ b/tests/encoders/test_btor2_ts_copy_equal.cpp
@@ -183,13 +183,8 @@ TEST_P(CopyUnitTests, CopyToDefault)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverCopyUnitTests,
     CopyUnitTests,
-    // TEMP excluding cvc5 because these tests use two solvers
-    // (default and created one)
-    // and this causes strange behavior for cvc5 until its fixed
-    // (note: updated to cvc5 now)
-    // see https://github.com/cvc5/cvc5/issues/5893
     testing::Combine(
-        testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })),
+        testing::ValuesIn(available_solver_enums()),
         // from test_encoder_inputs.h
         testing::ValuesIn(btor2_inputs)));
 

--- a/tests/test_ic3.cpp
+++ b/tests/test_ic3.cpp
@@ -79,9 +79,5 @@ TEST_P(IC3UnitTests, SimpleSystemUnsafe)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3UnitTests,
     IC3UnitTests,
-    // TEMP excluding cvc5 because IC3 variants use two solvers
-    // and this causes strange behavior for cvc5 until its fixed
-    // (note: updated to cvc5 now)
-    // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
+    testing::ValuesIn(available_solver_enums()));
 }  // namespace pono_tests

--- a/tests/test_ic3.cpp
+++ b/tests/test_ic3.cpp
@@ -79,9 +79,9 @@ TEST_P(IC3UnitTests, SimpleSystemUnsafe)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3UnitTests,
     IC3UnitTests,
-    // TEMP excluding CVC4 because IC3 variants use two solvers
-    // and this causes strange behavior for CVC4 until its fixed
+    // TEMP excluding cvc5 because IC3 variants use two solvers
+    // and this causes strange behavior for cvc5 until its fixed
     // (note: updated to cvc5 now)
     // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
 }  // namespace pono_tests

--- a/tests/test_ic3bits.cpp
+++ b/tests/test_ic3bits.cpp
@@ -65,10 +65,6 @@ TEST_P(IC3BitsUnitTests, CounterSystemSafe)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3BitsUnitTests,
     IC3BitsUnitTests,
-    // TEMP excluding cvc5 because IC3 variants use two solvers
-    // and this causes strange behavior for cvc5 until its fixed
-    // (note: updated to cvc5 now)
-    // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
+    testing::ValuesIn(available_solver_enums()));
 
 }  // namespace pono_tests

--- a/tests/test_ic3bits.cpp
+++ b/tests/test_ic3bits.cpp
@@ -65,10 +65,10 @@ TEST_P(IC3BitsUnitTests, CounterSystemSafe)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3BitsUnitTests,
     IC3BitsUnitTests,
-    // TEMP excluding CVC4 because IC3 variants use two solvers
-    // and this causes strange behavior for CVC4 until its fixed
+    // TEMP excluding cvc5 because IC3 variants use two solvers
+    // and this causes strange behavior for cvc5 until its fixed
     // (note: updated to cvc5 now)
     // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
 
 }  // namespace pono_tests

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -136,10 +136,6 @@ TEST_P(IC3SAUnitTests, SimpleCounterVar)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3SAUnitTests,
     IC3SAUnitTests,
-    // TEMP excluding cvc5 because IC3 variants use two solvers
-    // and this causes strange behavior for cvc5 until its fixed
-    // (note: updated to cvc5 now)
-    // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
+    testing::ValuesIn(available_solver_enums()));
 
 }  // namespace pono_tests

--- a/tests/test_ic3sa.cpp
+++ b/tests/test_ic3sa.cpp
@@ -136,10 +136,10 @@ TEST_P(IC3SAUnitTests, SimpleCounterVar)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedSolverIC3SAUnitTests,
     IC3SAUnitTests,
-    // TEMP excluding CVC4 because IC3 variants use two solvers
-    // and this causes strange behavior for CVC4 until its fixed
+    // TEMP excluding cvc5 because IC3 variants use two solvers
+    // and this causes strange behavior for cvc5 until its fixed
     // (note: updated to cvc5 now)
     // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
 
 }  // namespace pono_tests

--- a/tests/test_uf.cpp
+++ b/tests/test_uf.cpp
@@ -87,14 +87,6 @@ TEST_P(UFUnitTests, FalseProp)
     return;
   }
 
-  // TODO: update this when the bug is fixed
-  if (s->get_solver_enum() == CVC5) {
-    std::cout << "Warning: not running with cvc5 because it segfaults "
-              << "in the TsatProof part of its modded minisat for "
-              << "an unknown reason." << std::endl;
-    return;
-  }
-
   RelationalTransitionSystem rts(s);
   Term x = rts.make_statevar("x", bvsort);
   Term f = s->make_symbol("f", funsort);

--- a/tests/test_uf.cpp
+++ b/tests/test_uf.cpp
@@ -88,8 +88,8 @@ TEST_P(UFUnitTests, FalseProp)
   }
 
   // TODO: update this when the bug is fixed
-  if (s->get_solver_enum() == CVC4) {
-    std::cout << "Warning: not running with CVC4 because it segfaults "
+  if (s->get_solver_enum() == CVC5) {
+    std::cout << "Warning: not running with cvc5 because it segfaults "
               << "in the TsatProof part of its modded minisat for "
               << "an unknown reason." << std::endl;
     return;

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -139,14 +139,6 @@ TEST_P(UtilsEngineUnitTests, MakeProver)
     return;
   }
 
-  // TEMP excluding cvc5 because IC3 variants use two solvers
-  // and this causes strange behavior for cvc5 until its fixed
-  // (note: updated to cvc5 now)
-  // see https://github.com/cvc5/cvc5/issues/5893
-  if (se == smt::CVC5) {
-    return;
-  }
-
   SmtSolver s = create_solver(se);
   s->set_opt("produce-unsat-assumptions", "true");
   std::shared_ptr<Prover> prover = make_prover(eng, prop, fts, s);

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -139,11 +139,11 @@ TEST_P(UtilsEngineUnitTests, MakeProver)
     return;
   }
 
-  // TEMP excluding CVC4 because IC3 variants use two solvers
-  // and this causes strange behavior for CVC4 until its fixed
+  // TEMP excluding cvc5 because IC3 variants use two solvers
+  // and this causes strange behavior for cvc5 until its fixed
   // (note: updated to cvc5 now)
   // see https://github.com/cvc5/cvc5/issues/5893
-  if (se == smt::CVC4) {
+  if (se == smt::CVC5) {
     return;
   }
 

--- a/tests/test_witness.cpp
+++ b/tests/test_witness.cpp
@@ -92,11 +92,6 @@ TEST_P(WitnessUnitTests, ArraysDefaultSolver)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedWitnessUnitTests,
     WitnessUnitTests,
-    // TEMP excluding cvc5 because these tests use two solvers
-    // (default and created one)
-    // and this causes strange behavior for cvc5 until its fixed
-    // (note: updated to cvc5 now)
-    // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
+    testing::ValuesIn(available_solver_enums()));
 
 }  // namespace pono_tests

--- a/tests/test_witness.cpp
+++ b/tests/test_witness.cpp
@@ -92,11 +92,11 @@ TEST_P(WitnessUnitTests, ArraysDefaultSolver)
 INSTANTIATE_TEST_SUITE_P(
     ParameterizedWitnessUnitTests,
     WitnessUnitTests,
-    // TEMP excluding CVC4 because these tests use two solvers
+    // TEMP excluding cvc5 because these tests use two solvers
     // (default and created one)
-    // and this causes strange behavior for CVC4 until its fixed
+    // and this causes strange behavior for cvc5 until its fixed
     // (note: updated to cvc5 now)
     // see https://github.com/cvc5/cvc5/issues/5893
-    testing::ValuesIn(available_solver_enums_except({ smt::CVC4 })));
+    testing::ValuesIn(available_solver_enums_except({ smt::CVC5 })));
 
 }  // namespace pono_tests


### PR DESCRIPTION
- Update to use latest version of smt-switch as of 2022-10-04 (https://github.com/stanford-centaur/smt-switch ; `499621b009ca0e86a65339aed59157bfaa874776`). It comes with cvc5, hence we switch from CVC4 to cvc5 on the Pono end.
- Waiting for completion of final tests