### PR TITLE
Assign unique artifact name to each job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
         if: steps.test-cpp.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: failing-test-log
+          name: ${{ matrix.os }}-${{ matrix.link_type }}-test-log-${{ github.run_id }}
           path: build/tests/Testing/Temporary/LastTest.log
-      
+
       - name: Fail pipeline due to C++ test failure
         if: steps.test-cpp.outcome == 'failure'
         run: |


### PR DESCRIPTION
Since #401, there could be multiple failing tests which upload test logs as artifacts.

According to the [README](https://github.com/actions/upload-artifact?tab=readme-ov-file#not-uploading-to-the-same-artifact) of `@actions/upload-artifact`,
we should assign a unique artifact name to each job.