### PR TITLE
Test generation of violation witnesses

### DIFF
--- a/tests/test_engines.cpp
+++ b/tests/test_engines.cpp
@@ -75,6 +75,8 @@ TEST_P(EngineUnitTests, BmcFalse)
   Bmc b(*false_p, *ts, s);
   ProverResult r = b.check_until(20);
   ASSERT_EQ(r, ProverResult::FALSE);
+  vector<UnorderedTermMap> cex;
+  ASSERT_TRUE(b.witness(cex));
 }
 
 TEST_P(EngineUnitTests, BmcSimplePathTrue)
@@ -91,6 +93,8 @@ TEST_P(EngineUnitTests, BmcSimplePathFalse)
   BmcSimplePath bsp(*false_p, *ts, s);
   ProverResult r = bsp.check_until(20);
   ASSERT_EQ(r, ProverResult::FALSE);
+  vector<UnorderedTermMap> cex;
+  ASSERT_TRUE(bsp.witness(cex));
 }
 
 TEST_P(EngineUnitTests, KInductionTrue)
@@ -107,6 +111,8 @@ TEST_P(EngineUnitTests, KInductionFalse)
   KInduction kind(*false_p, *ts, s);
   ProverResult r = kind.check_until(20);
   ASSERT_EQ(r, ProverResult::FALSE);
+  vector<UnorderedTermMap> cex;
+  ASSERT_TRUE(kind.witness(cex));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -144,6 +150,8 @@ TEST_P(InterpUnitTest, InterpFalse)
   InterpolantMC itpmc(*false_p, *ts, s);
   ProverResult r = itpmc.check_until(20);
   ASSERT_EQ(r, ProverResult::FALSE);
+  vector<UnorderedTermMap> cex;
+  ASSERT_TRUE(itpmc.witness(cex));
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -288,7 +296,9 @@ TEST_P(InterpOptionsTests, CounterSystemUnsafe)
 
   InterpolantMC interp_mc(p, fts, s);
   ProverResult r = interp_mc.prove();
-  ASSERT_EQ(r, FALSE);
+  ASSERT_EQ(r, ProverResult::FALSE);
+  vector<UnorderedTermMap> cex;
+  ASSERT_TRUE(interp_mc.witness(cex));
 }
 
 TEST_P(InterpOptionsTests, CounterSystemSafe)
@@ -300,7 +310,7 @@ TEST_P(InterpOptionsTests, CounterSystemSafe)
 
   InterpolantMC interp_mc(p, fts, s);
   ProverResult r = interp_mc.prove();
-  ASSERT_EQ(r, TRUE);
+  ASSERT_EQ(r, ProverResult::TRUE);
   Term invar = interp_mc.invar();
   ASSERT_TRUE(check_invar(fts, prop_term, invar));
 }


### PR DESCRIPTION
This PR adds tests to ensure that violation witnesses can be generated without errors.
Note that these tests do not verify the correctness of the generated witnesses,
only that the generation process completes successfully.

Similar tests for IC3 engines are added in #421.