### PR TITLE
Export Btor2 violation witnesses for justice

### DIFF
--- a/pono.cpp
+++ b/pono.cpp
@@ -334,20 +334,23 @@ int main(int argc, char ** argv)
       if (res == FALSE) {
         cout << "sat" << endl;
         cout << prop_label << endl;
-        // note: witness for justice property is not yet supported
-        if (!pono_options.justice_) {
-          assert(pono_options.witness_ || !cex.size());
-          if (cex.size()) {
-            if (pono_options.btor2_witness_name_.empty()) {
-              print_witness_btor(btor_enc, cex, fts);
+        assert(pono_options.witness_ || cex.empty());
+        if (!cex.empty()) {
+          if (pono_options.btor2_witness_name_.empty()) {
+            print_witness_btor(btor_enc, cex, fts);
+          } else {
+            dump_witness_btor(btor_enc,
+                              cex,
+                              fts,
+                              pono_options.prop_idx_,
+                              pono_options.btor2_witness_name_);
+          }
+          if (!pono_options.vcd_name_.empty()) {
+            if (pono_options.justice_) {
+              throw PonoException(
+                  "VCD generation for justice properties "
+                  "is not supported yet.");
             } else {
-              dump_witness_btor(btor_enc,
-                                cex,
-                                fts,
-                                pono_options.prop_idx_,
-                                pono_options.btor2_witness_name_);
-            }
-            if (!pono_options.vcd_name_.empty()) {
               VCDWitnessPrinter vcdprinter(fts, cex, btor_enc.get_symbol_map());
               vcdprinter.dump_trace_to_file(pono_options.vcd_name_);
             }


### PR DESCRIPTION
Btor2 witness printer only exports the values of state and input variables (recorded in BTOR2Encoder). Therefore, the auxiliary variables introduced by liveness algorithms (such as L2S) are not included in the witness.