### PR TITLE
ci: Remove setup-python action from pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.1
   build:
     strategy:


### PR DESCRIPTION
The workers already have Python installed.