### PR TITLE
Add config file for ruff, a Python linter and formatter

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,9 @@
+target-version = "py38"
+
+[lint]
+select = ["ALL"]
+ignore = ["D", "T", "COM812"]
+
+[lint.per-file-ignores]
+"tests/python/test_*" = ["INP001", "S101"]
+"scripts/*" = ["S603"]


### PR DESCRIPTION
All rules are enabled, except for the following:
- pydocstyle rules (D)
- flake8 rules that remove print (T)
- rules that conflict with the formatter (COM812)
- bandit's rule warning about subprocess (S603) in scripts
- rules prohibiting assert (S101) and bare modules (INP001) in tests