### PR TITLE
Fix(CI): Add config-settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           exit 1
 
       - name: Install Python Bindings
-        run: python3 -m pip install -e ./build/python[test,pysmt]
+        run: python3 -m pip install -e ./build/python[test,pysmt] --config-settings editable_mode=compat
 
       - name: Test Python Bindings
         run: pytest ./tests


### PR DESCRIPTION
According to the [Deprecate legacy setup.py develop mechanism](https://github.com/pypa/pip/issues/11457), the CI broke recently, a suggested option is added to the CI in this PR, all tests can pass now.