### PR TITLE
ci: Replace pre-commit action with prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7
-      - uses: pre-commit/action@v3.0.1
+      - uses: j178/prek-action@v2
+        with:
+          extra-args: --all-files
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
The pre-commit hook is not being updated anymore (see https://github.com/pre-commit/action/issues/241) and [prek](https://prek.j178.dev/) is a drop-in replacement.