### PR TITLE
K-induction: one-time base case check and interval unrolling

### DIFF
--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -91,8 +91,8 @@ ProverResult KInduction::check_until(int k)
   // will be checked in the final, a posteriori base case check to
   // make sure no counterexamples are missed;
   // This restriction means that we only support interval unrolling combined with base case skipping
-  if (bound_step_ != 1 && !options_.kind_no_base_check_)
-    throw PonoException("Temporary restriction: must disable base checks when using 'bound_step != 1'");
+  if (bound_step_ != 1 && !options_.kind_one_time_base_check_)
+    throw PonoException("Temporary restriction: must enable one-time base checks when using 'bound_step != 1'");
   
   Result res;
   for (int i = reached_k_ + 1; i <= k; i += bound_step_) {
@@ -152,7 +152,7 @@ ProverResult KInduction::check_until(int k)
       kind_log_msg(1, "", "checking inductive step (initial states) at bound: {}", i);
       res = solver_->check_sat_assuming(sel_assumption_);
       if (res.is_unsat()) {
-	if (options_.kind_no_base_check_) {
+	if (options_.kind_one_time_base_check_) {
 	  if (final_base_case_check(i))
 	    return ProverResult::TRUE;
 	  else
@@ -177,7 +177,7 @@ ProverResult KInduction::check_until(int k)
 
     // for inductive case and base case: add bad state predicate
     if (!options_.kind_no_ind_check_ || !options_.kind_no_ind_check_property_ ||
-	!options_.kind_no_base_check_)
+	!options_.kind_one_time_base_check_)
       solver_->assert_formula(unroller_.at_time(bad_, i));
 
     // inductive case check
@@ -185,7 +185,7 @@ ProverResult KInduction::check_until(int k)
       kind_log_msg(1, "", "checking inductive step (property) at bound: {}", i);
       res = solver_->check_sat_assuming(sel_assumption_);
       if (res.is_unsat()) {
-	if (options_.kind_no_base_check_) {
+	if (options_.kind_one_time_base_check_) {
 	  // remove bad state at current time 'i'
 	  solver_->pop();
 	  if (final_base_case_check(i))
@@ -210,7 +210,7 @@ ProverResult KInduction::check_until(int k)
     sel_assumption_.push_back(not_sel_neg_bad_state_terms_);
     sel_assumption_.push_back(not_sel_simple_path_terms_);
 
-    if (!options_.kind_no_base_check_) {
+    if (!options_.kind_one_time_base_check_) {
       kind_log_msg(1, "", "checking base case at bound: {}", i);
       res = solver_->check_sat_assuming(sel_assumption_);
       if (res.is_sat()) {
@@ -358,7 +358,7 @@ void KInduction::kind_log_msg(size_t level, const std::string & indent,
 
 bool
 KInduction::final_base_case_check(int cur_bound) {
-  assert(options_.kind_no_base_check_);
+  assert(options_.kind_one_time_base_check_);
   // enable initial state predicate but NOT its negated instances
   // disable negated bad state terms
   // DISABLE simple path --- TODO/CHECK: could keep it if UNSAT

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -113,14 +113,16 @@ ProverResult KInduction::check_until(int k)
     // simple path check
     if (!options_.kind_no_simple_path_check_) {
       // solver call inside 'check_simple_path_lazy/eager'
-      if (!options_.kind_eager_simple_path_check_) {
-	if (ts_.statevars().size() && check_simple_path_lazy(i)) {
+      if (ts_.statevars().size() &&
+	  ((!options_.kind_eager_simple_path_check_ && check_simple_path_lazy(i)) ||
+	   (options_.kind_eager_simple_path_check_ && check_simple_path_eager(i)))) {
+	if (options_.kind_one_time_base_check_) {
+	  if (final_base_case_check(i))
+	    return ProverResult::TRUE;
+	  else
+	    return ProverResult::FALSE;
+	} else
 	  return ProverResult::TRUE;
-	}
-      } else {
-	if (ts_.statevars().size() && check_simple_path_eager(i)) {
-	  return ProverResult::TRUE;
-	}
       }
     }
 

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -79,7 +79,7 @@ ProverResult KInduction::check_until(int k)
 	  options_.kind_no_ind_check_property_));
 
   // number of steps by which current bound is increased; default bound_step_ == 1
-  const int bound_step_ = 4;
+  const int bound_step_ = options_.kind_bound_step_;
 
   if (bound_step_ != 1 && options_.kind_eager_simple_path_check_)
     throw PonoException("Temporary restriction: must combine eager simple "\
@@ -141,7 +141,7 @@ ProverResult KInduction::check_until(int k)
       sel_assumption_.push_back(not_sel_simple_path_terms_);
 
       for (int j = reached_k_ + 1; j <= i; j++) {
-	kind_log_msg(1, "  ", "DEBUG: ind init states, j = {}", j);
+	// TODO REMOVE: kind_log_msg(1, "  ", "DEBUG: ind init states, j = {}", j);
 	smt::Term neg_init_at_j = unroller_.at_time(
 	  solver_->make_term(Not, ts_.init()), j);
 	smt::Term clause = solver_->make_term(PrimOp::Or, sel_neg_init_terms_, neg_init_at_j);
@@ -222,14 +222,14 @@ ProverResult KInduction::check_until(int k)
     solver_->pop();
 
     for (int j = i; j < i + bound_step_; j++) {
-      kind_log_msg(1, "  ", "DEBUG adding transitions, j = {}", j);
+      // TODO REMOVE: kind_log_msg(1, "  ", "DEBUG adding transitions, j = {}", j);
       // add transition and negated bad state property
       // it is sound to add the negated bad state property for use in
       // next base case checks and inductive case checks (initial
       // states) because we proved in base check that it is implied when
       // assuming initial state predicate
       solver_->assert_formula(unroller_.at_time(ts_.trans(), j));
-      kind_log_msg(1, "  ", "DEBUG adding negated bad state terms, j = {}", j);
+      // TODO REMOVE: kind_log_msg(1, "  ", "DEBUG adding negated bad state terms, j = {}", j);
       // add negated bad state term using selector term as part of disjunction
       Term disj = solver_->make_term(PrimOp::Or, sel_neg_bad_state_terms_,
 				     unroller_.at_time(solver_->make_term(Not, bad_), j));

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -221,7 +221,7 @@ ProverResult KInduction::check_until(int k)
 
     solver_->pop();
 
-    for (int j = reached_k_ + 1; j <= i; j++) {
+    for (int j = i; j < i + bound_step_; j++) {
       kind_log_msg(1, "  ", "DEBUG adding transitions, j = {}", j);
       // add transition and negated bad state property
       // it is sound to add the negated bad state property for use in
@@ -229,6 +229,7 @@ ProverResult KInduction::check_until(int k)
       // states) because we proved in base check that it is implied when
       // assuming initial state predicate
       solver_->assert_formula(unroller_.at_time(ts_.trans(), j));
+      kind_log_msg(1, "  ", "DEBUG adding negated bad state terms, j = {}", j);
       // add negated bad state term using selector term as part of disjunction
       Term disj = solver_->make_term(PrimOp::Or, sel_neg_bad_state_terms_,
 				     unroller_.at_time(solver_->make_term(Not, bad_), j));

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -48,13 +48,6 @@ void KInduction::initialize()
   init0_ = unroller_.at_time(ts_.init(), 0);
   false_ = solver_->make_term(false);
 
-  // Note on selector literals: as a potential optimization, we could enforce the
-  // values of selector literals permanently by adding unit clauses rather than
-  // setting the literal via assumptions. E.g., in the default configuration of
-  // k-induction, most constraints like negated bad state terms and simple path
-  // constraints are added permanently and are never removed. So the value of their
-  // respective selective literal is never flipped and can be set permanently.
-
   // selector literal to toggle initial state predicate
   Sort boolsort = solver_->make_sort(smt::BOOL);
   sel_init_ = solver_->make_symbol("sel_init", boolsort);
@@ -74,6 +67,19 @@ void KInduction::initialize()
   // add selector term to toggle simple path constraints
   sel_simple_path_terms_ = solver_->make_symbol("sel_simple_path_terms_", boolsort);
   not_sel_simple_path_terms_ = solver_->make_term(Not, sel_simple_path_terms_);
+
+  // Note on selector literals: as a potential optimization, we could enforce the
+  // values of selector literals permanently by adding unit clauses rather than
+  // setting the literal via assumptions. E.g., in the default configuration of
+  // k-induction, most constraints like negated bad state terms and simple path
+  // constraints are added permanently and are never removed. So the value of their
+  // respective selective literal is never flipped and can be set permanently.
+  // E.g., this can be done as follows:
+  //
+  // if (!options_.kind_one_time_base_check_) {
+  //   solver_->assert_formula(not_sel_simple_path_terms_);
+  //   solver_->assert_formula(not_sel_neg_bad_state_terms_);
+  // }
 }
 
 ProverResult KInduction::check_until(int k)

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -48,6 +48,13 @@ void KInduction::initialize()
   init0_ = unroller_.at_time(ts_.init(), 0);
   false_ = solver_->make_term(false);
 
+  // Note on selector literals: as a potential optimization, we could enforce the
+  // values of selector literals permanently by adding unit clauses rather than
+  // setting the literal via assumptions. E.g., in the default configuration of
+  // k-induction, most constraints like negated bad state terms and simple path
+  // constraints are added permanently and are never removed. So the value of their
+  // respective selective literal is never flipped and can be set permanently.
+
   // selector literal to toggle initial state predicate
   Sort boolsort = solver_->make_sort(smt::BOOL);
   sel_init_ = solver_->make_symbol("sel_init", boolsort);

--- a/engines/kinduction.cpp
+++ b/engines/kinduction.cpp
@@ -130,7 +130,9 @@ ProverResult KInduction::check_until(int k)
     solver_->push();
 
     // for inductive case and base case: add bad state predicate
-    solver_->assert_formula(unroller_.at_time(bad_, i));
+    if (!options_.kind_no_ind_check_ || !options_.kind_no_ind_check_property_ ||
+	!options_.kind_no_base_check_)
+      solver_->assert_formula(unroller_.at_time(bad_, i));
 
     // inductive case check
     if (!options_.kind_no_ind_check_property_) {
@@ -149,11 +151,13 @@ ProverResult KInduction::check_until(int k)
     sel_assumption_.push_back(not_sel_init_);
     sel_assumption_.push_back(sel_neg_init_terms_);
 
-    kind_log_msg(1, "", "checking base case at bound: {}", i);
-    res = solver_->check_sat_assuming(sel_assumption_);
-    if (res.is_sat()) {
-      compute_witness();
-      return ProverResult::FALSE;
+    if (!options_.kind_no_base_check_) {
+      kind_log_msg(1, "", "checking base case at bound: {}", i);
+      res = solver_->check_sat_assuming(sel_assumption_);
+      if (res.is_sat()) {
+	compute_witness();
+	return ProverResult::FALSE;
+      }
     }
 
     solver_->pop();

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -55,6 +55,9 @@ class KInduction : public Prover
   // selector term to toggle negated bad state constraints
   smt::Term sel_neg_bad_state_terms_;
   smt::Term not_sel_neg_bad_state_terms_;
+  // selector term to toggle simple path constraints
+  smt::Term sel_simple_path_terms_;
+  smt::Term not_sel_simple_path_terms_;
   // 'sel_assumption_' is passed to solver's 'check_sat_assuming(...)' function
   smt::TermVec sel_assumption_;
 

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -71,6 +71,10 @@ class KInduction : public Prover
   template <typename... Args>
     void kind_log_msg(size_t level, const std::string & indent,
 		      const std::string & format, const Args &... args);
+  // If base case checking is skipped: run one final base check
+  // covering all bounds from 0 to current one to make sure that no
+  // counterexamples were missed
+  bool final_base_case_check(int cur_bound);
 };  // class KInduction
 
 }  // namespace pono

--- a/engines/kinduction.h
+++ b/engines/kinduction.h
@@ -52,6 +52,9 @@ class KInduction : public Prover
   // another selector term to toggle negated initial state terms
   smt::Term sel_neg_init_terms_;
   smt::Term not_sel_neg_init_terms_;
+  // selector term to toggle negated bad state constraints
+  smt::Term sel_neg_bad_state_terms_;
+  smt::Term not_sel_neg_bad_state_terms_;
   // 'sel_assumption_' is passed to solver's 'check_sat_assuming(...)' function
   smt::TermVec sel_assumption_;
 

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -89,7 +89,7 @@ enum optionIndex
   KIND_NO_IND_CHECK_INIT_STATES,
   KIND_NO_IND_CHECK,
   KIND_NO_IND_CHECK_PROPERTY,
-  KIND_NO_BASE_CHECK,
+  KIND_ONE_TIME_BASE_CHECK,
   KIND_BOUND_STEP
 };
 
@@ -570,13 +570,13 @@ const option::Descriptor usage[] = {
     "  --kind-no-ind-check-property \tK-induction: skip checking inductive case based "
     "on property (WARNING: will cause incompleteness on most problem instances)"
     },
-  { KIND_NO_BASE_CHECK,
+  { KIND_ONE_TIME_BASE_CHECK,
     0,
     "",
-    "kind-no-base-check",
+    "kind-one-time-base-check",
     Arg::None,
-    "  --kind-no-base-check \tK-induction: skip base case check "
-    "(EXPERIMENTAL OPTION: may cause unsoundness)"
+    "  --kind-one-time-base-check \tK-induction: check base case only once after"
+    " inductive check was unsatisfiable (WARNING: counterexamples might be missed)"
     },
   { KIND_BOUND_STEP,
     0,
@@ -770,7 +770,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_NO_IND_CHECK: kind_no_ind_check_ = true;
 	  kind_no_ind_check_init_states_ = true; kind_no_ind_check_property_ = true; break;
         case KIND_NO_IND_CHECK_PROPERTY: kind_no_ind_check_property_ = true; break;
-        case KIND_NO_BASE_CHECK: kind_no_base_check_ = true; break;
+        case KIND_ONE_TIME_BASE_CHECK: kind_one_time_base_check_ = true; break;
         case KIND_BOUND_STEP: kind_bound_step_ = atoi(opt.arg);
 	  if (kind_bound_step_ == 0)
 	    throw PonoException("--kind-bound-step must be greater than 0");

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -88,7 +88,8 @@ enum optionIndex
   KIND_NO_MULTI_CALL_SIMPLE_PATH_CHECK,
   KIND_NO_IND_CHECK_INIT_STATES,
   KIND_NO_IND_CHECK,
-  KIND_NO_IND_CHECK_PROPERTY
+  KIND_NO_IND_CHECK_PROPERTY,
+  KIND_NO_BASE_CHECK
 };
 
 struct Arg : public option::Arg
@@ -568,6 +569,14 @@ const option::Descriptor usage[] = {
     "  --kind-no-ind-check-property \tK-induction: skip checking inductive case based "
     "on property (WARNING: will cause incompleteness on most problem instances)"
     },
+  { KIND_NO_BASE_CHECK,
+    0,
+    "",
+    "kind-no-base-check",
+    Arg::None,
+    "  --kind-no-base-check \tK-induction: skip base case check "
+    "(EXPERIMENTAL OPTION: may cause unsoundness)"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -752,6 +761,7 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
         case KIND_NO_IND_CHECK: kind_no_ind_check_ = true;
 	  kind_no_ind_check_init_states_ = true; kind_no_ind_check_property_ = true; break;
         case KIND_NO_IND_CHECK_PROPERTY: kind_no_ind_check_property_ = true; break;
+        case KIND_NO_BASE_CHECK: kind_no_base_check_ = true; break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.cpp
+++ b/options/options.cpp
@@ -89,7 +89,8 @@ enum optionIndex
   KIND_NO_IND_CHECK_INIT_STATES,
   KIND_NO_IND_CHECK,
   KIND_NO_IND_CHECK_PROPERTY,
-  KIND_NO_BASE_CHECK
+  KIND_NO_BASE_CHECK,
+  KIND_BOUND_STEP
 };
 
 struct Arg : public option::Arg
@@ -577,6 +578,14 @@ const option::Descriptor usage[] = {
     "  --kind-no-base-check \tK-induction: skip base case check "
     "(EXPERIMENTAL OPTION: may cause unsoundness)"
     },
+  { KIND_BOUND_STEP,
+    0,
+    "",
+    "kind-bound-step",
+    Arg::Numeric,
+    "  --kind-bound-step \tAmount by which bound (unrolling depth) "
+    "is increased in k-induction (default: 1)"
+    },
   { 0, 0, 0, 0, 0, 0 }
 };
 /*********************************** end Option Handling setup
@@ -762,6 +771,10 @@ ProverResult PonoOptions::parse_and_set_options(int argc,
 	  kind_no_ind_check_init_states_ = true; kind_no_ind_check_property_ = true; break;
         case KIND_NO_IND_CHECK_PROPERTY: kind_no_ind_check_property_ = true; break;
         case KIND_NO_BASE_CHECK: kind_no_base_check_ = true; break;
+        case KIND_BOUND_STEP: kind_bound_step_ = atoi(opt.arg);
+	  if (kind_bound_step_ == 0)
+	    throw PonoException("--kind-bound-step must be greater than 0");
+	  break;
         case UNKNOWN_OPTION:
           // not possible because Arg::Unknown returns ARG_ILLEGAL
           // which aborts the parse with an error

--- a/options/options.h
+++ b/options/options.h
@@ -148,7 +148,8 @@ class PonoOptions
         kind_no_ind_check_init_states_(default_kind_no_ind_check_init_states_),
         kind_no_ind_check_(default_kind_no_ind_check_),
         kind_no_ind_check_property_(default_kind_no_ind_check_property_),
-        kind_no_base_check_(default_kind_no_base_check_)
+        kind_no_base_check_(default_kind_no_base_check_),
+        kind_bound_step_(default_kind_bound_step_)
   {
   }
 
@@ -287,6 +288,8 @@ class PonoOptions
   bool kind_no_ind_check_property_;
   // K-induction: skip base case check (EXPERIMENTAL OPTION: may cause unsoundness)
   bool kind_no_base_check_;
+  // K-induction: amount of steps by which transition relation is unrolled
+  unsigned kind_bound_step_;
 
 private:
   // Default options
@@ -354,6 +357,7 @@ private:
   static const bool default_kind_no_ind_check_ = false;
   static const bool default_kind_no_ind_check_property_ = false;
   static const bool default_kind_no_base_check_ = false;
+  static const unsigned default_kind_bound_step_ = 1;
 };
 
 // Useful functions for printing etc...

--- a/options/options.h
+++ b/options/options.h
@@ -148,7 +148,7 @@ class PonoOptions
         kind_no_ind_check_init_states_(default_kind_no_ind_check_init_states_),
         kind_no_ind_check_(default_kind_no_ind_check_),
         kind_no_ind_check_property_(default_kind_no_ind_check_property_),
-        kind_no_base_check_(default_kind_no_base_check_),
+        kind_one_time_base_check_(default_kind_one_time_base_check_),
         kind_bound_step_(default_kind_bound_step_)
   {
   }
@@ -286,8 +286,8 @@ class PonoOptions
   // K-induction: skip inductive case check based on property (EXPERT
   // OPTION: will cause incompleteness for most problem instances)
   bool kind_no_ind_check_property_;
-  // K-induction: skip base case check (EXPERIMENTAL OPTION: may cause unsoundness)
-  bool kind_no_base_check_;
+  // K-induction: check base case only once after inductive case check was unsatisfiable
+  bool kind_one_time_base_check_;
   // K-induction: amount of steps by which transition relation is unrolled
   unsigned kind_bound_step_;
 
@@ -356,7 +356,7 @@ private:
   static const bool default_kind_no_ind_check_init_states_ = false;
   static const bool default_kind_no_ind_check_ = false;
   static const bool default_kind_no_ind_check_property_ = false;
-  static const bool default_kind_no_base_check_ = false;
+  static const bool default_kind_one_time_base_check_ = false;
   static const unsigned default_kind_bound_step_ = 1;
 };
 

--- a/options/options.h
+++ b/options/options.h
@@ -147,7 +147,8 @@ class PonoOptions
         kind_no_multi_call_simple_path_check_(default_kind_no_multi_call_simple_path_check_),
         kind_no_ind_check_init_states_(default_kind_no_ind_check_init_states_),
         kind_no_ind_check_(default_kind_no_ind_check_),
-        kind_no_ind_check_property_(default_kind_no_ind_check_property_)
+        kind_no_ind_check_property_(default_kind_no_ind_check_property_),
+        kind_no_base_check_(default_kind_no_base_check_)
   {
   }
 
@@ -284,7 +285,9 @@ class PonoOptions
   // K-induction: skip inductive case check based on property (EXPERT
   // OPTION: will cause incompleteness for most problem instances)
   bool kind_no_ind_check_property_;
-  
+  // K-induction: skip base case check (EXPERIMENTAL OPTION: may cause unsoundness)
+  bool kind_no_base_check_;
+
 private:
   // Default options
   static const Engine default_engine_ = BMC;
@@ -350,6 +353,7 @@ private:
   static const bool default_kind_no_ind_check_init_states_ = false;
   static const bool default_kind_no_ind_check_ = false;
   static const bool default_kind_no_ind_check_property_ = false;
+  static const bool default_kind_no_base_check_ = false;
 };
 
 // Useful functions for printing etc...


### PR DESCRIPTION
- Optional unrolling in intervals of length `n`, where `n == 1` by default; added new option `--kind-bound-step <n>` to set the length of the interval.
- New option `--kind-one-time-base-check`: do not check the base case for each unrolling. Instead, check only the inductive cases, i.e., simple paths, property-based check, and initial-state-based check, unless disabled via the respective command line options. If the inductive case check is unsatisfiable, then run one final base case check that covers all bounds `0, ..., cur`, where `cur` is the current bound at which the property was proven to hold. This is to make sure that no counterexamples of were missed. However, in general, running with `--kind-one-time-base-check` will miss counterexamples. Hence this option is intended to focus the search on finding proofs.
- Also, to run the final base case check and avoid over-constraining the formula, we must be able to remove constraints that were added during the inductive case checks, e.g., simple paths constraints or property terms. To achieve this, selector terms are used that are passed to the SMT solver as assumptions.