### PR TITLE
Fix invalid-symbol crash in LivenessToSafetyTranslator for quoted names

### DIFF
--- a/modifiers/liveness_to_safety_translator.cpp
+++ b/modifiers/liveness_to_safety_translator.cpp
@@ -6,6 +6,7 @@
 
 #include "core/ts.h"
 #include "smt-switch/smt.h"
+#include "utils/str_util.h"
 
 namespace pono {
 LivenessToSafetyTranslator::LivenessToSafetyTranslator(std::string var_prefix)
@@ -39,7 +40,8 @@ smt::Term LivenessToSafetyTranslator::translate(TransitionSystem & ts,
   std::vector<std::pair<smt::Term, smt::Term>> loop_states;
   for (auto statevar : orig_statevars) {
     auto loop_state = ts.make_statevar(
-        statevar->to_string() + prefix_ + "_loop", statevar->get_sort());
+        name_desanitize(statevar->to_string()) + prefix_ + "_loop",
+        statevar->get_sort());
     loop_states.push_back({ statevar, loop_state });
     // loop_i' = (save /\ !saved) ? state_i : loop_i;
     ts.assign_next(loop_state,

--- a/tests/test_modifiers.cpp
+++ b/tests/test_modifiers.cpp
@@ -221,6 +221,44 @@ TEST_P(ModifierUnitTests, LivenessToSafetyTranslator)
   EXPECT_TRUE(result.is_unsat());
 }
 
+TEST_P(ModifierUnitTests, LivenessToSafetyTranslatorHierarchicalName)
+{
+  // Regression test: a state variable whose name requires SMT-LIB `|...|`
+  // quoting (e.g. a hierarchical name like SystemVerilog produces, such as
+  // "mod.sig[3]") must not corrupt the generated "loop" copy's name.
+  // LivenessToSafetyTranslator used to build the new name via
+  // `statevar->to_string() + suffix`; to_string() already returns the
+  // quoted form for such names, so appending more text after it produced a
+  // malformed name (text trailing a closing quote), which some solvers
+  // (e.g. bzla) reject with "invalid symbol ... not SMT-LIB compliant".
+  FunctionalTransitionSystem fts(s);
+  Term x = fts.make_statevar("mod.sig[3]", bvsort);
+  fts.assign_next(x, x);
+  Term minus_one = fts.make_term(-1, bvsort);
+  Term justice_cond = fts.make_term(smt::Equal, x, minus_one);
+
+  LivenessToSafetyTranslator l2s;
+  ASSERT_NO_THROW(l2s.translate(fts, { justice_cond }));
+
+  Term loop;
+  for (auto statevar : fts.statevars()) {
+    if (statevar != x && statevar->get_sort() == bvsort) {
+      loop = statevar;
+    }
+  }
+  ASSERT_TRUE(loop);
+
+  // The printed name must be a single well-formed SMT-LIB token: after
+  // stripping one optional outer `|...|` quote pair, there must be no
+  // leftover '|' characters.
+  string loop_name = loop->to_string();
+  if (loop_name.size() > 2 && loop_name.front() == '|'
+      && loop_name.back() == '|') {
+    loop_name = loop_name.substr(1, loop_name.size() - 2);
+  }
+  EXPECT_EQ(loop_name.find('|'), string::npos);
+}
+
 INSTANTIATE_TEST_SUITE_P(ParameterizedModifierUnitTests,
                          ModifierUnitTests,
                          testing::ValuesIn(available_solver_enums()));

--- a/utils/str_util.cpp
+++ b/utils/str_util.cpp
@@ -17,6 +17,7 @@
 #include "str_util.h"
 
 #include <cassert>
+#include <cctype>
 #include <iostream>
 #include <sstream>
 
@@ -187,6 +188,31 @@ const std::string & lookup_or_key(
 {
   auto it = map.find(key);
   return (it != map.end() && !it->second.empty()) ? it->second : key;
+}
+
+std::string name_sanitize(const std::string & s)
+{
+  if (s.length() > 2 && s.front() == '|' && s.back() == '|')
+    return s;  // already | |
+  bool need_separator = false;
+  for (auto pos = s.begin(); pos != s.end(); ++pos) {
+    char c = *pos;
+    if (isalnum(c)) continue;
+    if (c == '.' || c == '-') continue;
+    if (c == '_' && pos != s.begin()) continue;
+    // else
+    need_separator = true;
+    break;
+  }
+  if (need_separator) return "|" + s + "|";
+  return s;
+}
+
+std::string name_desanitize(const std::string & s)
+{
+  if (s.length() > 2 && s.front() == '|' && s.back() == '|')
+    return s.substr(1, s.length() - 2);  // already | |
+  return s;
 }
 
 }  // namespace pono

--- a/utils/str_util.h
+++ b/utils/str_util.h
@@ -82,4 +82,11 @@ const std::string & lookup_or_key(
     const std::unordered_map<std::string, std::string> & map,
     const std::string & key);
 
+/// Wrap a name in `|...|` if it isn't already a valid SMT-LIB "simple
+/// symbol" (e.g. it contains characters other than alnum/./-/_).
+std::string name_sanitize(const std::string & s);
+
+/// Inverse of name_sanitize: strip a matching `|...|` pair if present.
+std::string name_desanitize(const std::string & s);
+
 }  // namespace pono

--- a/utils/syntax_analysis_common.cpp
+++ b/utils/syntax_analysis_common.cpp
@@ -137,31 +137,6 @@ bool PerVarsetInfo::TermLearnerInsertTerm(const smt::Term & new_term)
 //
 // --------------------------------------------------
 
-std::string name_sanitize(const std::string & s)
-{
-  if (s.length() > 2 && s.front() == '|' && s.back() == '|')
-    return s;  // already | |
-  bool need_separator = false;
-  for (auto pos = s.begin(); pos != s.end(); ++pos) {
-    char c = *pos;
-    if (isalnum(c)) continue;
-    if (c == '.' || c == '-') continue;
-    if (c == '_' && pos != s.begin()) continue;
-    // else
-    need_separator = true;
-    break;
-  }
-  if (need_separator) return "|" + s + "|";
-  return s;
-}
-
-std::string name_desanitize(const std::string & s)
-{
-  if (s.length() > 2 && s.front() == '|' && s.back() == '|')
-    return s.substr(1, s.length() - 2);  // already | |
-  return s;
-}
-
 uint64_t get_width_of_var(const smt::Term & v)
 {
   if (v->get_sort()->get_sort_kind() == smt::SortKind::BOOL)

--- a/utils/syntax_analysis_common.h
+++ b/utils/syntax_analysis_common.h
@@ -163,8 +163,6 @@ typedef std::unordered_map<IC3FormulaModel *, PerCexInfo>
 //
 // --------------------------------------------------
 
-std::string name_sanitize(const std::string &);
-std::string name_desanitize(const std::string & s);
 uint64_t get_width_of_var(const smt::Term & v);
 smt::Term smt_string_to_const_term(const std::string & val, smt::SmtSolver & s);
 bool is_primop_symmetry(smt::PrimOp);


### PR DESCRIPTION
LivenessToSafetyTranslator built each "loop" state's name via statevar->to_string() + suffix. to_string() already returns the SMT-LIB-quoted form for names that aren't simple symbols (e.g. hierarchical names containing '.' or '[]'), so appending more text after it produced a malformed name like
"|mod.sig[3]|__pono_generated___loop" -- a quoted symbol with trailing characters after its closing '|'. Bitwuzla rejects this with "invalid symbol ..., symbol is not SMT-LIB compliant"; other backends silently mangle it instead.

Strip a matching pipe-quote pair before appending, using name_desanitize -- moved from utils/syntax_analysis_common.{h,cpp} (IC3SA/SyGuS-specific, and coupled to sygus_ic3formula_helper.h) into utils/str_util.{h,cpp}, which already holds general-purpose string helpers (e.g. lookup_or_key) used outside that subsystem.

Adds a regression test using a state variable name shaped like a SystemVerilog hierarchical path, which reproduces the exact reported error against bzla before the fix.