### PR TITLE
Fix setup-smt-switch.sh on Bash 3.2

### DIFF
--- a/contrib/setup-smt-switch.sh
+++ b/contrib/setup-smt-switch.sh
@@ -106,7 +106,7 @@ fi
 if [[ -d build ]]; then
   echo "$(pwd)/build already exists, please remove it manually if you want to reconfigure smt-switch"
 else
-  ./configure.sh --prefix=local --static --smtlib-reader --bitwuzla --cvc5 "${conf_opts[@]}"
+  ./configure.sh --prefix=local --static --smtlib-reader --bitwuzla --cvc5 ${conf_opts[@]+"${conf_opts[@]}"}
 fi
 cd build
 cmake --build . -j


### PR DESCRIPTION
MacOS only ships with this version, which has a bug expanding empty arrays when nounset is enabled.