### PR TITLE
Update smt-switch to v1.0.0

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -4,7 +4,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 
-SMT_SWITCH_VERSION=22c1066d0e3a41cc5323188cb714735e14e9fad3
+SMT_SWITCH_VERSION=v1.0.0
 
 usage () {
     cat <<EOF


### PR DESCRIPTION
Updates:
* Allow custom download step in contrib scripts by @CyanoKobalamyne in https://github.com/stanford-centaur/smt-switch/pull/422
* Install tracer.hpp header for cadical by @CyanoKobalamyne in https://github.com/stanford-centaur/smt-switch/pull/423
* Allow extra options for `meson compile` by @CyanoKobalamyne in https://github.com/stanford-centaur/smt-switch/pull/424
* Update Boolector to last version by @CyanoKobalamyne in https://github.com/stanford-centaur/smt-switch/pull/425