### PR TITLE
Skip creating lambda indices in array axiom enumerator

### DIFF
--- a/core/functional_unroller.h
+++ b/core/functional_unroller.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "core/unroller.h"
+#include "utils/exceptions.h"
 
 namespace pono {
 class FunctionalUnroller : public Unroller

--- a/core/rts.cpp
+++ b/core/rts.cpp
@@ -17,6 +17,7 @@
 #include "rts.h"
 
 #include "smt-switch/utils.h"
+#include "utils/exceptions.h"
 
 using namespace smt;
 using namespace std;

--- a/core/ts.cpp
+++ b/core/ts.cpp
@@ -22,6 +22,7 @@
 #include "smt-switch/substitution_walker.h"
 #include "smt-switch/utils.h"
 #include "smt/available_solvers.h"
+#include "utils/exceptions.h"
 
 using namespace smt;
 using namespace std;
@@ -407,6 +408,29 @@ void TransitionSystem::add_inputvar(const Term & v)
   inputvars_.insert(v);
   // automatically include in named_terms
   name_term(v->to_string(), v);
+}
+
+bool TransitionSystem::has_finite_index_sort() const
+{
+  for (const auto & sv : this->statevars()) {
+    auto sort = sv->get_sort();
+    if (sort->get_sort_kind() == ARRAY) {
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk == BV || sk == BOOL) {
+        return true;
+      }
+    }
+  }
+  for (const auto & iv : this->inputvars()) {
+    auto sort = iv->get_sort();
+    if (sort->get_sort_kind() == ARRAY) {
+      SortKind sk = sort->get_indexsort()->get_sort_kind();
+      if (sk == BV || sk == BOOL) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 // term building methods -- forwards to SmtSolver solver_

--- a/core/ts.h
+++ b/core/ts.h
@@ -21,7 +21,6 @@
 
 #include "smt-switch/cvc5_factory.h"
 #include "smt-switch/smt.h"
-#include "utils/exceptions.h"
 
 namespace pono {
 
@@ -67,7 +66,7 @@ class TransitionSystem
    */
   TransitionSystem(const TransitionSystem & other_ts, smt::TermTranslator & tt);
 
-  virtual ~TransitionSystem(){};
+  virtual ~TransitionSystem() = default;
 
   /** Equality comparison between TransitionSystems
    *  compares each member variable
@@ -319,6 +318,10 @@ class TransitionSystem
 
   /* Same as @ref is_right_total(), but uses the given solver type */
   bool is_right_total(const smt::SolverEnum se) const;
+
+  /** @return true if a state or input variable is an array with a finite index
+   * sort. */
+  bool has_finite_index_sort() const;
 
   /* Returns true iff all the symbols in the formula are current states */
   bool only_curr(const smt::Term & term) const;

--- a/core/unroller.cpp
+++ b/core/unroller.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 
 #include "smt-switch/utils.h"
+#include "utils/exceptions.h"
 
 using namespace smt;
 using namespace std;

--- a/engines/ceg_prophecy_arrays.h
+++ b/engines/ceg_prophecy_arrays.h
@@ -57,6 +57,9 @@ class CegProphecyArrays : public CEGAR<Prover_T>
   }
 
  protected:
+  bool has_finite_index_sort_ =
+      false;  ///< whether the arrays in the system have a finite index sort
+
   TransitionSystem conc_ts_;
   TransitionSystem & abs_ts_;
   Unroller abs_unroller_;
@@ -73,9 +76,6 @@ class CegProphecyArrays : public CEGAR<Prover_T>
   smt::UnorderedTermSet
       important_vars_;  ///< important variables
                         ///< useful for IC3IA to prioritize predicates
-
-  // whether the arrays in the system has a finite index sort
-  bool has_finite_index_sort_ = false;
 
   TransitionSystem & prover_interface_ts() override { return conc_ts_; }
 

--- a/engines/cegar.h
+++ b/engines/cegar.h
@@ -38,7 +38,7 @@ class CEGAR : public Prover_T
   {
   }
 
-  virtual ~CEGAR() {}
+  virtual ~CEGAR() = default;
 
  protected:
   /** Abstract the transition system -- usually only performed once

--- a/engines/ic3.cpp
+++ b/engines/ic3.cpp
@@ -16,6 +16,8 @@
 
 #include <cassert>
 
+#include "utils/exceptions.h"
+
 using namespace smt;
 using namespace std;
 

--- a/modifiers/control_signals.cpp
+++ b/modifiers/control_signals.cpp
@@ -19,6 +19,8 @@
 #include <cassert>
 #include <cmath>
 
+#include "utils/exceptions.h"
+
 using namespace smt;
 using namespace std;
 

--- a/modifiers/history_modifier.cpp
+++ b/modifiers/history_modifier.cpp
@@ -17,6 +17,7 @@
 #include <cassert>
 
 #include "core/rts.h"
+#include "utils/exceptions.h"
 
 using namespace smt;
 using namespace std;

--- a/refiners/array_axiom_enumerator.cpp
+++ b/refiners/array_axiom_enumerator.cpp
@@ -138,8 +138,13 @@ WalkerStepResult ArrayFinder::visit_term(Term & term)
 ArrayAxiomEnumerator::ArrayAxiomEnumerator(ArrayAbstractor & aa,
                                            Unroller & un,
                                            const Term & prop,
-                                           bool red_axioms)
-    : super(aa.abs_ts()), aa_(aa), un_(un), reduce_axioms_unsatcore_(red_axioms)
+                                           bool red_axioms,
+                                           bool has_finite_index_sort)
+    : super(aa.abs_ts()),
+      aa_(aa),
+      un_(un),
+      reduce_axioms_unsatcore_(red_axioms),
+      has_finite_index_sort_(has_finite_index_sort)
 {
   conc_bad_ = solver_->make_term(Not, prop);
   false_ = solver_->make_term(false);
@@ -152,21 +157,14 @@ void ArrayAxiomEnumerator::initialize()
   initialized_ = true;
 
   collect_arrays_and_indices();
-  create_lambda_indices();
+  if (!has_finite_index_sort_) {
+    create_lambda_indices();
+  }
 }
 
 bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
                                             size_t bound,
                                             bool include_nonconsecutive)
-{
-  return enumerate_axioms(
-      abs_trace_formula, bound, include_nonconsecutive, false);
-}
-
-bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
-                                            size_t bound,
-                                            bool include_nonconsecutive,
-                                            bool skip_lambda_axioms)
 {
   assert(initialized_);
 
@@ -202,21 +200,21 @@ bool ArrayAxiomEnumerator::enumerate_axioms(const Term & abs_trace_formula,
 
     // experimenting with new heuristic order
     found_lemmas |= check_consecutive_axioms(ARRAYEQ_READ, only_curr);
-    if (!skip_lambda_axioms) {
+    if (!has_finite_index_sort_) {
       found_lemmas |= check_consecutive_axioms(ARRAYEQ_READ_LAMBDA, only_curr);
     }
     found_lemmas |= check_consecutive_axioms(STORE_WRITE, only_curr);
     found_lemmas |= check_consecutive_axioms(STORE_READ, only_curr);
-    if (!skip_lambda_axioms) {
+    if (!has_finite_index_sort_) {
       found_lemmas |= check_consecutive_axioms(STORE_READ_LAMBDA, only_curr);
     }
     found_lemmas |= check_consecutive_axioms(CONSTARR, only_curr);
-    if (!skip_lambda_axioms) {
+    if (!has_finite_index_sort_) {
       found_lemmas |= check_consecutive_axioms(CONSTARR_LAMBDA, only_curr);
     }
     found_lemmas |= check_consecutive_axioms(ARRAYEQ_WITNESS, only_curr);
 
-    if (!found_lemmas && !skip_lambda_axioms) {
+    if (!found_lemmas && !has_finite_index_sort_) {
       // NOTE: don't need non-consecutive version of these axioms
       //       all different over current and next is sufficient to be all
       //       different for all time

--- a/refiners/array_axiom_enumerator.h
+++ b/refiners/array_axiom_enumerator.h
@@ -15,12 +15,15 @@
 **/
 #pragma once
 
-#include "core/prop.h"
-#include "core/ts.h"
+#include <cstddef>
+#include <string>
+#include <unordered_set>
+
 #include "core/unroller.h"
 #include "modifiers/array_abstractor.h"
 #include "refiners/axiom_enumerator.h"
 #include "smt-switch/identity_walker.h"
+#include "smt-switch/smt.h"
 
 namespace pono {
 
@@ -76,20 +79,16 @@ class ArrayAxiomEnumerator : public AxiomEnumerator
   ArrayAxiomEnumerator(ArrayAbstractor & aa,
                        Unroller & un,
                        const smt::Term & prop,
-                       bool red_axioms);
+                       bool red_axioms,
+                       bool has_finite_index_sort = false);
 
   typedef AxiomEnumerator super;
 
   void initialize() override;
 
   bool enumerate_axioms(const smt::Term & abs_trace_formula,
-                        size_t bound,
+                        std::size_t bound,
                         bool include_nonconsecutive = true) override;
-
-  bool enumerate_axioms(const smt::Term & abs_trace_formula,
-                        size_t bound,
-                        bool include_nonconsecutive,
-                        bool skip_lambda_axioms);
 
   /** Add a new index to the index set
    *  This can happen as we add auxiliary variables
@@ -382,8 +381,9 @@ class ArrayAxiomEnumerator : public AxiomEnumerator
 
   bool reduce_axioms_unsatcore_;  ///< reduce generated axioms with an unsat
                                   ///< core if set to true
+  bool has_finite_index_sort_;    ///< lambda axioms will be omitted if true
 
-  size_t bound_;  ///< the bound of the current abstract trace
+  std::size_t bound_;  ///< the bound of the current abstract trace
   smt::UnorderedTermMap
       constarrs_;  ///< maps (abstract) constarrs to their constant value
   smt::UnorderedTermSet stores_;  ///< vector of (abstract) stores

--- a/refiners/axiom_enumerator.h
+++ b/refiners/axiom_enumerator.h
@@ -56,7 +56,7 @@ class AxiomEnumerator
   {
   }
 
-  virtual ~AxiomEnumerator(){};
+  virtual ~AxiomEnumerator() = default;
 
   virtual void initialize() = 0;
 


### PR DESCRIPTION
When there are finite array indices.

Also move the code for determining whether there are such indices into TransitionSystem itself.