### PR TITLE
Allow using cvc5 in IC3 variants

### DIFF
--- a/options/options.cpp
+++ b/options/options.cpp
@@ -768,13 +768,6 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
       throw PonoException(
           "Counterexample-guided prophecy only supported with MathSAT so far");
     }
-
-    if (smt_solver_ == smt::CVC5
-        && ic3_variants().find(engine_) != ic3_variants().end()) {
-      throw PonoException(
-          "cvc5 cannot handle multiple solver instances, and thus does not "
-          "currently support IC3 variants.");
-    }
   }
   catch (PonoException & ce) {
     cout << ce.what() << endl;


### PR DESCRIPTION
This PR removes the restriction that the IC3 engines could only be used with either MathSAT or Boolector, but not with CVC4. There were issues with creating multiple instances of CVC4, which is required in IC3 (https://github.com/upscale-project/pono/blob/841c86c37c4fa967e1b2558cc266e7fa79fa5f4b/options/options.cpp#L772-L778). Hence the use of CVC4 in IC3 was disallowed. Since the update of Pono to use cvc5 instead of CVC4 (https://github.com/upscale-project/pono/pull/307), this restriction is no longer needed.