### PR TITLE
Fixed Yosys manual link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ open build/html/index.html
 
 ## Generating BTOR2 from Verilog
 
-The best tool for creating BTOR2 from Verilog is [Yosys](https://github.com/YosysHQ/yosys). Yosys has an excellent manual [here](http://www.clifford.at/yosys/files/yosys_manual.pdf). 
+The best tool for creating BTOR2 from Verilog is [Yosys](https://github.com/YosysHQ/yosys). Yosys has an excellent manual [here](https://yosyshq.readthedocs.io/projects/yosys/en/latest/).
 You can also run yosys interactively by running yosys with no arguments. Then you can view help messages for each command with: `help <command>`. Running `help` with no arguments lists all commands.
 
 A particularly useful command if you're having trouble is `show`, which can show the current state of the circuit in Yosys.


### PR DESCRIPTION
This is a short pr, I just noticed that the old link to the Yosys manual in the README ([http://www.clifford.at/yosys/files/yosys_manual.pdf](http://www.clifford.at/yosys/files/yosys_manual.pdf)) appears to go to a online casino now. I updated the link to instead point to the latest [Yosys docs](https://yosyshq.readthedocs.io/projects/yosys/en/latest/).