### PR TITLE
Add copyright notices to Python files

### DIFF
--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 import multiprocessing
 import platform
 import re

--- a/examples/python-api/simple_alu.py
+++ b/examples/python-api/simple_alu.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 import argparse
 
 import pono

--- a/scripts/parallel_pono.py
+++ b/scripts/parallel_pono.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# Copyright (c) 2019 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 import argparse

--- a/tests/python/__init__.py
+++ b/tests/python/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 import smt_switch as ss
 
 if hasattr(ss, "create_msat_interpolator"):

--- a/tests/python/test_coi.py
+++ b/tests/python/test_coi.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_encoders.py
+++ b/tests/python/test_encoders.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_modifiers.py
+++ b/tests/python/test_modifiers.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2021 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_printers.py
+++ b/tests/python/test_printers.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 import tempfile

--- a/tests/python/test_pseudo_init_and_prop.py
+++ b/tests/python/test_pseudo_init_and_prop.py
@@ -9,6 +9,7 @@
 This method is general but is most useful for improving IC3IA performance.
 This test is based on the C++ tests.
 """
+
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_pseudo_init_and_prop.py
+++ b/tests/python/test_pseudo_init_and_prop.py
@@ -4,6 +4,11 @@
 # information.
 #
 # This file is part of the pono project.
+"""Test the pseudo_init_and_prop modification function.
+
+This method is general but is most useful for improving IC3IA performance.
+This test is based on the C++ tests.
+"""
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_pseudo_init_and_prop.py
+++ b/tests/python/test_pseudo_init_and_prop.py
@@ -1,18 +1,9 @@
-###############################################################
-# \file test_pseudo_init_and_prop.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2021 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
+# Copyright (c) 2021 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
 #
-# \brief Test the pseudo_init_and_prop modification function.
-#        This method is general but is most useful for improving
-#        IC3IA performance. This test is based on the C++ tests.
-#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_replace_terms.py
+++ b/tests/python/test_replace_terms.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_ts.py
+++ b/tests/python/test_ts.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable

--- a/tests/python/test_unroller.py
+++ b/tests/python/test_unroller.py
@@ -1,3 +1,9 @@
+# Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
+# source directory and their institutional affiliations. All rights reserved.
+# See the file LICENSE in the top-level source directory for licensing
+# information.
+#
+# This file is part of the pono project.
 from __future__ import annotations
 
 from typing import Callable


### PR DESCRIPTION
Insert the project's standard copyright/license header at the top of every Python file that lacked one, using each file's git creation year, and normalize the existing header in test_pseudo_init_and_prop.py to match.