### PR TITLE
Remove "All rights reserved." from Python copyright headers

### DIFF
--- a/contrib/wheels/build_wheel.py
+++ b/contrib/wheels/build_wheel.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 import multiprocessing

--- a/examples/python-api/simple_alu.py
+++ b/examples/python-api/simple_alu.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 import argparse

--- a/scripts/parallel_pono.py
+++ b/scripts/parallel_pono.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 # Copyright (c) 2019 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/__init__.py
+++ b/tests/python/__init__.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 import smt_switch as ss

--- a/tests/python/test_coi.py
+++ b/tests/python/test_coi.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_encoders.py
+++ b/tests/python/test_encoders.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_engines.py
+++ b/tests/python/test_engines.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_modifiers.py
+++ b/tests/python/test_modifiers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_printers.py
+++ b/tests/python/test_printers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_pseudo_init_and_prop.py
+++ b/tests/python/test_pseudo_init_and_prop.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 """Test the pseudo_init_and_prop modification function.

--- a/tests/python/test_replace_terms.py
+++ b/tests/python/test_replace_terms.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_ts.py
+++ b/tests/python/test_ts.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations

--- a/tests/python/test_unroller.py
+++ b/tests/python/test_unroller.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020 by the authors listed in the file AUTHORS in the top-level
-# source directory and their institutional affiliations. All rights reserved.
-# See the file LICENSE in the top-level source directory for licensing
-# information.
+# source directory and their institutional affiliations. See the file LICENSE
+# in the top-level source directory for licensing information.
 #
 # This file is part of the pono project.
 from __future__ import annotations


### PR DESCRIPTION
The headers added in #578 included this sentence unlike the project's intended standard wording; drop it and reflow the surrounding lines.

See https://liferay.dev/b/how-and-why-to-properly-write-copyright-statements-in-your-code#what-is-wrong-with-all-rights-reserved for why "All rights reserved." is unnecessary and should be omitted.